### PR TITLE
Filter zero MAC addresses from passive scan

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,7 +7,12 @@ import threading
 import asyncio
 
 from scripts.interfaceTools import *
-from scripts.networkScan import active_scan, passive_scan
+from scripts.networkScan import (
+    active_scan,
+    passive_scan,
+    get_mac_by_ip,
+    get_ip_by_mac,
+)
 
 app = Flask(__name__)
 socketio = SocketIO(app)
@@ -89,6 +94,21 @@ def traceroute_page():
     return render_template('traceroute.html', title='Traceroute',
                            networkTechnologies=networkTechnologies,
                            interfaces=network_interfaces)
+
+
+@app.route('/clients/<mac>')
+def client_detail(mac):
+    ip = get_ip_by_mac(mac)
+    manufacturer = lookup_manufacturer(mac) if mac else 'Unknown'
+    return render_template(
+        'client_detail.html',
+        title=f'Client {mac}',
+        ip=ip,
+        mac=mac,
+        manufacturer=manufacturer,
+        networkTechnologies=networkTechnologies,
+        interfaces=network_interfaces,
+    )
 
 @app.route('/active-scan', methods=['POST'])
 def active_scan_route():

--- a/scripts/networkScan.py
+++ b/scripts/networkScan.py
@@ -19,7 +19,7 @@ def _get_ipv4_cidr(interface):
 
 
 def active_scan(interface):
-    """Perform a ping sweep to discover live hosts."""
+    """Perform a ping sweep and return live hosts with MAC addresses."""
     cidr = _get_ipv4_cidr(interface)
     if not cidr:
         return []
@@ -37,7 +37,8 @@ def active_scan(interface):
                 stderr=subprocess.DEVNULL,
             )
             if result.returncode == 0:
-                live_hosts.append(str(ip))
+                mac = get_mac_by_ip(str(ip))
+                live_hosts.append({"ip": str(ip), "mac": mac})
         except Exception:
             continue
     return live_hosts
@@ -51,8 +52,43 @@ def passive_scan(interface):
             next(f)  # skip header
             for line in f:
                 parts = line.split()
-                if len(parts) >= 6 and parts[5] == interface:
+                if (
+                    len(parts) >= 6
+                    and parts[5] == interface
+                    and parts[3] != "00:00:00:00:00:00"
+                ):
                     devices.append({"ip": parts[0], "mac": parts[3]})
     except Exception:
         pass
     return devices
+
+
+def get_mac_by_ip(ip):
+    """Return the MAC address for a given IP from the ARP table."""
+    try:
+        with open("/proc/net/arp") as f:
+            next(f)  # skip header
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 4 and parts[0] == ip:
+                    mac = parts[3]
+                    if mac != "00:00:00:00:00:00":
+                        return mac
+                    break
+    except Exception:
+        pass
+    return None
+
+
+def get_ip_by_mac(mac):
+    """Return the IP address for a given MAC from the ARP table."""
+    try:
+        with open("/proc/net/arp") as f:
+            next(f)  # skip header
+            for line in f:
+                parts = line.split()
+                if len(parts) >= 4 and parts[3].lower() == mac.lower():
+                    return parts[0]
+    except Exception:
+        pass
+    return None

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -12,7 +12,16 @@ $(document).ready(function () {
           html += '<p>No hosts found</p>';
         } else {
           html += '<ul>';
-          resp.hosts.forEach(function (ip) { html += `<li>${ip}</li>`; });
+          resp.hosts.forEach(function (host) {
+            const display = host.ip;
+            const macParam = host.mac ? host.mac : host.ip;
+            const link = `/clients/${encodeURIComponent(macParam)}`;
+            html += `<li><a href="${link}">${display}</a>`;
+            if (host.mac) {
+              html += ` (${host.mac})`;
+            }
+            html += `</li>`;
+          });
           html += '</ul>';
         }
         $('#scan-results').html(html);
@@ -37,7 +46,8 @@ $(document).ready(function () {
         } else {
           html += '<ul>';
           resp.devices.forEach(function (dev) {
-            html += `<li>${dev.ip} (${dev.mac})</li>`;
+            const link = `/clients/${encodeURIComponent(dev.mac)}`;
+            html += `<li><a href="${link}">${dev.ip}</a> (${dev.mac})</li>`;
           });
           html += '</ul>';
         }

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,0 +1,19 @@
+{% include '_header.html' %}
+<body class="d-flex flex-column min-vh-100">
+  <div class="page-contents">
+    <div class="details">
+      <h1>Client {{ mac }}</h1>
+      <ul>
+        <li>IP Address: {{ ip if ip else 'Unknown' }}</li>
+        {% if mac %}
+          <li>MAC Address: {{ mac }}</li>
+          <li>Manufacturer: {{ manufacturer }}</li>
+        {% else %}
+          <li>MAC Address: Unknown</li>
+        {% endif %}
+      </ul>
+    </div>
+  </div>
+  {% include '_footer.html' %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- ignore ARP entries with all-zero MAC addresses
- add `/clients/<mac>` pages showing IP, MAC and manufacturer
- link active and passive scan results to new client pages
- include MAC addresses in active scan results

## Testing
- `python -m py_compile scripts/networkScan.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_6853365557bc832fa970cc59f5090bcc