### PR TITLE
Fix interface tools to only read network directories

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,9 +54,7 @@ def adapters():
 @app.route('/<interface_type>')
 def interfaces_by_type(interface_type):
     interface_type = interface_type.capitalize()
-    print(f"Looking for interfaces of type: {interface_type}")
     filtered_interfaces = [iface for iface in network_interfaces if iface.interface_type.lower() == interface_type.lower()]
-    print(f"Filtered interfaces: {filtered_interfaces}")
     if filtered_interfaces:
         return render_template('interface_type.html', title=f'{interface_type}', interfaces=filtered_interfaces, networkTechnologies=networkTechnologies, technology=interface_type)
     else:
@@ -65,12 +63,10 @@ def interfaces_by_type(interface_type):
 @app.route('/<interface_type>/<interface_name>')
 def interface_detail(interface_type, interface_name):
     interface_type = interface_type.lower()
-    print(f"Looking for interface of type: {interface_type} with name: {interface_name}")
     interface = next((iface for iface in network_interfaces if iface.name == interface_name and iface.interface_type.lower() == interface_type), None)
     if interface:
         return render_template('interface_detail.html', title=interface.name, interface=interface, networkTechnologies=networkTechnologies, interfaces=network_interfaces)
     else:
-        print(f"Interface not found: {interface_type}/{interface_name}")
         return "Interface not found", 404
 
 
@@ -189,6 +185,7 @@ def beacon_advertise():
 
 
 if __name__ == '__main__':
-    host='0.0.0.0'
-    port=8080
+    host = '0.0.0.0'
+    port = 8080
+    print(f"Server running at http://{host}:{port}")
     socketio.run(app, host=host, port=port, debug=True)

--- a/scripts/interfaceTools.py
+++ b/scripts/interfaceTools.py
@@ -96,7 +96,6 @@ class NetworkInterface:
         new_state = self.get_state()
         if new_state != self.state:
             self.state = new_state
-            print(f"{self.name} Different State Yo!")
 
     def update_state_periodically(self, interval=5):
         """Periodically update the state of the interface."""
@@ -189,7 +188,12 @@ def _parse_ip_addrs(name, family):
 
 
 def get_network_interfaces():
-    interface_names = os.listdir("/sys/class/net")
+    base_path = "/sys/class/net"
+    interface_names = [
+        name
+        for name in os.listdir(base_path)
+        if os.path.isdir(os.path.join(base_path, name))
+    ]
     network_objects = []
 
     for name in interface_names:
@@ -227,10 +231,6 @@ def get_network_interfaces():
         # Determine manufacturer based on MAC address
         network_interface.manufacturer = lookup_manufacturer(network_interface.get_mac_address())
         network_objects.append(network_interface)
-    
-    # Print the __str__ representation of each NetworkInterface object
-    for network_object in network_objects:
-        print(network_object)
     
     return network_objects
 

--- a/static/css/interface.css
+++ b/static/css/interface.css
@@ -4,7 +4,8 @@
 .details {
   flex-grow: 1;
 }
-#wlans {
+#wlans,
+.wlans {
   flex-grow: 1;
   margin: 2%;
 }

