### PR TITLE
Add WiGLE map support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Mobile Router
+
+This project is a small Flask application for interacting with network interfaces. It now supports looking up wireless access points via the WiGLE API and displaying their location on a map.
+
+## WiGLE API Configuration
+
+Set the following environment variables before starting the application:
+
+- `WIGLE_API_NAME` – your WiGLE API username.
+- `WIGLE_API_TOKEN` – your WiGLE API token.
+
+These credentials are used to query the WiGLE network search endpoint.
+
+## Running
+
+Install dependencies and run the application:
+
+```bash
+pip install -r requirements.txt
+python app.py
+```
+
+Navigate to `http://localhost:8080/wigle-map` to search for a BSSID and view its location on the map.

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ psutil==6.0.0
 pywifi==1.1.12
 scapy==2.5.0
 Werkzeug==3.0.3
+
+requests==2.31.0

--- a/static/js/wireless-adapters.js
+++ b/static/js/wireless-adapters.js
@@ -56,6 +56,7 @@ $(document).ready(function () {
                       <p>Frequency - ${network.freq}</p>
                       <p>Signal - ${network.signal}</p>
                       <p>Security - ${akmMap[network.akm]}</p>
+                      <button type="button" class="map-button btn btn-secondary" data-bssid="${network.bssid}">Map</button>
                     </div>
                   </div>
                 </div>
@@ -86,6 +87,10 @@ $(document).ready(function () {
         });
         
         $("#wlans").html(wlanDiv);
+        $("#wlans").on("click", ".map-button", function () {
+          const bssid = $(this).data("bssid");
+          window.open(`/wigle-map?bssid=${bssid}`, "_blank");
+        });
       },
       error: function (error) {
         console.log("Error occurred during network scan");

--- a/templates/_navbar.html
+++ b/templates/_navbar.html
@@ -25,6 +25,7 @@
         {% endif %}
       {% endfor %}
       <a href="/red-team" class="nav-link {% if title == 'Red Team' %}active{% endif %}">Red Team</a>
+      <a href="/wigle-map" class="nav-link {% if title == 'WiGLE Map' %}active{% endif %}">WiGLE Map</a>
     </div>
     <div class="d-flex d-md-none text-left">
       <button id="listAdapters1" type="button" class="fa-solid fa-rotate btn" data-toggle="tooltip" data-placement="bottom" title="Refresh Network Adapters" style="background-color:transparent; color: white;"></button>

--- a/templates/wigle_map.html
+++ b/templates/wigle_map.html
@@ -1,0 +1,24 @@
+{% include '_header.html' %}
+<link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-sA+e2LZ3ccN4oyQ0PFwZ5q96ncG20EhnEih0qKxs20Y=" crossorigin="" />
+<script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-o7ptIptjaH/9woDgCuGZO4i0CXQ+SP2B9ZF6NUI20jk=" crossorigin=""></script>
+<body class="d-flex flex-column min-vh-100">
+  <div class="container">
+    <h1>WiGLE Map Lookup</h1>
+    <form method="get" action="/wigle-map" class="form-inline mb-3">
+      <input type="text" class="form-control mr-2" name="bssid" placeholder="BSSID" value="{{ bssid or '' }}" required>
+      <button type="submit" class="btn btn-primary">Search</button>
+    </form>
+    {% if lat and lon %}
+    <div id="map" style="height: 500px;"></div>
+    <script>
+      var map = L.map('map').setView([{{ lat }}, {{ lon }}], 15);
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', { maxZoom: 19 }).addTo(map);
+      L.marker([{{ lat }}, {{ lon }}]).addTo(map).bindPopup('{{ bssid }}').openPopup();
+    </script>
+    {% elif bssid %}
+    <p>No location found for {{ bssid }}.</p>
+    {% endif %}
+  </div>
+  {% include '_footer.html' %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- integrate WiGLE API lookup using env variables `WIGLE_API_NAME` and `WIGLE_API_TOKEN`
- create `/wigle-map` route and template with Leaflet map
- add map buttons in wireless adapter scan results
- expose link in the navbar
- document setup and running in `README.md`

## Testing
- `python3 -m py_compile $(find . -path ./mobileRouter -prune -o -name '*.py' -print)`

------
https://chatgpt.com/codex/tasks/task_e_68401d55bc58832fbc462d301a6c6596