### PR TITLE
Filter zero MAC addresses from passive scan

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import threading
 import asyncio
 
 from scripts.interfaceTools import *
-from scripts.networkScan import active_scan, passive_scan
+from scripts.networkScan import active_scan, passive_scan, get_mac_by_ip
 
 app = Flask(__name__)
 socketio = SocketIO(app)
@@ -89,6 +89,21 @@ def traceroute_page():
     return render_template('traceroute.html', title='Traceroute',
                            networkTechnologies=networkTechnologies,
                            interfaces=network_interfaces)
+
+
+@app.route('/clients/<ip>')
+def client_detail(ip):
+    mac = get_mac_by_ip(ip)
+    manufacturer = lookup_manufacturer(mac) if mac else 'Unknown'
+    return render_template(
+        'client_detail.html',
+        title=f'Client {ip}',
+        ip=ip,
+        mac=mac,
+        manufacturer=manufacturer,
+        networkTechnologies=networkTechnologies,
+        interfaces=network_interfaces,
+    )
 
 @app.route('/active-scan', methods=['POST'])
 def active_scan_route():

--- a/scripts/networkScan.py
+++ b/scripts/networkScan.py
@@ -51,8 +51,29 @@ def passive_scan(interface):
             next(f)  # skip header
             for line in f:
                 parts = line.split()
-                if len(parts) >= 6 and parts[5] == interface:
+                if (
+                    len(parts) >= 6
+                    and parts[5] == interface
+                    and parts[3] != "00:00:00:00:00:00"
+                ):
                     devices.append({"ip": parts[0], "mac": parts[3]})
     except Exception:
         pass
     return devices
+
+
+def get_mac_by_ip(ip):
+    """Return the MAC address for a given IP from the ARP table."""
+    try:
+        with open("/proc/net/arp") as f:
+            next(f)  # skip header
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 4 and parts[0] == ip:
+                    mac = parts[3]
+                    if mac != "00:00:00:00:00:00":
+                        return mac
+                    break
+    except Exception:
+        pass
+    return None

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -12,7 +12,10 @@ $(document).ready(function () {
           html += '<p>No hosts found</p>';
         } else {
           html += '<ul>';
-          resp.hosts.forEach(function (ip) { html += `<li>${ip}</li>`; });
+          resp.hosts.forEach(function (ip) {
+            const link = `/clients/${encodeURIComponent(ip)}`;
+            html += `<li><a href="${link}">${ip}</a></li>`;
+          });
           html += '</ul>';
         }
         $('#scan-results').html(html);
@@ -37,7 +40,8 @@ $(document).ready(function () {
         } else {
           html += '<ul>';
           resp.devices.forEach(function (dev) {
-            html += `<li>${dev.ip} (${dev.mac})</li>`;
+            const link = `/clients/${encodeURIComponent(dev.ip)}`;
+            html += `<li><a href="${link}">${dev.ip}</a> (${dev.mac})</li>`;
           });
           html += '</ul>';
         }

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,0 +1,19 @@
+{% include '_header.html' %}
+<body class="d-flex flex-column min-vh-100">
+  <div class="page-contents">
+    <div class="details">
+      <h1>Client {{ ip }}</h1>
+      <ul>
+        <li>IP Address: {{ ip }}</li>
+        {% if mac %}
+          <li>MAC Address: {{ mac }}</li>
+          <li>Manufacturer: {{ manufacturer }}</li>
+        {% else %}
+          <li>MAC Address: Unknown</li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+  {% include '_footer.html' %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ignore ARP entries with all-zero MAC addresses
- add `/clients/<ip>` pages showing IP, MAC and manufacturer
- link active and passive scan results to new client pages

## Testing
- `python -m py_compile scripts/networkScan.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6853365557bc832fa970cc59f5090bcc