### PR TITLE
Add Flask-SocketIO and bleak to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,5 @@ psutil==6.0.0
 pywifi==1.1.12
 scapy==2.5.0
 Werkzeug==3.0.3
+Flask-SocketIO==5.3.6
+bleak==0.22.2


### PR DESCRIPTION
## Summary
- add `Flask-SocketIO` and `bleak` to requirements.txt

## Testing
- `python -m pip check`

------
https://chatgpt.com/codex/tasks/task_e_6851b557a1e4832f98a91eb927243df0