### PR TITLE
Add setup automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,14 @@ wireless and wired adapters.
 
 ## Setup
 
-1. Install Python 3.10 or newer.
-2. Create a virtual environment and activate it:
+Running the following script will ensure Python is available, create a
+virtual environment and install any required packages. If everything is
+already installed these steps will be skipped and the server will start
+immediately.
 
-   ```bash
-   python3 -m venv venv
-   source venv/bin/activate
-   ```
-3. Install the required dependencies:
-
-   ```bash
-   pip install -r requirements.txt
-   ```
+```bash
+./setup.sh
+```
 
 ## Usage
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+set -e
+
+PYTHON_BIN="python3"
+
+# Check for python3
+if ! command -v $PYTHON_BIN >/dev/null 2>&1; then
+    echo "Python3 not found. Attempting to install..."
+    if command -v apt-get >/dev/null 2>&1; then
+        sudo apt-get update
+        sudo apt-get install -y python3 python3-venv
+    elif command -v brew >/dev/null 2>&1; then
+        brew install python
+    else
+        echo "Could not find a package manager to install Python. Please install Python3 manually." >&2
+        exit 1
+    fi
+fi
+
+# Create virtual environment if it doesn't exist
+if [ ! -d "venv" ]; then
+    echo "Creating virtual environment..."
+    $PYTHON_BIN -m venv venv
+fi
+
+# Install requirements if needed
+source venv/bin/activate
+if [ -f requirements.txt ]; then
+    echo "Installing requirements..."
+    pip install --upgrade pip
+    pip install -r requirements.txt
+fi
+
+deactivate
+
+# Start the server
+source venv/bin/activate
+exec $PYTHON_BIN app.py
+


### PR DESCRIPTION
## Summary
- add a `setup.sh` script that installs Python if needed, creates a virtual environment, installs requirements and launches the app
- document the script in the README

## Testing
- `bash -n setup.sh`
- `python3 -m py_compile app.py scripts/interfaceTools.py scripts/network/networkAttacks.py scripts/wifi/access_point.py scripts/wifi/beaconspoof.py scripts/wifi/client.py scripts/wifi/network.py scripts/wifi/utils.py`


------
https://chatgpt.com/codex/tasks/task_e_6851ba70b0a8832fa0c491e3b441ebbd