### PR TITLE
Implement adapters endpoint and refresh UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,12 @@ def favicon():
 def red_team():
     return render_template('red-team.html', title='Red Team', networkTechnologies=networkTechnologies, interfaces=network_interfaces)
 
+# Endpoint to fetch the current list of network adapters
+@app.route('/adapters', methods=['POST'])
+def adapters():
+    """Return the available network interfaces as JSON."""
+    return jsonify({'interfaces': [iface.__dict__ for iface in network_interfaces]})
+
 @app.route('/<interface_type>')
 def interfaces_by_type(interface_type):
     interface_type = interface_type.capitalize()

--- a/static/js/wireless-scripts.js
+++ b/static/js/wireless-scripts.js
@@ -7,6 +7,8 @@ $(document).ready(function () {
       },
       success: function (response) {
         console.log(response);
+        // Refresh the page to show updated interface information
+        location.reload();
       },
       error: function (error) {
         console.log(error);
@@ -25,6 +27,8 @@ $(document).ready(function () {
       success: function (response) {
         console.log("list adpters Was Successfull. YAY!!!");
         console.log(response);
+        // Refresh the page so the navbar shows the latest adapters
+        location.reload();
       },
       error: function (error) {
         console.log(error);


### PR DESCRIPTION
## Summary
- add `/adapters` POST endpoint to expose network interfaces
- refresh the page when adapters are requested in the navbar

## Testing
- `python -m py_compile app.py scripts/interfaceTools.py`

------
https://chatgpt.com/codex/tasks/task_e_6851b537eb0c832f98dbb978bd28d444