### PR TITLE
Filter zero MAC addresses from passive scan

### DIFF
--- a/scripts/networkScan.py
+++ b/scripts/networkScan.py
@@ -51,7 +51,11 @@ def passive_scan(interface):
             next(f)  # skip header
             for line in f:
                 parts = line.split()
-                if len(parts) >= 6 and parts[5] == interface:
+                if (
+                    len(parts) >= 6
+                    and parts[5] == interface
+                    and parts[3] != "00:00:00:00:00:00"
+                ):
                     devices.append({"ip": parts[0], "mac": parts[3]})
     except Exception:
         pass


### PR DESCRIPTION
## Summary
- ignore ARP entries with all-zero MAC addresses

## Testing
- `python -m py_compile scripts/networkScan.py`


------
https://chatgpt.com/codex/tasks/task_e_6853365557bc832fa970cc59f5090bcc