### PR TITLE
Add MAC spoofing ability

### DIFF
--- a/app.py
+++ b/app.py
@@ -158,6 +158,19 @@ def bluetooth_scan():
     except Exception as e:
         return jsonify({'status': 'error', 'message': f'Bluetooth scan error: {str(e)}'}), 500
 
+@app.route('/spoof-mac', methods=['POST'])
+def spoof_mac_route():
+    data = request.form
+    interface = data.get("interface")
+    new_mac = data.get("mac")
+    if not interface or not new_mac:
+        return jsonify({"status": "error", "message": "Missing parameters"}), 400
+    success = spoof_mac(interface, new_mac)
+    if success:
+        return jsonify({"status": "success", "message": "MAC updated"})
+    else:
+        return jsonify({"status": "error", "message": "Failed to update MAC"}), 500
+
 
 @app.route('/beacon-advertise', methods=['POST'])
 def beacon_advertise():

--- a/scripts/interfaceTools.py
+++ b/scripts/interfaceTools.py
@@ -243,3 +243,15 @@ async def get_bluetooth_devices():
     except Exception as e:
         print(f"Error discovering Bluetooth devices: {e}")
         return []
+
+def spoof_mac(interface, new_mac):
+    """Change the MAC address of a network interface."""
+    try:
+        subprocess.check_call(["ip", "link", "set", interface, "down"])
+        subprocess.check_call(["ip", "link", "set", interface, "address", new_mac])
+        subprocess.check_call(["ip", "link", "set", interface, "up"])
+        return True
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to spoof MAC on {interface}: {e}")
+        return False
+

--- a/static/js/mac-spoof.js
+++ b/static/js/mac-spoof.js
@@ -1,0 +1,21 @@
+$(document).ready(function() {
+  $('.edit-mac').on('click', function(event) {
+    event.preventDefault();
+    const iface = $(this).data('interface');
+    const current = $(this).data('current');
+    const newMac = prompt('Enter new MAC address', current);
+    if (newMac && newMac !== current) {
+      $.ajax({
+        url: '/spoof-mac',
+        method: 'POST',
+        data: { interface: iface, mac: newMac },
+        success: function() {
+          location.reload();
+        },
+        error: function() {
+          alert('Failed to update MAC');
+        }
+      });
+    }
+  });
+});

--- a/templates/_adapters-card-large.html
+++ b/templates/_adapters-card-large.html
@@ -10,13 +10,13 @@
           <br>
           {% if interface.interface_type == 'Bluetooth' %}
             <h6>BD address</h6>
-            <p class="card-text small">{{ interface.get_mac_address() }}</p>
+            <p class="card-text small"><span id="mac-{{ interface.name }}-list">{{ interface.get_mac_address() }}</span> <a href="#" class="edit-mac" data-interface="{{ interface.name }}" data-current="{{ interface.get_mac_address() }}" title="Edit MAC"><i class="fa-solid fa-pencil"></i></a></p>
           {% elif interface.interface_type == 'Loopback' %}
             <h6>IP Address</h6>
             <p class="card-text small">127.0.0.1</p>
           {% else %}
             <h6>MAC address</h6>
-            <p class="card-text small">{{ interface.get_mac_address() }}</p>
+            <p class="card-text small"><span id="mac-{{ interface.name }}-list">{{ interface.get_mac_address() }}</span> <a href="#" class="edit-mac" data-interface="{{ interface.name }}" data-current="{{ interface.get_mac_address() }}" title="Edit MAC"><i class="fa-solid fa-pencil"></i></a></p>
           {% endif %}
         </div>
       </div>

--- a/templates/_adapters-card.html
+++ b/templates/_adapters-card.html
@@ -8,7 +8,7 @@
         <p class="card-text">
           Type: <a href="/{{ interface.interface_type | lower }}" class="no-link-design" onclick="event.stopPropagation();">{{ interface.interface_type }}</a>
         </p>
-        <p class="card-text">Address: {{ interface.addresses[0].address }}</p>
+        <p class="card-text">Address: <span id="mac-{{ interface.name }}-card">{{ interface.addresses[0].address }}</span> <a href="#" class="edit-mac" data-interface="{{ interface.name }}" data-current="{{ interface.addresses[0].address }}" title="Edit MAC"><i class="fa-solid fa-pencil"></i></a></p>
     </div>
   </div>
 </div>

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -12,6 +12,7 @@
 
 <script src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.0.0/socket.io.js"></script>
 <script src="/static/js/socket-io-updates.js"></script>
+<script src="/static/js/mac-spoof.js"></script>
 
 <title>{{ title }}</title>
 

--- a/templates/interface_detail.html
+++ b/templates/interface_detail.html
@@ -10,7 +10,7 @@
             <li>Interface Name: {{ interface.name }}</li>
             {% for addr in interface.addresses %}
               <li>Family: {{ addr.family }}</li>
-              <li>Address: {{ addr.address }}</li>
+              <li>Address: <span id="mac-{{ interface.name }}-{{ loop.index }}">{{ addr.address }}</span>{% if addr.family == 'AF_PACKET (MAC)' %} <a href="#" class="edit-mac" data-interface="{{ interface.name }}" data-current="{{ addr.address }}" title="Edit MAC"><i class="fa-solid fa-pencil"></i></a>{% endif %}</li>
               <li>Netmask: {{ addr.netmask }}</li>
               <li>Broadcast: {{ addr.broadcast }}</li>
               <li>PTP: {{ addr.ptp }}</li>
@@ -25,7 +25,7 @@
             <li>Interface Name: {{ interface.name }}</li>
             {% for addr in interface.addresses %}
               <li>Family: {{ addr.family }}</li>
-              <li>Address: {{ addr.address }}</li>
+              <li>Address: <span id="mac-{{ interface.name }}-{{ loop.index }}">{{ addr.address }}</span>{% if addr.family == 'AF_PACKET (MAC)' %} <a href="#" class="edit-mac" data-interface="{{ interface.name }}" data-current="{{ addr.address }}" title="Edit MAC"><i class="fa-solid fa-pencil"></i></a>{% endif %}</li>
               <li>Netmask: {{ addr.netmask }}</li>
               <li>Broadcast: {{ addr.broadcast }}</li>
               <li>PTP: {{ addr.ptp }}</li>
@@ -34,7 +34,7 @@
             <li>Interface Name: {{ interface.name }}</li>
             {% for addr in interface.addresses %}
               <li>Family: {{ addr.family }}</li>
-              <li>Address: {{ addr.address }}</li>
+              <li>Address: <span id="mac-{{ interface.name }}-{{ loop.index }}">{{ addr.address }}</span>{% if addr.family == 'AF_PACKET (MAC)' %} <a href="#" class="edit-mac" data-interface="{{ interface.name }}" data-current="{{ addr.address }}" title="Edit MAC"><i class="fa-solid fa-pencil"></i></a>{% endif %}</li>
               <li>Netmask: {{ addr.netmask }}</li>
               <li>Broadcast: {{ addr.broadcast }}</li>
               <li>PTP: {{ addr.ptp }}</li>


### PR DESCRIPTION
## Summary
- add helper to change MAC address in `interfaceTools`
- expose `/spoof-mac` route for editing MAC addresses
- load new `mac-spoof.js` on every page
- display pencil edit buttons next to MAC addresses
- allow editing from interface cards and detail pages

## Testing
- `python -m py_compile app.py scripts/interfaceTools.py`

------
https://chatgpt.com/codex/tasks/task_e_6852a706b6f0832f9593eb3358667a0b