--- a/static/js/wireless-adapters.js
+++ b/static/js/wireless-adapters.js
@@ -1,93 +1,39 @@
 $(document).ready(function () {
   $("button#wlan-scan").on("click", function () {
     const interfaceName = $(this).val();
+    const resultDiv = $(`#wlans-${interfaceName}`);
+
     $.ajax({
       url: "/wlan-scan",
       type: "POST",
-      data: { 'selectedInterface': interfaceName },
+      data: { selectedInterface: interfaceName },
       beforeSend: function () {
         console.log(`Scanning for networks ${interfaceName}`);
       },
       success: function (response) {
         console.log(`Networks on ${interfaceName} scanned successfully`);
 
-        const akmMap = {
-          "": "Open",
-          "0": "Open",
-          "1": "WPA Ent",
-          "2": "WPAPSK",
-          "3": "WPA2 Ent",
-          "4": "WPA2PSK",
-          "5": "UNKNOWN"
-        };
-
-        const groupedNetworks = {};
-
+        const ssids = [];
         response.wlans.forEach(function (network) {
-          if (groupedNetworks[network.ssid]) {
-            groupedNetworks[network.ssid].push(network);
-          } else {
-            groupedNetworks[network.ssid] = [network];
+          if (network.ssid && !ssids.includes(network.ssid)) {
+            ssids.push(network.ssid);
           }
         });
 
-        let wlanDiv = `<h1>Wireless Networks</h1>`;
-        Object.entries(groupedNetworks).forEach(function ([ssid, bssids], index) {
-          const ssidAccordionId = `ssidAccordion-${index}`;
+        if (ssids.length === 0) {
+          resultDiv.html("<p>No networks found</p>");
+          return;
+        }
 
-          let accordionContent = '';
-          bssids.forEach(function (network, subIndex) {
-            const accessPointNumber = subIndex + 1;
-            const bssidAccordionId = `bssidAccordion-${index}-${subIndex}`;
-
-            accordionContent += `
-              <div class="accordion" id="${bssidAccordionId}">
-                <div class="card">
-                  <div class="card-header" id="heading${bssidAccordionId}">
-                    <h2 class="mb-0">
-                      <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse${bssidAccordionId}" aria-expanded="false" aria-controls="collapse${bssidAccordionId}">
-                        Access Point ${accessPointNumber} - ${network.bssid}
-                      </button>
-                    </h2>
-                  </div>
-                  <div id="collapse${bssidAccordionId}" class="collapse" aria-labelledby="heading${bssidAccordionId}" data-parent="#${bssidAccordionId}">
-                    <div class="card-body">
-                      <p>Manufacturer - ${network.manufacturer}</p>
-                      <p>Frequency - ${network.freq}</p>
-                      <p>Signal - ${network.signal}</p>
-                      <p>Security - ${akmMap[network.akm]}</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            `;
-          });
-
-          const accordion =
-            `<div class="accordion" id="${ssidAccordionId}">
-              <div class="card">
-                <div class="card-header" id="heading${ssidAccordionId}">
-                  <h2 class="mb-0">
-                    <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse${ssidAccordionId}" aria-expanded="false" aria-controls="collapse${ssidAccordionId}">
-                      ${ssid}
-                    </button>
-                  </h2>
-                </div>
-                <div id="collapse${ssidAccordionId}" class="collapse" aria-labelledby="heading${ssidAccordionId}" data-parent="#${ssidAccordionId}">
-                  <div class="card-body">
-                  <button type="button" class="connect-button btn btn-primary" data-toggle="modal">connect</button>
-                    ${accordionContent}
-                  </div>
-                </div>
-              </div>
-            </div>`;
-            
-          wlanDiv += accordion;
+        let dropdown = '<select class="form-select mt-2">';
+        ssids.forEach(function (ssid) {
+          dropdown += `<option value="${ssid}">${ssid}</option>`;
         });
-        
-        $("#wlans").html(wlanDiv);
+        dropdown += '</select>';
+
+        resultDiv.html(dropdown);
       },
-      error: function (error) {
+      error: function () {
         console.log("Error occurred during network scan");
       },
       complete: function () {

--- a/templates/_adapters-card-large.html
+++ b/templates/_adapters-card-large.html
@@ -24,7 +24,7 @@
   </a>
   {% if interface.interface_type == 'Wireless' %}
     <button id="wlan-scan" class="btn btn-primary mb-2" style="width: 80%; display: block; margin: 0 auto;" value="{{ interface.name }}">Scan for Networks</button>
-    <div id="wlans"></div>
+    <div id="wlans-{{ interface.name }}" class="wlans"></div>
     <script src="/static/js/wireless-adapters.js"></script>
   {% endif %}
 </div>

--- a/templates/interface_detail.html
+++ b/templates/interface_detail.html
@@ -46,7 +46,7 @@
         {% endif %}
         </ul>
       </div>
-      <div id="wlans"></div>
+      <div id="wlans-{{ interface.name }}" class="wlans"></div>
       <div id="bluetooth-devices"></div>
     </div>
     {% include '_footer.html' %}


### PR DESCRIPTION
## Summary
- filter non-directory entries when scanning `/sys/class/net`
- limit console noise when polling interfaces
- show server URL on startup
- show scanned networks in dropdown

## Testing
- `python -m py_compile scripts/interfaceTools.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6851d2a4b0cc832fb94e18e82519fdee