### PR TITLE
Add inventory/diagnostics services, client intelligence, service discovery and advanced network UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -27,6 +27,8 @@ from services import persistence as persistence_service
 from services import oui as oui_service
 from services import labs as labs_service
 from services import reports as reports_service
+from services import alerts as alerts_service
+from services import evidence as evidence_service
 from scripts.interfaceTools import (
     get_bluetooth_devices,
     get_network_interfaces,
@@ -482,157 +484,30 @@ def inventory_key(device):
 
 
 def create_new_device_alert(device, source, interface=None):
-    """Record an unread alert for a newly observed inventory device."""
-    display_name = device.get('name') or device.get('hostname') or device.get('ssid') or device.get('ip') or device.get('mac') or 'Unknown device'
-    device_identifier = device.get('mac') or device.get('bssid') or device.get('ip')
-    device_url = f"/clients/{quote(str(device_identifier))}" if device_identifier else None
-    alert = {
-        'id': uuid.uuid4().hex,
-        'device_id': device.get('id'),
-        'display_name': display_name,
-        'ip': device.get('ip'),
-        'mac': device.get('mac') or device.get('bssid'),
-        'manufacturer': device.get('manufacturer') or 'Unknown',
-        'device_url': device_url,
-        'source': source,
-        'interface': interface,
-        'created_at': time.time(),
-        'read': False,
-    }
-    with new_device_alerts_lock:
-        new_device_alerts.insert(0, alert)
-        del new_device_alerts[200:]
-    return alert
+    return alerts_service.create_new_device_alert(device, source, interface, new_device_alerts, new_device_alerts_lock)
 
 
 def create_grouped_device_alert(devices, source, interface=None):
-    """Record one unread alert for a batch of newly observed devices."""
-    devices = [dict(device) for device in devices or []]
-    alert = {
-        'id': uuid.uuid4().hex,
-        'alert_type': 'grouped-discovery',
-        'display_name': f"{len(devices)} new devices discovered",
-        'ip': None,
-        'mac': None,
-        'manufacturer': 'Multiple',
-        'device_url': '/inventory',
-        'source': source,
-        'interface': interface,
-        'created_at': time.time(),
-        'read': False,
-        'device_count': len(devices),
-        'devices': [
-            {
-                'id': device.get('id'),
-                'display_name': device.get('name') or device.get('hostname') or device.get('ssid') or device.get('ip') or device.get('mac') or 'Unknown device',
-                'ip': device.get('ip'),
-                'mac': device.get('mac') or device.get('bssid'),
-                'manufacturer': device.get('manufacturer') or 'Unknown',
-            }
-            for device in devices[:10]
-        ],
-    }
-    with new_device_alerts_lock:
-        new_device_alerts.insert(0, alert)
-        del new_device_alerts[200:]
-    return alert
-
+    return alerts_service.create_grouped_device_alert(devices, source, interface, new_device_alerts, new_device_alerts_lock)
 
 
 def evidence_records():
-    """Return evidence vault records with display labels."""
-    with evidence_vault_lock:
-        records = [dict(item) for item in evidence_vault]
-    for item in records:
-        item['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('created_at', 0)))
-    return records
+    return evidence_service.evidence_records(evidence_vault, evidence_vault_lock)
 
 
 def create_evidence_record(title, category='note', source=None, device=None, notes=None, content=None, uploaded_file=None):
-    """Store a timestamped evidence record and optional uploaded file metadata."""
-    title = (title or '').strip()
-    if not title:
-        raise ValueError('Evidence title is required')
-    category = (category or 'note').strip().lower()
-    if category not in {'note', 'scan-output', 'capture', 'screenshot', 'artifact'}:
-        raise ValueError('Unsupported evidence category')
-
-    now = time.time()
-    record = {
-        'id': uuid.uuid4().hex,
-        'title': title,
-        'category': category,
-        'source': (source or '').strip(),
-        'device': (device or '').strip(),
-        'notes': (notes or '').strip(),
-        'content': (content or '').strip(),
-        'created_at': now,
-        'file_name': None,
-        'file_size': None,
-        'download_url': None,
-    }
-
-    if uploaded_file and uploaded_file.filename:
-        os.makedirs(EVIDENCE_DIR, exist_ok=True)
-        safe_name = secure_filename(uploaded_file.filename)
-        if not safe_name:
-            raise ValueError('Uploaded file name is not valid')
-        stored_name = f"{record['id']}-{safe_name}"
-        path = os.path.join(EVIDENCE_DIR, stored_name)
-        uploaded_file.save(path)
-        record.update({
-            'file_name': safe_name,
-            'stored_name': stored_name,
-            'file_size': os.path.getsize(path),
-            'download_url': f"/evidence/{record['id']}/download",
-        })
-
-    with evidence_vault_lock:
-        evidence_vault.insert(0, record)
-        del evidence_vault[500:]
-    save_runtime_state('evidence')
-    return dict(record)
+    return evidence_service.create_evidence_record(
+        title, category, source, device, notes, content, uploaded_file,
+        EVIDENCE_DIR, evidence_vault, evidence_vault_lock, save_runtime_state, secure_filename,
+    )
 
 
 def evidence_as_csv(records):
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerow(['Title', 'Category', 'Source', 'Device', 'File', 'Created', 'Notes', 'Content'])
-    for item in records:
-        writer.writerow([
-            item.get('title'),
-            item.get('category'),
-            item.get('source'),
-            item.get('device'),
-            item.get('file_name'),
-            item.get('created_at_label'),
-            item.get('notes'),
-            item.get('content'),
-        ])
-    return output.getvalue()
+    return evidence_service.evidence_as_csv(records)
 
 
 def evidence_as_markdown(records):
-    lines = ['# Evidence Vault', '']
-    if not records:
-        lines.append('_No evidence records captured yet._')
-    for item in records:
-        lines.extend([
-            f"## {item.get('title', 'Untitled')}",
-            f"- Category: {item.get('category') or 'note'}",
-            f"- Source: {item.get('source') or '—'}",
-            f"- Device: {item.get('device') or '—'}",
-            f"- Created: {item.get('created_at_label')}",
-        ])
-        if item.get('file_name'):
-            lines.append(f"- File: {item.get('file_name')} ({item.get('file_size') or 0} bytes)")
-        if item.get('notes'):
-            lines.extend(['', item.get('notes')])
-        if item.get('content'):
-            lines.extend(['', '```', item.get('content'), '```'])
-        lines.append('')
-    return '\n'.join(lines)
-
+    return evidence_service.evidence_as_markdown(records)
 
 
 def set_interface_power_state(interface_name, desired_state, interface_type=None):
@@ -865,17 +740,12 @@ def bluetooth_detail_fields(device):
     return fields
 
 def alert_records():
-    """Return alert records with display labels."""
-    with new_device_alerts_lock:
-        records = [dict(alert) for alert in new_device_alerts]
-    for alert in records:
-        alert['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(alert.get('created_at', 0)))
-    return records
+    return alerts_service.alert_records(new_device_alerts, new_device_alerts_lock)
 
 
 def unread_alert_count():
-    with new_device_alerts_lock:
-        return len([alert for alert in new_device_alerts if not alert.get('read')])
+    return alerts_service.unread_alert_count(new_device_alerts, new_device_alerts_lock)
+
 
 def record_inventory_devices(devices, source, interface=None):
     merged = inventory_service.merge_devices(
@@ -2671,21 +2541,15 @@ def alerts_status():
 
 @app.route('/alerts/<alert_id>/read', methods=['POST'])
 def mark_alert_read(alert_id):
-    with new_device_alerts_lock:
-        for alert in new_device_alerts:
-            if alert['id'] == alert_id:
-                alert['read'] = True
-                unread_count = len([item for item in new_device_alerts if not item.get('read')])
-                return json_success(alert=dict(alert), unread_count=unread_count)
+    alert, unread_count = alerts_service.mark_alert_read(alert_id, new_device_alerts, new_device_alerts_lock)
+    if alert:
+        return json_success(alert=alert, unread_count=unread_count)
     return json_error('Alert not found', 404)
 
 
 @app.route('/alerts/read-all', methods=['POST'])
 def mark_all_alerts_read():
-    with new_device_alerts_lock:
-        for alert in new_device_alerts:
-            alert['read'] = True
-    return json_success(unread_count=0)
+    return json_success(unread_count=alerts_service.mark_all_alerts_read(new_device_alerts, new_device_alerts_lock))
 
 
 @app.route('/port-scan')

--- a/app.py
+++ b/app.py
@@ -326,17 +326,18 @@ PINEAP_MODULES = {'recon', 'evil-twin-lab', 'handshake-capture', 'portal-awarene
 HANDSHAKE_CAPTURE_TYPES = {'wpa-handshake', 'pmkid'}
 
 
-def normalize_mac(value):
-    """Return a lowercase colon-separated MAC address or raise ValueError."""
-    if not value or not MAC_RE.match(value):
+def require_normalized_mac(value):
+    """Return a normalized MAC address or raise ValueError for required lab inputs."""
+    mac = normalize_mac(value)
+    if not mac:
         raise ValueError('Enter a valid MAC address in the form aa:bb:cc:dd:ee:ff')
-    return value.lower().replace('-', ':')
+    return mac
 
 
 def validate_lab_deauth_request(data):
     """Validate bounded deauth lab inputs for an authorized classroom exercise."""
-    ap_mac = normalize_mac(data.get('ap'))
-    target_mac = normalize_mac(data.get('target') or BROADCAST_MAC)
+    ap_mac = require_normalized_mac(data.get('ap'))
+    target_mac = require_normalized_mac(data.get('target') or BROADCAST_MAC)
     if ap_mac == BROADCAST_MAC:
         raise ValueError('AP MAC must be a specific lab access point, not broadcast')
     if data.get('authorized') != 'on':
@@ -359,7 +360,7 @@ def validate_evil_twin_lab_request(data):
     if not ssid or len(ssid) > 32:
         raise ValueError('Enter the exact lab SSID, up to 32 characters')
 
-    bssid = normalize_mac(data.get('bssid'))
+    bssid = require_normalized_mac(data.get('bssid'))
     channel = parse_int(data.get('channel'), 'Channel must be an integer')
     if channel < 1 or channel > 196:
         raise ValueError('Channel must be between 1 and 196')
@@ -445,7 +446,7 @@ def validate_pineap_lab_request(data):
     ssid = (data.get('ssid') or '').strip()
     if ssid and len(ssid) > 32:
         raise ValueError('SSID must be 32 characters or fewer')
-    bssid = normalize_mac(data.get('bssid')) if data.get('bssid') else None
+    bssid = require_normalized_mac(data.get('bssid')) if data.get('bssid') else None
     channel = None
     if data.get('channel'):
         channel = parse_int(data.get('channel'), 'Channel must be an integer')
@@ -507,7 +508,7 @@ def validate_handshake_lab_request(data):
     ssid = (data.get('ssid') or '').strip()
     if not ssid or len(ssid) > 32:
         raise ValueError('Enter the exact lab SSID, up to 32 characters')
-    bssid = normalize_mac(data.get('bssid'))
+    bssid = require_normalized_mac(data.get('bssid'))
     channel = parse_int(data.get('channel'), 'Channel must be an integer')
     if channel < 1 or channel > 196:
         raise ValueError('Channel must be between 1 and 196')

--- a/app.py
+++ b/app.py
@@ -11,10 +11,19 @@ import shutil
 import subprocess
 import csv
 import io
+import ipaddress
+import socket
 from urllib.parse import quote
+from urllib.request import Request, urlopen
+from urllib.error import URLError, HTTPError
 from werkzeug.utils import secure_filename
 
 from routes import register_blueprints
+from services import device_intel
+from services import inventory as inventory_service
+from services import diagnostics as diagnostics_service
+from services import port_scans as port_scan_service
+from services import wireless_clients as wireless_client_service
 from scripts.interfaceTools import (
     get_bluetooth_devices,
     get_network_interfaces,
@@ -57,6 +66,23 @@ new_device_alerts = []
 new_device_alerts_lock = threading.Lock()
 evidence_vault = []
 evidence_vault_lock = threading.Lock()
+evil_twin_lab_runs = []
+evil_twin_lab_lock = threading.Lock()
+pineap_lab_runs = []
+pineap_lab_lock = threading.Lock()
+handshake_lab_records = []
+handshake_lab_lock = threading.Lock()
+ping_history = []
+vlan_segmentation_notes = []
+watched_clients = set()
+client_timelines = {}
+client_timelines_lock = threading.Lock()
+scheduled_client_checks = {}
+wireless_network_client_cache = {}
+wireless_network_labels = {}
+passive_monitor_jobs = {}
+passive_monitor_lock = threading.Lock()
+HTTP_PREVIEW_DIR = os.path.join(app.instance_path, 'http_previews')
 EVIDENCE_DIR = os.path.join(app.instance_path, 'evidence_vault')
 MAC_RE = re.compile(r'^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$')
 
@@ -97,25 +123,31 @@ ROADMAP_SECTIONS = [
         'title': 'Network visibility',
         'items': [
             {'title': 'Device inventory page', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'The /inventory page aggregates discovered devices, sources, interfaces, manufacturers, and first/last seen timestamps.', 'description': 'Aggregate discovered IPs, MACs, manufacturers, ports, SSIDs, and first/last seen timestamps.'},
+            {'title': 'Comprehensive network device scan', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Network Scan now combines active ARP, passive observations, local ARP/neighbor tables, optional ping sweeps, mDNS, UPnP/SSDP, and LLDP/CDP metadata into one inventory-building workflow.', 'description': 'Scan local networks for devices using multiple discovery methods and merge results into inventory with source attribution.'},
+            {'title': 'IP client profiles and watchlists', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Client pages now include health scoring, saved service history, web inspection, watch alerts, timeline events, owner/location/tags, baselines, drift checks, reachability history, and per-client JSON/Markdown exports.', 'description': 'Turn discovered IP clients into investigation profiles with health, ownership, baseline, watch, timeline, and export workflows.'},
             {'title': 'Network map', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Visualize adapters, SSIDs, access points, clients, and wired hosts as a simple topology map.'},
+            {'title': 'Client relationship map', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Client profiles now show relationship nodes and links for interfaces, discovery sources, saved services, and related evidence records.', 'description': 'Show each IP client connected to interfaces, SSIDs, gateways, VLAN context, services, evidence records, and alerts.'},
+            {'title': 'Scheduled client checks', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Client profiles can save recurring check plans for ping, common ports, HTTP inspection, service fingerprinting, and baseline drift so a scheduler can run them.', 'description': 'Run recurring reachability, common-port, service-fingerprint, and drift checks for watched clients with alerting.'},
+            {'title': 'Client remediation checklist', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Turn baseline drift, sensitive services, and unknown identity hints into suggested remediation tasks with resolved/accepted-risk state.'},
+            {'title': 'Client change approval log', 'priority': 'Low', 'priority_class': 'secondary', 'description': 'Let users approve expected port, owner, location, and tag changes with reviewer notes for audit-friendly inventory maintenance.'},
             {'title': 'Dedicated wireless occupancy report page', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Create a drill-down page that compares adapters, channel congestion, BSSID detail, historical heatmaps, and exportable recommendations.'},
             {'title': 'Manufacturer/OUI insights', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Inventory groups devices by manufacturer and highlights unknown OUIs for review.', 'description': 'Group discovered devices by vendor and highlight unknown or unusual manufacturers.'},
             {'title': 'New device alerts', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'New devices create unread alerts with a navbar badge and alert center.', 'description': 'Notify when a newly observed MAC, IP, SSID, or Bluetooth device appears.'},
-            {'title': 'Grouped discovery notifications', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'When multiple devices are discovered in the same scan, group them into one notification while keeping individual passive-discovery alerts for devices that appear later.'},
+            {'title': 'Grouped discovery notifications', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Inventory discovery now creates one grouped alert for multi-device active/job scans while preserving individual passive-scan alerts.', 'description': 'When multiple devices are discovered in the same scan, group them into one notification while keeping individual passive-discovery alerts for devices that appear later.'},
         ],
     },
     {
         'title': 'Core network tools',
         'items': [
-            {'title': 'Ping and reachability testing', 'priority': 'High', 'priority_class': 'danger', 'description': 'Add single-host ping, subnet ping sweeps, packet-loss summaries, latency stats, and IPv4/IPv6 reachability history.'},
-            {'title': 'ARP and neighbor discovery viewer', 'priority': 'High', 'priority_class': 'danger', 'description': 'Show local ARP and IPv6 neighbor tables with interface, state, OUI/vendor enrichment, and inventory links.'},
+            {'title': 'Ping and reachability testing', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Diagnostics now includes single-host ping, bounded subnet sweeps, packet loss, latency parsing, and recent reachability history.', 'description': 'Add single-host ping, subnet ping sweeps, packet-loss summaries, latency stats, and IPv4/IPv6 reachability history.'},
+            {'title': 'ARP and neighbor discovery viewer', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Comprehensive network scans now include local ARP cache and neighbor-table observations with OUI/vendor enrichment and inventory links.', 'description': 'Show local ARP and IPv6 neighbor tables with interface, state, OUI/vendor enrichment, and inventory links.'},
             {'title': 'DNS lookup and diagnostics toolkit', 'priority': 'High', 'priority_class': 'danger', 'description': 'Support A, AAAA, PTR, MX, TXT, NS, and CNAME lookups, resolver comparison, timing, and split-horizon troubleshooting.'},
-            {'title': 'Route table and gateway diagnostics', 'priority': 'High', 'priority_class': 'danger', 'description': 'Display default gateways, per-interface routes, metrics, IPv4/IPv6 routes, VPN route hints, and scan-path context.'},
+            {'title': 'Route table and gateway diagnostics', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Diagnostics now reports default gateways, parsed IPv4/IPv6 routes, per-interface metrics, VPN route hints, and target scan-path context.', 'description': 'Display default gateways, per-interface routes, metrics, IPv4/IPv6 routes, VPN route hints, and scan-path context.'},
             {'title': 'Connectivity health check', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Check gateway, DNS, HTTP, HTTPS, NTP, IPv4, IPv6, captive portal state, and explain which layer is failing.'},
             {'title': 'Packet capture and protocol summary', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Start and stop scoped packet captures, export PCAP files, summarize protocols/top talkers, and attach captures to evidence.'},
             {'title': 'Live traffic monitor', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Show bandwidth, packets per second, top talkers, protocol mix, and short history per interface.'},
             {'title': 'Local socket and listener inventory', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'List local listening ports and established connections with process names where available and highlight externally exposed listeners.'},
-            {'title': 'Service fingerprinting and banner detection', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Identify services beyond port numbers using banners and safe protocol checks with confidence labels.'},
+            {'title': 'Service fingerprinting and banner detection', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'IP client profiles can run safe banner probes and HTTP checks against saved open ports with confidence labels.', 'description': 'Identify services beyond port numbers using banners and safe protocol checks with confidence labels.'},
             {'title': 'HTTP service inspector', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Inspect HTTP/HTTPS services for status, redirects, page title, server headers, login forms, TLS details, and basic security headers.'},
         ],
     },
@@ -124,14 +156,14 @@ ROADMAP_SECTIONS = [
         'items': [
             {'title': 'TLS certificate inspection', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Show certificate subject, issuer, SANs, expiration, self-signed status, hostname mismatch, and chain details.'},
             {'title': 'DHCP lease and server inspection', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Display DHCP lease details, DNS/router options, renewal timing, and warnings for multiple or unexpected DHCP servers.'},
-            {'title': 'mDNS and Bonjour service discovery', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Discover local mDNS services, hostnames, ports, TXT records, device roles, and add service metadata to inventory.'},
-            {'title': 'UPnP and SSDP discovery', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Discover UPnP devices, friendly names, model/manufacturer metadata, service lists, and exposed control URLs.'},
-            {'title': 'LLDP and CDP neighbor discovery', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Reveal switch/router neighbors, port IDs, chassis IDs, VLAN hints, and management addresses when packets are visible.'},
-            {'title': 'VLAN discovery and segmentation notes', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Track VLAN interfaces, observed tags, SSID-to-VLAN notes, and segmentation validation context.'},
-            {'title': 'Egress and public IP diagnostics', 'priority': 'Low', 'priority_class': 'secondary', 'description': 'Show public IP, NAT context, DNS egress resolver, IPv6 egress, VPN/proxy hints, and per-interface egress differences.'},
-            {'title': 'iperf3 performance testing', 'priority': 'Low', 'priority_class': 'secondary', 'description': 'Run controlled iperf3 client/server tests for throughput, jitter, loss, and LAN performance baselines.'},
-            {'title': 'SNMP inventory discovery', 'priority': 'Low', 'priority_class': 'secondary', 'description': 'Safely collect SNMP system identity and interface metadata from authorized devices when credentials are provided.'},
-            {'title': 'IPv6 assessment toolkit', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Add IPv6 ping, traceroute, neighbor discovery, router advertisement visibility, DNS records, and IPv6 port scanning support.'},
+            {'title': 'mDNS and Bonjour service discovery', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Service Discovery now parses mDNS/Bonjour service records, hostnames, ports, TXT records, roles, and inventory metadata.', 'description': 'Discover local mDNS services, hostnames, ports, TXT records, device roles, and add service metadata to inventory.'},
+            {'title': 'UPnP and SSDP discovery', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Service Discovery now performs bounded SSDP discovery and catalogs friendly names, model/manufacturer hints, service types, and control URLs.', 'description': 'Discover UPnP devices, friendly names, model/manufacturer metadata, service lists, and exposed control URLs.'},
+            {'title': 'LLDP and CDP neighbor discovery', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Service Discovery now surfaces lldpctl neighbor data including switch/router names, ports, VLAN hints, and management addresses when visible.', 'description': 'Reveal switch/router neighbors, port IDs, chassis IDs, VLAN hints, and management addresses when packets are visible.'},
+            {'title': 'VLAN discovery and segmentation notes', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Advanced Diagnostics now inventories VLAN interfaces/tags and stores SSID-to-VLAN segmentation validation notes.', 'description': 'Track VLAN interfaces, observed tags, SSID-to-VLAN notes, and segmentation validation context.'},
+            {'title': 'Egress and public IP diagnostics', 'priority': 'Low', 'priority_class': 'secondary', 'status': 'Done', 'completed_note': 'Advanced Diagnostics now reports public IP hints, NAT context, DNS resolvers, IPv6 egress, VPN/proxy hints, and per-interface route context.', 'description': 'Show public IP, NAT context, DNS egress resolver, IPv6 egress, VPN/proxy hints, and per-interface egress differences.'},
+            {'title': 'iperf3 performance testing', 'priority': 'Low', 'priority_class': 'secondary', 'status': 'Done', 'completed_note': 'Advanced Diagnostics now runs bounded iperf3 client/server checks for LAN throughput baselines when iperf3 is installed.', 'description': 'Run controlled iperf3 client/server tests for throughput, jitter, loss, and LAN performance baselines.'},
+            {'title': 'SNMP inventory discovery', 'priority': 'Low', 'priority_class': 'secondary', 'status': 'Done', 'completed_note': 'Advanced Diagnostics now safely collects SNMP system and interface metadata from authorized targets when credentials are supplied.', 'description': 'Safely collect SNMP system identity and interface metadata from authorized devices when credentials are provided.'},
+            {'title': 'IPv6 assessment toolkit', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Advanced Diagnostics now includes IPv6 ping, traceroute, neighbor/default-route views, AAAA lookup, and bounded IPv6 TCP checks.', 'description': 'Add IPv6 ping, traceroute, neighbor discovery, router advertisement visibility, DNS records, and IPv6 port scanning support.'},
         ],
     },
     {
@@ -150,11 +182,11 @@ ROADMAP_SECTIONS = [
     {
         'title': 'Wireless risk lab',
         'items': [
-            {'title': 'WPA handshake capture lab', 'priority': 'High', 'priority_class': 'danger', 'description': 'Capture, validate, catalog, and export WPA/WPA2 handshake or PMKID evidence from authorized lab networks.'},
+            {'title': 'WPA handshake capture lab', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Red Team now catalogs authorized WPA/WPA2 handshake or PMKID evidence with validation status, Evidence Vault mirroring, and JSON/CSV exports.', 'description': 'Capture, validate, catalog, and export WPA/WPA2 handshake or PMKID evidence from authorized lab networks.'},
             {'title': 'Scoped deauthentication actions', 'priority': 'High', 'priority_class': 'danger', 'description': 'Run AP-wide or client-specific deauthentication actions against authorized lab networks with targeting controls, rate limits, and clear logs.'},
             {'title': 'Remote cracking orchestration', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Queue authorized handshake material to stronger remote workers such as Spark, track job progress, and import results for password-strength review.'},
-            {'title': 'PineAP-style recon and campaign engine', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Build functional WiFi Pineapple-style recon, campaign, handshake, module, and Cloud C2-inspired workflows for authorized labs.'},
-            {'title': 'Evil twin and captive portal lab', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Run controlled rogue-AP and captive-portal lab workflows with explicit SSID targeting, logging, cleanup, and detection guidance.'},
+            {'title': 'PineAP-style recon and campaign engine', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Red Team now includes a PineAP-style lab console for authorized recon, campaign, handshake, and module workflow logging.', 'description': 'Build functional WiFi Pineapple-style recon, campaign, handshake, module, and Cloud C2-inspired workflows for authorized labs.'},
+            {'title': 'Evil twin and captive portal lab', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Red Team now records authorized evil-twin/captive-portal lab plans with explicit SSID/BSSID/channel targeting, cleanup steps, and detection guidance.', 'description': 'Run controlled rogue-AP and captive-portal lab workflows with explicit SSID targeting, logging, cleanup, and detection guidance.'},
             {'title': 'WPS exposure checks', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Wireless scan results and network detail pages now flag APs advertising WPS and explain why WPS can weaken credential protection.', 'description': 'Identify lab networks advertising WPS and explain why WPS increases wireless credential risk.'},
             {'title': 'Client privacy and probe request monitor', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Monitor probe behavior to show device presence, preferred-network leakage, and tracking risk in authorized training environments.'},
             {'title': 'Rogue DHCP, DNS, and portal lab', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Run isolated post-association lab workflows for rogue DHCP, DNS manipulation, and portal redirection with validation checks.'},
@@ -213,6 +245,11 @@ BLUETOOTH_MAC_RE = re.compile(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$')
 
 DEAUTH_FRAME_LIMIT = 5
 BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+EVIL_TWIN_MAX_DURATION_MINUTES = 30
+EVIL_TWIN_ACTIONS = {'plan', 'start', 'cleanup'}
+PINEAP_ACTIONS = {'recon', 'campaign', 'handshake', 'module'}
+PINEAP_MODULES = {'recon', 'evil-twin-lab', 'handshake-capture', 'portal-awareness', 'detection-report'}
+HANDSHAKE_CAPTURE_TYPES = {'wpa-handshake', 'pmkid'}
 
 
 def normalize_mac(value):
@@ -234,6 +271,245 @@ def validate_lab_deauth_request(data):
     if frames < 1 or frames > DEAUTH_FRAME_LIMIT:
         raise ValueError(f'Frames must be between 1 and {DEAUTH_FRAME_LIMIT} for first-year labs')
     return ap_mac, target_mac, frames
+
+
+def validate_evil_twin_lab_request(data):
+    """Validate a controlled rogue-AP/captive-portal lab workflow request."""
+    action = (data.get('action') or 'plan').strip().lower()
+    if action not in EVIL_TWIN_ACTIONS:
+        raise ValueError('Choose plan, start, or cleanup for the lab workflow')
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab before preparing an evil twin lab workflow')
+
+    ssid = (data.get('ssid') or '').strip()
+    if not ssid or len(ssid) > 32:
+        raise ValueError('Enter the exact lab SSID, up to 32 characters')
+
+    bssid = normalize_mac(data.get('bssid'))
+    channel = parse_int(data.get('channel'), 'Channel must be an integer')
+    if channel < 1 or channel > 196:
+        raise ValueError('Channel must be between 1 and 196')
+
+    duration = parse_int(data.get('durationMinutes') or '10', 'Duration must be an integer')
+    if duration < 1 or duration > EVIL_TWIN_MAX_DURATION_MINUTES:
+        raise ValueError(f'Duration must be between 1 and {EVIL_TWIN_MAX_DURATION_MINUTES} minutes')
+
+    portal_message = (data.get('portalMessage') or 'Training portal: do not enter real credentials.').strip()
+    if len(portal_message) > 200:
+        raise ValueError('Portal message must be 200 characters or fewer')
+
+    return {
+        'action': action,
+        'ssid': ssid,
+        'bssid': bssid,
+        'channel': channel,
+        'duration_minutes': duration,
+        'portal_message': portal_message,
+    }
+
+
+def build_evil_twin_lab_guidance(run):
+    """Return safe operator, cleanup, and defensive guidance for the lab."""
+    return {
+        'operator_steps': [
+            f"Verify the isolated lab AP broadcasting '{run['ssid']}' has BSSID {run['bssid']} on channel {run['channel']}.",
+            'Use a dedicated lab radio and avoid bridging the portal to production networks.',
+            'Display only the training message; do not request, collect, or store credentials.',
+            f"Stop the workflow within {run['duration_minutes']} minutes and confirm clients reconnect to the legitimate lab AP.",
+        ],
+        'cleanup_steps': [
+            'Stop hostapd/dnsmasq or any lab AP service started outside Mobile Router.',
+            'Remove temporary DHCP/DNS/portal configuration files for this SSID.',
+            'Restore interface mode, channel, IP addressing, forwarding, and firewall rules.',
+            'Record the cleanup result in the lab log and evidence notes.',
+        ],
+        'detection_guidance': [
+            'Alert on duplicate SSIDs with a new BSSID, mismatched channel, or weaker security than baseline.',
+            'Compare beacon RSN/capability fields and vendor OUIs against the approved AP inventory.',
+            'Watch DHCP/DNS gateway changes and captive-portal redirects from unknown MAC addresses.',
+            'Train users to report unexpected portal prompts and never enter real credentials in drills.',
+        ],
+    }
+
+
+def record_evil_twin_lab_run(selected_interface, lab):
+    """Record a non-credential evil-twin/captive-portal lab workflow event."""
+    run = {
+        'id': uuid.uuid4().hex,
+        'created_at': time.time(),
+        'interface': selected_interface,
+        **lab,
+    }
+    run.update(build_evil_twin_lab_guidance(run))
+    with evil_twin_lab_lock:
+        evil_twin_lab_runs.append(run)
+        del evil_twin_lab_runs[:-25]
+    app.logger.info(
+        'Evil twin lab %s recorded for SSID %r BSSID %s channel %s on %s',
+        run['action'], run['ssid'], run['bssid'], run['channel'], selected_interface,
+    )
+    return run
+
+
+def _split_module_ids(value):
+    modules = []
+    for item in re.split(r'[,\s]+', value or ''):
+        item = item.strip().lower()
+        if item:
+            modules.append(item)
+    return modules
+
+
+def validate_pineap_lab_request(data):
+    """Validate a WiFi Pineapple-style lab controller request."""
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab before running a campaign workflow')
+    action = (data.get('action') or 'recon').strip().lower()
+    if action not in PINEAP_ACTIONS:
+        raise ValueError('Choose recon, campaign, handshake, or module')
+    ssid = (data.get('ssid') or '').strip()
+    if ssid and len(ssid) > 32:
+        raise ValueError('SSID must be 32 characters or fewer')
+    bssid = normalize_mac(data.get('bssid')) if data.get('bssid') else None
+    channel = None
+    if data.get('channel'):
+        channel = parse_int(data.get('channel'), 'Channel must be an integer')
+        if channel < 1 or channel > 196:
+            raise ValueError('Channel must be between 1 and 196')
+    modules = _split_module_ids(data.get('modules') or 'recon,detection-report')
+    unknown = [module for module in modules if module not in PINEAP_MODULES]
+    if unknown:
+        raise ValueError(f"Unknown lab module: {', '.join(unknown)}")
+    if action in {'campaign', 'handshake', 'module'} and not ssid:
+        raise ValueError('Enter an explicit lab SSID for campaign, handshake, or module workflows')
+    return {
+        'action': action,
+        'ssid': ssid,
+        'bssid': bssid,
+        'channel': channel,
+        'modules': modules,
+        'notes': (data.get('notes') or '').strip()[:500],
+    }
+
+
+def build_pineap_lab_result(selected_interface, lab):
+    """Build an auditable, non-destructive PineAP-style lab result."""
+    recon = []
+    if lab['action'] == 'recon':
+        from scripts.wifi import utils as wifi_utils
+        wifi_utils.scan_networks(selected_interface)
+        recon = wifi_utils.get_networks_summary()
+    run = {
+        'id': uuid.uuid4().hex,
+        'created_at': time.time(),
+        'interface': selected_interface,
+        **lab,
+        'recon': recon,
+        'campaign_steps': [
+            'Recon: inventory authorized lab SSIDs, BSSIDs, channels, security, and WPS exposure.',
+            'Campaign: select only approved training modules and log operator intent before execution.',
+            'Handshake: capture or upload WPA/WPA2 handshake or PMKID evidence without password cracking.',
+            'Report: export findings, cleanup actions, and detection opportunities for defenders.',
+        ],
+        'module_status': [
+            {'id': module, 'status': 'queued' if lab['action'] != 'recon' else 'available'}
+            for module in lab['modules']
+        ],
+        'safety': 'This controller records authorized lab workflow state and recon output; it does not collect credentials or run cracking jobs.',
+    }
+    with pineap_lab_lock:
+        pineap_lab_runs.insert(0, run)
+        del pineap_lab_runs[100:]
+    app.logger.info('PineAP-style lab %s recorded for SSID %r on %s', run['action'], run['ssid'], selected_interface)
+    return run
+
+
+def validate_handshake_lab_request(data):
+    """Validate handshake/PMKID evidence catalog inputs."""
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab before cataloging handshake evidence')
+    ssid = (data.get('ssid') or '').strip()
+    if not ssid or len(ssid) > 32:
+        raise ValueError('Enter the exact lab SSID, up to 32 characters')
+    bssid = normalize_mac(data.get('bssid'))
+    channel = parse_int(data.get('channel'), 'Channel must be an integer')
+    if channel < 1 or channel > 196:
+        raise ValueError('Channel must be between 1 and 196')
+    capture_type = (data.get('captureType') or 'wpa-handshake').strip().lower()
+    if capture_type not in HANDSHAKE_CAPTURE_TYPES:
+        raise ValueError('Capture type must be WPA handshake or PMKID')
+    return {
+        'ssid': ssid,
+        'bssid': bssid,
+        'channel': channel,
+        'capture_type': capture_type,
+        'client': normalize_mac(data.get('client')) if data.get('client') else '',
+        'validation_notes': (data.get('validationNotes') or '').strip()[:500],
+    }
+
+
+def validate_handshake_evidence(record, uploaded_file=None):
+    """Attach lightweight validation status for uploaded WPA/PMKID evidence."""
+    file_name = uploaded_file.filename if uploaded_file and uploaded_file.filename else ''
+    extension = os.path.splitext(file_name.lower())[1]
+    accepted = {'.cap', '.pcap', '.pcapng', '.hc22000', '.hccapx'}
+    checks = [
+        'SSID/BSSID/channel are explicitly scoped to the authorized lab target.',
+        'Evidence is cataloged for validation/export only; password cracking is out of scope.',
+    ]
+    if file_name:
+        checks.append('Uploaded capture extension is recognized.' if extension in accepted else 'Uploaded capture extension is unusual; verify manually.')
+    else:
+        checks.append('No capture uploaded yet; record is ready for later evidence attachment.')
+    status = 'needs-review' if file_name and extension not in accepted else 'cataloged'
+    return {'validation_status': status, 'validation_checks': checks}
+
+
+def record_handshake_lab_evidence(selected_interface, lab, uploaded_file=None):
+    """Catalog handshake/PMKID lab evidence and mirror it into the evidence vault."""
+    validation = validate_handshake_evidence(lab, uploaded_file=uploaded_file)
+    evidence = create_evidence_record(
+        f"{lab['capture_type'].upper()} evidence for {lab['ssid']}",
+        category='capture',
+        source='WPA handshake capture lab',
+        device=lab['bssid'],
+        notes=lab['validation_notes'],
+        content='\n'.join(validation['validation_checks']),
+        uploaded_file=uploaded_file,
+    )
+    record = {
+        'id': uuid.uuid4().hex,
+        'created_at': time.time(),
+        'interface': selected_interface,
+        **lab,
+        **validation,
+        'evidence_id': evidence['id'],
+        'download_url': evidence.get('download_url'),
+        'file_name': evidence.get('file_name'),
+        'file_size': evidence.get('file_size'),
+    }
+    with handshake_lab_lock:
+        handshake_lab_records.insert(0, record)
+        del handshake_lab_records[200:]
+    app.logger.info('Handshake lab evidence %s cataloged for SSID %r BSSID %s', record['capture_type'], record['ssid'], record['bssid'])
+    return record
+
+
+def handshake_lab_export_records():
+    with handshake_lab_lock:
+        records = [dict(item) for item in handshake_lab_records]
+    for item in records:
+        item['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('created_at', 0)))
+    return records
+
+
+def handshake_records_as_csv(records):
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['SSID', 'BSSID', 'Channel', 'Type', 'Client', 'Status', 'File', 'Created'])
+    for item in records:
+        writer.writerow([item.get('ssid'), item.get('bssid'), item.get('channel'), item.get('capture_type'), item.get('client'), item.get('validation_status'), item.get('file_name'), item.get('created_at_label')])
+    return output.getvalue()
 
 
 class BluetoothToolUnavailable(RuntimeError):
@@ -422,6 +698,39 @@ def create_new_device_alert(device, source, interface=None):
     return alert
 
 
+def create_grouped_device_alert(devices, source, interface=None):
+    """Record one unread alert for a batch of newly observed devices."""
+    devices = [dict(device) for device in devices or []]
+    alert = {
+        'id': uuid.uuid4().hex,
+        'alert_type': 'grouped-discovery',
+        'display_name': f"{len(devices)} new devices discovered",
+        'ip': None,
+        'mac': None,
+        'manufacturer': 'Multiple',
+        'device_url': '/inventory',
+        'source': source,
+        'interface': interface,
+        'created_at': time.time(),
+        'read': False,
+        'device_count': len(devices),
+        'devices': [
+            {
+                'id': device.get('id'),
+                'display_name': device.get('name') or device.get('hostname') or device.get('ssid') or device.get('ip') or device.get('mac') or 'Unknown device',
+                'ip': device.get('ip'),
+                'mac': device.get('mac') or device.get('bssid'),
+                'manufacturer': device.get('manufacturer') or 'Unknown',
+            }
+            for device in devices[:10]
+        ],
+    }
+    with new_device_alerts_lock:
+        new_device_alerts.insert(0, alert)
+        del new_device_alerts[200:]
+    return alert
+
+
 
 def evidence_records():
     """Return evidence vault records with display labels."""
@@ -576,20 +885,7 @@ def bluetooth_device_summary(device):
 
 
 def find_inventory_device(identifier):
-    normalized = normalize_mac(identifier) if identifier else None
-    with device_inventory_lock:
-        if normalized:
-            for key in (f'mac:{normalized}', normalized):
-                if key in device_inventory:
-                    return dict(device_inventory[key])
-            for item in device_inventory.values():
-                if normalize_mac(item.get('mac') or item.get('address')) == normalized:
-                    return dict(item)
-        for item in device_inventory.values():
-            if item.get('ip') == identifier or item.get('id') == identifier:
-                return dict(item)
-    return None
-
+    return inventory_service.find_device(identifier, device_inventory, device_inventory_lock, normalize_mac)
 
 
 def _bluetooth_truthy(value):
@@ -774,40 +1070,597 @@ def unread_alert_count():
         return len([alert for alert in new_device_alerts if not alert.get('read')])
 
 def record_inventory_devices(devices, source, interface=None):
-    """Merge discovered devices into the in-memory inventory with OUI metadata."""
-    now = time.time()
-    changed_devices = []
+    return inventory_service.merge_devices(
+        devices, source, interface, device_inventory, device_inventory_lock,
+        normalize_mac, inventory_key, lookup_manufacturer,
+        create_new_device_alert, create_grouped_device_alert,
+    )
+
+
+def record_device_open_ports(host, port_details, source='port-scan'):
+    updated = inventory_service.record_open_ports(
+        host, port_details, source, device_inventory, device_inventory_lock,
+        enrich_port_web_url, append_client_timeline_event, is_client_watched,
+        create_client_watch_alert,
+    )
+    if updated:
+        role_guess = device_intel.infer_device_role(updated)
+        with device_inventory_lock:
+            key = updated.get('id')
+            if key in device_inventory:
+                device_inventory[key]['device_role_guess'] = role_guess
+                updated = dict(device_inventory[key])
+    return updated
+
+
+def enrich_port_web_url(host, detail):
+    """Attach a clickable web URL for HTTP-like TCP services."""
+    item = dict(detail)
+    service = str(item.get('service') or '').lower()
+    port = int(item.get('port'))
+    if port in {80, 8080, 8000} or service.startswith('http '):
+        item['web_url'] = f"http://{host}:{port}/"
+    elif port in {443, 8443, 9443} or service.startswith('https'):
+        item['web_url'] = f"https://{host}:{port}/"
+    return item
+
+
+def enrich_web_port_metadata(host, detail):
+    """Add lightweight HTTP status/title metadata for clickable web services."""
+    item = enrich_port_web_url(host, detail)
+    if not item.get('web_url'):
+        return item
+    try:
+        inspected = inspect_http_services(host, [item['port']])[0]
+    except (IndexError, OSError, ValueError):
+        return item
+    for key in ('status', 'title', 'server', 'error', 'thumbnail_url', 'favicon'):
+        if inspected.get(key) not in (None, ''):
+            item[f'http_{key}'] = inspected.get(key)
+    if item.get('web_url', '').startswith('https://'):
+        tls_metadata = device_intel.tls_certificate_metadata(host, item['port'])
+        if tls_metadata:
+            item['tls_certificate'] = tls_metadata
+    return item
+
+
+def _clean_detected_client_name(name, ip=None):
+    """Normalize display names learned from local naming protocols."""
+    value = str(name or '').strip().strip('.')
+    if not value or value == str(ip or ''):
+        return ''
+    if value.endswith('.local'):
+        return value
+    return value[:120]
+
+
+def _reverse_dns_display_name(ip):
+    """Attempt a reverse-DNS/PTR lookup for an IP client."""
+    try:
+        hostname, _aliases, _addresses = socket.gethostbyaddr(ip)
+    except (OSError, socket.herror, socket.gaierror):
+        return ''
+    return _clean_detected_client_name(hostname, ip)
+
+
+def _dhcp_lease_display_name(ip):
+    """Look for a client hostname in common local DHCP lease files."""
+    lease_paths = [
+        '/var/lib/misc/dnsmasq.leases',
+        '/tmp/dhcp.leases',
+        '/var/lib/dhcp/dhcpd.leases',
+        '/var/lib/dhcp/dhclient.leases',
+    ]
+    for path in lease_paths:
+        if not os.path.exists(path):
+            continue
+        try:
+            with open(path, encoding='utf-8', errors='ignore') as handle:
+                content = handle.read()
+        except OSError:
+            continue
+        for line in content.splitlines():
+            parts = line.split()
+            if len(parts) >= 4 and parts[2] == ip:
+                return _clean_detected_client_name(parts[3], ip)
+        block_match = re.search(rf'lease\s+{re.escape(ip)}\s+\{{(.*?)\}}', content, re.S)
+        if block_match:
+            host_match = re.search(r'client-hostname\s+"([^"]+)"', block_match.group(1))
+            if host_match:
+                return _clean_detected_client_name(host_match.group(1), ip)
+    return ''
+
+
+def display_name_for_inventory_device(device, fallback=None):
+    """Choose the best human-readable name for an inventory device."""
+    device = device or {}
+    return (
+        device.get('preferred_name')
+        or device.get('detected_display_name')
+        or device.get('name')
+        or device.get('hostname')
+        or device.get('friendly_name')
+        or device.get('ssid')
+        or device.get('ip')
+        or device.get('mac')
+        or fallback
+        or 'Unknown device'
+    )
+
+
+def enrich_ip_client_display_name(identifier, device=None):
+    """Detect and persist a better display name for an IP client when possible."""
+    device = dict(device or find_inventory_device(identifier) or {})
+    ip = device.get('ip') or (identifier if identifier and not MAC_RE.match(str(identifier)) else None)
+    if not ip:
+        return device
+    existing = display_name_for_inventory_device(device, ip)
+    if existing and existing not in {ip, device.get('mac'), device.get('id')}:
+        device['display_name'] = existing
+        return device
+    detected = _clean_detected_client_name(device.get('hostname') or device.get('name'), ip)
+    source = 'inventory'
+    if not detected:
+        detected = _dhcp_lease_display_name(ip)
+        source = 'dhcp-lease'
+    if not detected:
+        detected = _reverse_dns_display_name(ip)
+        source = 'reverse-dns'
+    if not detected:
+        device['display_name'] = existing or ip
+        return device
+    updates = {'detected_display_name': detected, 'display_name': detected, 'hostname': device.get('hostname') or detected, 'display_name_source': source}
     with device_inventory_lock:
-        for raw_device in devices or []:
-            device = dict(raw_device)
-            mac = normalize_mac(device.get('mac') or device.get('address') or device.get('bssid'))
-            if mac:
-                device['mac'] = mac
-            key = inventory_key(device)
-            if not key:
+        key = device.get('id') or f'ip:{ip}'
+        existing_record = device_inventory.get(key)
+        if existing_record is None:
+            for candidate_key, item in device_inventory.items():
+                if item.get('ip') == ip or item.get('mac') == device.get('mac'):
+                    key = candidate_key
+                    existing_record = item
+                    break
+        existing_record = dict(existing_record or {'id': key, 'ip': ip, 'manufacturer': device.get('manufacturer') or 'Unknown', 'first_seen': time.time(), 'sources': [], 'interfaces': []})
+        existing_record.update({k: v for k, v in updates.items() if v})
+        existing_record['last_seen'] = time.time()
+        device_inventory[key] = existing_record
+        device = dict(existing_record)
+    append_client_timeline_event(ip, 'Display name detected', f'Detected "{detected}" from {source}.', source)
+    return device
+
+
+def append_client_timeline_event(identifier, event_type, message, source=None):
+    """Record a lightweight per-client event shown on the client profile."""
+    key = str(identifier or '').strip()
+    if not key:
+        return None
+    event = {'timestamp': time.time(), 'type': event_type, 'message': message, 'source': source or 'client-profile'}
+    with client_timelines_lock:
+        client_timelines.setdefault(key, []).insert(0, event)
+        del client_timelines[key][50:]
+    return event
+
+
+def client_timeline(identifier, inventory_device=None):
+    """Return explicit and inferred timeline entries for a client."""
+    keys = {str(identifier or '').strip()}
+    for field in ('ip', 'mac', 'id'):
+        value = (inventory_device or {}).get(field)
+        if value:
+            keys.add(str(value))
+    events = []
+    with client_timelines_lock:
+        for key in keys:
+            events.extend(dict(item) for item in client_timelines.get(key, []))
+    if inventory_device:
+        if inventory_device.get('first_seen'):
+            events.append({'timestamp': inventory_device['first_seen'], 'type': 'First discovered', 'message': 'Device first entered inventory.', 'source': ', '.join(inventory_device.get('sources', []))})
+        if inventory_device.get('last_seen'):
+            events.append({'timestamp': inventory_device['last_seen'], 'type': 'Last seen', 'message': 'Device was refreshed by discovery or scan activity.', 'source': ', '.join(inventory_device.get('sources', []))})
+        if inventory_device.get('last_port_scan'):
+            events.append({'timestamp': inventory_device['last_port_scan'], 'type': 'Port scan', 'message': f"{len(inventory_device.get('open_ports', []))} open port(s) saved to this profile.", 'source': 'port-scan'})
+    unique = {(round(item.get('timestamp', 0), 3), item.get('type'), item.get('message')): item for item in events}
+    ordered = sorted(unique.values(), key=lambda item: item.get('timestamp', 0), reverse=True)[:12]
+    for item in ordered:
+        item['time_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('timestamp', time.time())))
+    return ordered
+
+
+def client_health_summary(device, ip=None):
+    """Build a simple client health/risk summary from inventory evidence."""
+    device = device or {}
+    flags = []
+    score = 100
+    open_ports = device.get('open_port_details') or []
+    if not device.get('manufacturer') or device.get('manufacturer') == 'Unknown':
+        flags.append('Unknown manufacturer')
+        score -= 10
+    risky_ports = {21: 'FTP', 23: 'Telnet', 445: 'SMB', 3389: 'RDP', 5900: 'VNC'}
+    exposed = [item for item in open_ports if item.get('port') in risky_ports]
+    if exposed:
+        flags.append(f"{len(exposed)} sensitive service(s) exposed")
+        score -= 25
+    if len(open_ports) >= 8:
+        flags.append('Large open-port surface')
+        score -= 15
+    if not device.get('hostname') and not device.get('name'):
+        flags.append('No hostname learned')
+        score -= 5
+    if not open_ports:
+        flags.append('No service baseline yet')
+        score -= 5
+    score = max(0, min(100, score))
+    if score >= 85:
+        level = 'Good'
+        badge = 'success'
+    elif score >= 60:
+        level = 'Review'
+        badge = 'warning'
+    else:
+        level = 'Attention'
+        badge = 'danger'
+    return {'score': score, 'level': level, 'badge': badge, 'flags': flags or ['No notable client concerns from saved data'], 'open_port_count': len(open_ports), 'identity': device.get('hostname') or device.get('name') or ip or 'Unknown client'}
+
+
+def client_reachability_history(host, limit=10):
+    """Return recent ping results for a specific client."""
+    target = str(host or '').strip()
+    matches = [dict(item) for item in ping_history if item.get('host') == target]
+    for item in matches:
+        item['time_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('checked_at', time.time())))
+    return matches[-limit:]
+
+
+def _ttl_os_hint(history):
+    """Infer a coarse OS/device family hint from observed ping TTL values."""
+    ttl_values = []
+    for item in history or []:
+        for match in re.findall(r'ttl[= ](\d+)', item.get('output') or '', flags=re.I):
+            try:
+                ttl_values.append(int(match))
+            except ValueError:
                 continue
-            existing = device_inventory.get(key, {})
-            first_seen = existing.get('first_seen', now)
-            sources = sorted(set(existing.get('sources', [])) | {source})
-            interfaces_seen = sorted(set(existing.get('interfaces', [])) | ({interface} if interface else set()))
-            manufacturer = device.get('manufacturer') or (lookup_manufacturer(mac) if mac else None) or existing.get('manufacturer') or 'Unknown'
-            merged = {
-                **existing,
-                **{k: v for k, v in device.items() if v not in (None, '')},
-                'id': key,
-                'mac': mac or existing.get('mac'),
-                'manufacturer': manufacturer,
-                'first_seen': first_seen,
-                'last_seen': now,
-                'sources': sources,
-                'interfaces': interfaces_seen,
-            }
-            is_new_device = not existing
-            device_inventory[key] = merged
-            if is_new_device and not merged.get('is_control_traffic'):
-                create_new_device_alert(merged, source, interface)
-            changed_devices.append(dict(merged))
-    return changed_devices
+    if not ttl_values:
+        return {'hint': 'Unknown', 'confidence': 'low', 'evidence': []}
+    ttl = max(ttl_values)
+    if ttl <= 64:
+        hint = 'Linux/Unix, Android, or embedded IoT family'
+    elif ttl <= 128:
+        hint = 'Windows-family host or appliance'
+    else:
+        hint = 'Network appliance or BSD-derived stack'
+    return {'hint': hint, 'confidence': 'low', 'evidence': [f'Observed TTL {ttl} in reachability history']}
+
+
+def _forward_dns_records(names):
+    """Resolve learned client names back to addresses for identity correlation."""
+    records = []
+    for name in sorted({str(item or '').strip().strip('.') for item in names if item})[:6]:
+        try:
+            addresses = sorted({info[4][0] for info in socket.getaddrinfo(name, None)})
+        except (OSError, socket.gaierror):
+            addresses = []
+        records.append({'name': name, 'addresses': addresses})
+    return records
+
+
+def client_intelligence_profile(identifier, active_probe=False):
+    """Build a richer client intelligence snapshot from saved and optional safe probes."""
+    device = enrich_ip_client_display_name(identifier, find_inventory_device(identifier) or {})
+    host = device.get('ip') or identifier
+    observed_names = [item.get('name') for item in device.get('observed_names', []) if item.get('name')]
+    detected_names = [device.get('hostname'), device.get('name'), device.get('display_name'), device.get('detected_display_name'), *observed_names]
+    reverse_name = _reverse_dns_display_name(host) if host else ''
+    if reverse_name:
+        detected_names.append(reverse_name)
+    dhcp_name = _dhcp_lease_display_name(host) if host else ''
+    if dhcp_name:
+        detected_names.append(dhcp_name)
+    reachability = client_reachability_history(host, limit=10)
+    fingerprints = fingerprint_client_services(identifier) if active_probe else []
+    open_ports = device.get('open_port_details') or []
+    web_ports = [item for item in open_ports if item.get('web_url') or str(item.get('service') or '').lower() in {'http', 'https'}]
+    sensitive = [item for item in open_ports if item.get('port') in {21, 23, 445, 3389, 5900}]
+    stability = {
+        'first_seen': device.get('first_seen'),
+        'last_seen': device.get('last_seen'),
+        'sources': device.get('sources', []),
+        'interfaces': device.get('interfaces', []),
+        'seen_count_hint': len(device.get('sources', [])) + len(device.get('interfaces', [])),
+    }
+    recommendations = []
+    if device.get('likely_randomized_mac'):
+        recommendations.append('MAC appears locally administered/private; correlate by hostname, services, and SSID-scoped labels instead of OUI alone.')
+    if not device.get('manufacturer') or device.get('manufacturer') == 'Unknown':
+        recommendations.append('Manufacturer is unknown; refresh the OUI database or collect mDNS/DHCP/UPnP identity metadata.')
+    if sensitive:
+        recommendations.append('Sensitive remote-access or file-sharing ports are present; verify they are expected for this device.')
+    if not open_ports:
+        recommendations.append('No saved port/service baseline yet; run common ports once and reuse the saved profile before any larger scan.')
+    if web_ports:
+        recommendations.append('Web services are present; inspect titles, headers, favicon hashes, TLS certificates, and preview thumbnails for app identification.')
+    if not recommendations:
+        recommendations.append('Saved identity and service data is sufficient for a lightweight baseline; monitor for drift over time.')
+    return {
+        'host': host,
+        'manufacturer': device.get('manufacturer') or 'Unknown',
+        'mac': device.get('mac'),
+        'names': sorted({name for name in detected_names if name and name != host})[:12],
+        'dns': {'reverse': reverse_name, 'forward': _forward_dns_records(detected_names)},
+        'dhcp': {'hostname': dhcp_name},
+        'os_hint': _ttl_os_hint(reachability),
+        'services': {'open_port_count': len(open_ports), 'web_port_count': len(web_ports), 'sensitive_port_count': len(sensitive), 'fingerprints': fingerprints},
+        'stability': stability,
+        'relationships': client_relationship_map(identifier),
+        'recommendations': recommendations[:8],
+    }
+
+
+def update_client_metadata(identifier, data):
+    """Persist user-maintained client tags, ownership, notes, and expected ports."""
+    target = str(identifier or '').strip()
+    if not target:
+        raise ValueError('Missing client identifier')
+    raw_tags = data.get('tags') or ''
+    tags = sorted({tag.strip() for tag in raw_tags.split(',') if tag.strip()})[:12]
+    expected_ports = []
+    raw_expected_ports = data.get('expectedPorts') or ''
+    for raw_port in raw_expected_ports.split(','):
+        raw_port = raw_port.strip()
+        if not raw_port:
+            continue
+        port = parse_int(raw_port, 'Expected ports must be integers')
+        if not 1 <= port <= 65535:
+            raise ValueError('Expected ports must be between 1 and 65535')
+        expected_ports.append(port)
+    updates = {
+        'client_tags': tags,
+        'client_owner': (data.get('owner') or '').strip()[:80],
+        'client_location': (data.get('location') or '').strip()[:80],
+        'client_notes': (data.get('notes') or '').strip()[:500],
+        'expected_open_ports': sorted(set(expected_ports)),
+    }
+    with device_inventory_lock:
+        key = f'ip:{target}'
+        existing = device_inventory.get(key)
+        if existing is None:
+            for candidate_key, item in device_inventory.items():
+                if item.get('ip') == target or item.get('mac') == target or item.get('id') == target:
+                    key = candidate_key
+                    existing = item
+                    break
+        existing = dict(existing or {'id': key, 'ip': target, 'manufacturer': 'Unknown', 'first_seen': time.time(), 'sources': [], 'interfaces': []})
+        key = existing.get('id') or inventory_key(existing) or key
+        existing.update({k: v for k, v in updates.items() if v not in (None, '')})
+        existing['last_seen'] = time.time()
+        device_inventory[key] = existing
+    append_client_timeline_event(target, 'Profile updated', 'Client tags, ownership, notes, or expected ports were updated.', 'client-metadata')
+    return dict(existing)
+
+
+def save_client_baseline(identifier):
+    """Save current observed identity/service details as the expected baseline."""
+    device = find_inventory_device(identifier) or {}
+    target = device.get('ip') or identifier
+    baseline = {
+        'saved_at': time.time(),
+        'hostname': device.get('hostname') or device.get('name'),
+        'manufacturer': device.get('manufacturer'),
+        'open_ports': sorted(device.get('open_ports', [])),
+        'mac': device.get('mac'),
+        'sources': list(device.get('sources', [])),
+    }
+    updated = update_client_metadata(target, {'expectedPorts': ','.join(str(port) for port in baseline['open_ports'])})
+    with device_inventory_lock:
+        key = updated.get('id')
+        device_inventory[key]['client_baseline'] = baseline
+        updated = dict(device_inventory[key])
+    append_client_timeline_event(target, 'Baseline saved', f"Saved {len(baseline['open_ports'])} expected open port(s).", 'client-baseline')
+    return updated
+
+
+def client_baseline_diff(device):
+    """Compare current saved observations to expected profile/baseline data."""
+    device = device or {}
+    expected_ports = set(device.get('expected_open_ports') or (device.get('client_baseline') or {}).get('open_ports') or [])
+    current_ports = set(device.get('open_ports') or [])
+    added = sorted(current_ports - expected_ports) if expected_ports else []
+    missing = sorted(expected_ports - current_ports)
+    return {
+        'expected_ports': sorted(expected_ports),
+        'current_ports': sorted(current_ports),
+        'unexpected_ports': added,
+        'missing_ports': missing,
+        'status': 'Drift detected' if added or missing else ('Baseline saved' if expected_ports else 'No baseline'),
+    }
+
+
+def client_profile_export(identifier):
+    """Build an exportable IP client profile."""
+    device = find_inventory_device(identifier) or {}
+    host = device.get('ip') or identifier
+    related_evidence = [
+        item for item in evidence_records()
+        if str(item.get('device') or '') in {str(host), str(device.get('mac') or ''), str(device.get('id') or '')}
+    ]
+    return {
+        'exported_at': time.time(),
+        'host': host,
+        'device': device,
+        'health': client_health_summary(device, host),
+        'baseline': client_baseline_diff(device),
+        'reachability_history': client_reachability_history(host, limit=25),
+        'timeline': client_timeline(host, device),
+        'evidence': related_evidence,
+    }
+
+
+def client_relationship_map(identifier):
+    """Build a lightweight client relationship map for profile rendering/export."""
+    device = find_inventory_device(identifier) or {}
+    host = device.get('ip') or identifier
+    nodes = [{'id': f'client:{host}', 'label': host, 'type': 'client'}]
+    links = []
+    for iface in device.get('interfaces', []):
+        nodes.append({'id': f'interface:{iface}', 'label': iface, 'type': 'interface'})
+        links.append({'source': f'client:{host}', 'target': f'interface:{iface}', 'label': 'seen on'})
+    for source in device.get('sources', []):
+        nodes.append({'id': f'source:{source}', 'label': source, 'type': 'source'})
+        links.append({'source': f'client:{host}', 'target': f'source:{source}', 'label': 'discovered by'})
+    for port in device.get('open_port_details', [])[:12]:
+        node_id = f"service:{host}:{port.get('port')}"
+        nodes.append({'id': node_id, 'label': f"{port.get('port')}/tcp {port.get('service') or 'Unknown'}", 'type': 'service'})
+        links.append({'source': f'client:{host}', 'target': node_id, 'label': 'exposes'})
+    for item in client_profile_export(identifier).get('evidence', [])[:8]:
+        node_id = f"evidence:{item.get('id')}"
+        nodes.append({'id': node_id, 'label': item.get('title') or 'Evidence', 'type': 'evidence'})
+        links.append({'source': f'client:{host}', 'target': node_id, 'label': 'has evidence'})
+    unique_nodes = {node['id']: node for node in nodes}
+    return {'nodes': list(unique_nodes.values()), 'links': links}
+
+
+def fingerprint_client_services(identifier):
+    """Run safe, lightweight service fingerprint checks against saved open ports."""
+    device = find_inventory_device(identifier) or {}
+    host = device.get('ip') or identifier
+    fingerprints = []
+    http_ports = []
+    for detail in device.get('open_port_details', []):
+        port = detail.get('port')
+        service = str(detail.get('service') or '').lower()
+        finding = {'port': port, 'service': detail.get('service') or 'Unknown', 'confidence': 'low', 'banner': None, 'notes': []}
+        if port in (80, 443, 8080, 8443, 8000, 9443) or any(name in service for name in ('http', 'https', 'web')):
+            http_ports.append(port)
+            finding['confidence'] = 'medium'
+            finding['notes'].append('HTTP-like port selected for web inspection.')
+        elif port in (21, 22, 25, 110, 143, 587, 993, 995):
+            try:
+                with socket.create_connection((host, int(port)), timeout=2) as sock:
+                    sock.settimeout(2)
+                    try:
+                        banner = sock.recv(256).decode('utf-8', errors='ignore').strip()
+                    except socket.timeout:
+                        banner = ''
+                if banner:
+                    finding['banner'] = banner[:160]
+                    finding['confidence'] = 'high'
+                else:
+                    finding['notes'].append('Port accepted TCP connection but did not send a banner quickly.')
+                    finding['confidence'] = 'medium'
+            except OSError as exc:
+                finding['notes'].append(f'Banner probe unavailable: {exc}')
+        else:
+            finding['notes'].append('Service inferred from port number; no active banner probe selected.')
+        fingerprints.append(finding)
+    if http_ports:
+        web_results = inspect_http_services(host, sorted(set(http_ports))[:8])
+        by_port = {item['port']: item for item in web_results}
+        for finding in fingerprints:
+            web = by_port.get(finding.get('port'))
+            if web:
+                finding['http'] = web
+                if web.get('title') or web.get('server') or web.get('status'):
+                    finding['confidence'] = 'high'
+    append_client_timeline_event(host, 'Services fingerprinted', f"Checked {len(fingerprints)} saved service(s).", 'service-fingerprint')
+    return fingerprints
+
+
+def save_scheduled_client_check(identifier, data):
+    """Store a recurring-check plan for a watched or important client."""
+    target = str(identifier or '').strip()
+    if not target:
+        raise ValueError('Missing client identifier')
+    interval = max(5, min(parse_int(data.get('intervalMinutes') or 60, 'Interval must be an integer'), 10080))
+    checks = sorted({
+        check for check in (data.get('checks') or 'ping,common-ports,baseline-drift').split(',')
+        if check in {'ping', 'common-ports', 'http-inspect', 'service-fingerprint', 'baseline-drift'}
+    })
+    if not checks:
+        raise ValueError('Select at least one supported scheduled check')
+    plan = {
+        'client': target,
+        'interval_minutes': interval,
+        'checks': checks,
+        'created_at': time.time(),
+        'last_run': None,
+        'status': 'scheduled',
+    }
+    scheduled_client_checks[target] = plan
+    append_client_timeline_event(target, 'Scheduled checks updated', f"Scheduled {', '.join(checks)} every {interval} minute(s).", 'scheduled-checks')
+    return dict(plan)
+
+
+def is_client_watched(identifier):
+    key = str(identifier or '').strip()
+    return key in watched_clients
+
+
+def create_client_watch_alert(identifier, title, message):
+    alert = {
+        'id': str(uuid.uuid4()),
+        'alert_type': 'watched-client',
+        'title': title,
+        'message': message,
+        'ip': identifier,
+        'device_url': f"/clients/{quote(str(identifier))}",
+        'read': False,
+        'timestamp': time.time(),
+        'time_label': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime()),
+    }
+    with new_device_alerts_lock:
+        new_device_alerts.insert(0, alert)
+        del new_device_alerts[200:]
+    return alert
+
+
+def capture_http_preview_thumbnail(url):
+    """Capture a small web preview when a local browser/screenshot utility exists."""
+    tool = shutil.which('wkhtmltoimage') or shutil.which('chromium') or shutil.which('chromium-browser') or shutil.which('google-chrome')
+    if not tool:
+        return None
+    os.makedirs(HTTP_PREVIEW_DIR, exist_ok=True)
+    filename = secure_filename(re.sub(r'[^A-Za-z0-9_.-]+', '_', url))[:120] + '.png'
+    output_path = os.path.join(HTTP_PREVIEW_DIR, filename)
+    try:
+        if os.path.exists(output_path) and time.time() - os.path.getmtime(output_path) < 3600:
+            return f'/http-previews/{filename}'
+        if os.path.basename(tool) == 'wkhtmltoimage':
+            command = [tool, '--width', '480', '--height', '320', url, output_path]
+        else:
+            command = [tool, '--headless', '--disable-gpu', '--no-sandbox', f'--screenshot={output_path}', '--window-size=480,320', url]
+        result = subprocess.run(command, capture_output=True, text=True, timeout=8, check=False)
+        if result.returncode == 0 and os.path.exists(output_path):
+            return f'/http-previews/{filename}'
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    return None
+
+
+def inspect_http_services(host, ports):
+    """Safely inspect likely HTTP services for titles and headers."""
+    results = []
+    for port in ports:
+        scheme = 'https' if int(port) in (443, 8443, 9443) else 'http'
+        url = f"{scheme}://{host}:{port}/"
+        result = {'port': int(port), 'url': url, 'status': None, 'title': None, 'server': None, 'error': None, 'favicon': None}
+        try:
+            req = Request(url, headers={'User-Agent': 'MobileRouterLab/1.0'})
+            with urlopen(req, timeout=3) as resp:
+                body = resp.read(65536).decode('utf-8', errors='ignore')
+                result['status'] = getattr(resp, 'status', None)
+                result['server'] = resp.headers.get('Server')
+                match = re.search(r'<title[^>]*>(.*?)</title>', body, re.I | re.S)
+                if match:
+                    result['title'] = re.sub(r'\s+', ' ', match.group(1)).strip()[:120]
+                result['favicon'] = device_intel.favicon_metadata(url, urlopen)
+                result['thumbnail_url'] = capture_http_preview_thumbnail(url)
+        except HTTPError as e:
+            result['status'] = e.code
+            result['server'] = e.headers.get('Server')
+            result['error'] = e.reason
+        except (URLError, TimeoutError, socket.timeout, ValueError) as e:
+            result['error'] = str(e)
+        results.append(result)
+    return results
 
 
 def inventory_records():
@@ -829,33 +1682,60 @@ def inventory_records():
     with device_inventory_lock:
         records = [dict(item) for item in device_inventory.values()]
     for item in records:
-        item['display_name'] = item.get('name') or item.get('hostname') or item.get('ssid') or item.get('ip') or item.get('mac') or 'Unknown device'
+        item['display_name'] = display_name_for_inventory_device(item)
         item['manufacturer'] = item.get('manufacturer') or 'Unknown'
+        item['likely_randomized_mac'] = device_intel.is_locally_administered_mac(item.get('mac') or item.get('address'))
+        item['device_role_guess'] = item.get('device_role_guess') or device_intel.infer_device_role(item)
         item['is_unknown_manufacturer'] = item['manufacturer'] == 'Unknown'
+        item['client_health'] = client_health_summary(item, item.get('ip')) if item.get('ip') and not item.get('is_control_traffic') else None
+        item['client_baseline'] = client_baseline_diff(item) if item.get('ip') and not item.get('is_control_traffic') else None
+        item['is_watched_client'] = is_client_watched(item.get('ip')) if item.get('ip') else False
         item['first_seen_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('first_seen', 0)))
         item['last_seen_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('last_seen', 0)))
     return sorted(records, key=lambda item: item.get('last_seen', 0), reverse=True)
 
 
-def manufacturer_insights(records=None):
-    """Summarize the current inventory by manufacturer/OUI."""
+def wireless_network_cache_key(network):
+    return wireless_client_service.cache_key(network, normalize_mac)
+
+
+def wireless_network_client_label_key(interface, ssid, bssid, identity):
+    return wireless_client_service.client_label_key(interface, ssid, bssid, identity, normalize_mac)
+
+
+def network_client_display_label(network, client):
+    return wireless_client_service.client_display_label(
+        network, client, wireless_network_labels, normalize_mac,
+    )
+
+
+def sorted_network_clients(clients):
+    return wireless_client_service.sort_clients(clients)
+
+
+def merge_wireless_network_clients(network):
+    return wireless_client_service.merge_network_clients(
+        network, wireless_network_client_cache, wireless_network_labels, normalize_mac,
+        inventory_records,
+    )
+
+
+def inventory_export_payload(records=None):
     records = records if records is not None else inventory_records()
-    vendors = {}
-    unknown = 0
-    for item in records:
-        vendor = item.get('manufacturer') or 'Unknown'
-        vendors.setdefault(vendor, {'manufacturer': vendor, 'count': 0, 'devices': []})
-        vendors[vendor]['count'] += 1
-        vendors[vendor]['devices'].append(item)
-        if vendor == 'Unknown':
-            unknown += 1
-    top_vendors = sorted(vendors.values(), key=lambda item: (-item['count'], item['manufacturer']))
-    return {
-        'total_devices': len(records),
-        'known_manufacturers': len([vendor for vendor in vendors if vendor != 'Unknown']),
-        'unknown_manufacturers': unknown,
-        'top_vendors': top_vendors,
-    }
+    return inventory_service.export_payload(records)
+
+
+def import_inventory_payload(payload, source='inventory-import'):
+    return inventory_service.import_payload(
+        payload, source, record_inventory_devices, find_inventory_device, inventory_key,
+        device_inventory, device_inventory_lock, record_device_open_ports,
+    )
+
+
+def manufacturer_insights(records=None):
+    records = records if records is not None else inventory_records()
+    return inventory_service.manufacturer_summary(records)
+
 
 
 def json_error(message, status=400, **payload):
@@ -879,6 +1759,408 @@ def parse_int(value, error_message):
         return int(value)
     except (TypeError, ValueError) as exc:
         raise ValueError(error_message) from exc
+
+
+def _ping_command(host, count=4, timeout=2):
+    return diagnostics_service.ping_command(host, count=count, timeout=timeout, os_name=os.name)
+
+
+def _parse_ping_output(output):
+    return diagnostics_service.parse_ping_output(output)
+
+
+def run_ping_check(host, count=4, timeout=2):
+    return diagnostics_service.run_ping_check(host, count, timeout, parse_int, subprocess, ping_history)
+
+
+def run_ping_sweep(cidr, count=1, timeout=1):
+    return diagnostics_service.run_ping_sweep(cidr, count, timeout, run_ping_check, subprocess.TimeoutExpired)
+
+
+def _run_text_command(command, timeout=5):
+    try:
+        result = subprocess.run(command, capture_output=True, text=True, timeout=timeout, check=False)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {'command': command, 'returncode': 1, 'output': str(exc)}
+    return {'command': command, 'returncode': result.returncode, 'output': (result.stdout or result.stderr or '').strip()}
+
+
+def _parse_route_lines(output):
+    return diagnostics_service.parse_route_lines(output)
+
+
+def build_route_diagnostics(target=None):
+    return diagnostics_service.build_route_diagnostics(target, _run_text_command, os_name=os.name)
+
+
+def classify_service_role(service_type, text=''):
+    value = f"{service_type or ''} {text or ''}".lower()
+    if any(term in value for term in ['printer', 'ipp', 'pdl-datastream']):
+        return 'Printer'
+    if any(term in value for term in ['airplay', 'media', 'spotify', 'raop', 'dlna', 'mediarenderer']):
+        return 'Media device'
+    if any(term in value for term in ['router', 'gateway', 'internetgatewaydevice', 'wanipconnection']):
+        return 'Gateway/router'
+    if any(term in value for term in ['workstation', 'smb', 'ssh', 'http']):
+        return 'Host service'
+    return 'Service endpoint'
+
+
+def _parse_mdns_output(output):
+    services = []
+    for line in (output or '').splitlines():
+        line = line.strip()
+        if not line or line.startswith('#'):
+            continue
+        parts = [part.strip() for part in line.split(';')]
+        if len(parts) >= 9 and parts[0] == '=':
+            txt = ';'.join(parts[9:]) if len(parts) > 9 else ''
+            services.append({
+                'interface': parts[1],
+                'protocol': parts[2],
+                'name': parts[3],
+                'service_type': parts[4],
+                'domain': parts[5],
+                'hostname': parts[6],
+                'ip': parts[7],
+                'port': parts[8],
+                'txt': txt,
+                'role': classify_service_role(parts[4], txt),
+            })
+    return services
+
+
+def discover_mdns_services(selected_interface=None):
+    avahi = shutil.which('avahi-browse')
+    if not avahi:
+        return {'available': False, 'tool': None, 'services': [], 'message': 'Install avahi-utils or use dns-sd to discover mDNS/Bonjour services.'}
+    command = [avahi, '-artp']
+    result = _run_text_command(command, timeout=8)
+    services = _parse_mdns_output(result['output'])
+    if selected_interface:
+        services = [service for service in services if selected_interface in {service.get('interface'), service.get('interface_name')}]
+    inventory_items = [
+        {
+            'ip': service.get('ip'),
+            'hostname': service.get('hostname'),
+            'name': service.get('name'),
+            'device_type': service.get('role'),
+            'service_metadata': service,
+        }
+        for service in services if service.get('ip')
+    ]
+    record_inventory_devices(inventory_items, 'mdns-discovery', selected_interface)
+    return {'available': True, 'tool': avahi, 'services': services, 'message': f'Discovered {len(services)} mDNS service(s).'}
+
+
+def _parse_ssdp_response(response):
+    headers = {}
+    for line in response.split('\r\n'):
+        if ':' in line:
+            key, value = line.split(':', 1)
+            headers[key.strip().lower()] = value.strip()
+    location = headers.get('location') or ''
+    host = ''
+    try:
+        from urllib.parse import urlparse
+        host = urlparse(location).hostname or ''
+    except Exception:
+        host = ''
+    service_type = headers.get('st') or headers.get('nt') or ''
+    return {
+        'ip': host,
+        'friendly_name': headers.get('server') or headers.get('usn') or 'UPnP device',
+        'manufacturer': headers.get('manufacturer') or headers.get('server') or 'Unknown',
+        'model': headers.get('modelname') or headers.get('server') or '',
+        'service_type': service_type,
+        'control_url': location,
+        'usn': headers.get('usn'),
+        'role': classify_service_role(service_type, headers.get('server')),
+        'headers': headers,
+    }
+
+
+def discover_upnp_devices(timeout=2):
+    request_data = '\r\n'.join([
+        'M-SEARCH * HTTP/1.1',
+        'HOST: 239.255.255.250:1900',
+        'MAN: "ssdp:discover"',
+        'MX: 1',
+        'ST: ssdp:all',
+        '',
+        '',
+    ]).encode('utf-8')
+    devices = []
+    seen = set()
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP) as sock:
+            sock.settimeout(timeout)
+            sock.sendto(request_data, ('239.255.255.250', 1900))
+            deadline = time.time() + timeout
+            while time.time() < deadline:
+                try:
+                    data, _addr = sock.recvfrom(65535)
+                except socket.timeout:
+                    break
+                device = _parse_ssdp_response(data.decode('utf-8', errors='ignore'))
+                key = device.get('usn') or device.get('control_url') or device.get('ip')
+                if key and key not in seen:
+                    seen.add(key)
+                    devices.append(device)
+    except OSError as exc:
+        return {'available': False, 'devices': [], 'message': f'SSDP discovery unavailable: {exc}'}
+    record_inventory_devices([
+        {
+            'ip': device.get('ip'),
+            'name': device.get('friendly_name'),
+            'manufacturer': device.get('manufacturer'),
+            'device_type': device.get('role'),
+            'service_metadata': device,
+        }
+        for device in devices if device.get('ip')
+    ], 'upnp-discovery')
+    return {'available': True, 'devices': devices, 'message': f'Discovered {len(devices)} UPnP/SSDP device(s).'}
+
+
+def _parse_lldpctl_keyvalue(output):
+    neighbors = []
+    current = {}
+    for line in (output or '').splitlines():
+        if '=' not in line:
+            continue
+        key, value = line.split('=', 1)
+        key = key.strip()
+        value = value.strip().strip('"')
+        if key.endswith('.chassis.name'):
+            if current:
+                neighbors.append(current)
+            current = {'name': value, 'protocol': 'LLDP/CDP'}
+        elif key.endswith('.port.ifname') or key.endswith('.port.descr'):
+            current['port_id'] = value
+        elif key.endswith('.mgmt-ip'):
+            current['management_address'] = value
+        elif '.vlan.' in key and key.endswith('.vid'):
+            current.setdefault('vlans', []).append(value)
+        elif key.endswith('.chassis.descr'):
+            current['description'] = value
+    if current:
+        neighbors.append(current)
+    for neighbor in neighbors:
+        neighbor['role'] = 'Switch/router neighbor'
+    return neighbors
+
+
+def discover_lldp_neighbors(selected_interface=None):
+    lldpctl = shutil.which('lldpctl')
+    if not lldpctl:
+        return {'available': False, 'tool': None, 'neighbors': [], 'message': 'Install lldpd/lldpctl to reveal LLDP/CDP neighbors.'}
+    command = [lldpctl, '-f', 'keyvalue']
+    if selected_interface:
+        command.append(selected_interface)
+    result = _run_text_command(command, timeout=6)
+    neighbors = _parse_lldpctl_keyvalue(result['output'])
+    record_inventory_devices([
+        {
+            'ip': neighbor.get('management_address'),
+            'name': neighbor.get('name'),
+            'device_type': neighbor.get('role'),
+            'service_metadata': neighbor,
+        }
+        for neighbor in neighbors if neighbor.get('management_address')
+    ], 'lldp-cdp-discovery', selected_interface)
+    return {'available': result['returncode'] == 0, 'tool': lldpctl, 'neighbors': neighbors, 'message': f'Discovered {len(neighbors)} LLDP/CDP neighbor(s).'}
+
+
+def discover_vlan_context(ssid=None, vlan_id=None, notes=None):
+    return diagnostics_service.discover_vlan_context(
+        ssid, vlan_id, notes, _run_text_command, vlan_segmentation_notes, uuid.uuid4, os_name=os.name,
+    )
+
+
+def build_egress_diagnostics(selected_interface=None):
+    import builtins
+    import urllib.request as urllib_request
+
+    return diagnostics_service.build_egress_diagnostics(
+        selected_interface, _run_text_command, build_route_diagnostics, network_interfaces,
+        os.environ, urllib_request.urlopen, builtins.open, os_name=os.name,
+    )
+
+
+def run_iperf3_test(mode, host=None, port=5201, seconds=5):
+    return diagnostics_service.run_iperf3_test(mode, host, port, seconds, parse_int, shutil, subprocess)
+
+
+def run_snmp_inventory(host, community=None, version='2c', oid='system'):
+    return diagnostics_service.run_snmp_inventory(
+        host, community, version, oid, shutil, subprocess, record_inventory_devices,
+    )
+
+
+def run_ipv6_assessment(host=None, ports=None):
+    return diagnostics_service.run_ipv6_assessment(
+        host, ports, _run_text_command, shutil, socket, os_name=os.name,
+    )
+
+
+def parse_neighbor_table(output):
+    """Parse Linux ip neigh/ARP-like output into device dictionaries."""
+    devices = []
+    for line in (output or '').splitlines():
+        tokens = line.split()
+        if not tokens:
+            continue
+        ip = tokens[0].strip('()')
+        mac = None
+        iface = None
+        arp_match = re.search(r'\(([^)]+)\)\s+at\s+([0-9a-fA-F:.-]+).*\s+on\s+(\S+)', line)
+        if arp_match:
+            ip, mac, iface = arp_match.groups()
+        if 'lladdr' in tokens:
+            mac = tokens[tokens.index('lladdr') + 1]
+        if 'dev' in tokens:
+            iface = tokens[tokens.index('dev') + 1]
+        if mac or ip:
+            devices.append({'ip': ip, 'mac': mac, 'interface': iface, 'discovery_methods': ['neighbor-table'], 'scan_note': 'Observed in local ARP/neighbor table.'})
+    return devices
+
+
+def merge_discovered_devices(groups):
+    """Merge device records from multiple discovery methods by MAC, IP, or name."""
+    merged = {}
+    for method, devices in groups:
+        for raw in devices or []:
+            device = dict(raw)
+            mac = normalize_mac(device.get('mac') or device.get('address') or device.get('bssid'))
+            if mac:
+                device['mac'] = mac
+            key = mac or device.get('ip') or device.get('hostname') or device.get('name') or uuid.uuid4().hex
+            current = merged.setdefault(key, {})
+            methods = set(current.get('discovery_methods') or []) | set(device.get('discovery_methods') or []) | {method}
+            service_metadata = list(current.get('service_metadata_list') or [])
+            if device.get('service_metadata'):
+                service_metadata.append(device.get('service_metadata'))
+            current.update({k: v for k, v in device.items() if v not in (None, '', [])})
+            current['discovery_methods'] = sorted(methods)
+            if service_metadata:
+                current['service_metadata_list'] = service_metadata[-10:]
+    return list(merged.values())
+
+
+
+def passive_monitor_snapshot(interface=None):
+    """Return passive ARP-cache monitor state for one interface or all interfaces."""
+    with passive_monitor_lock:
+        if interface:
+            job = passive_monitor_jobs.get(interface)
+            return dict(job) if job else {'interface': interface, 'enabled': False}
+        return {name: dict(job) for name, job in passive_monitor_jobs.items()}
+
+
+def _passive_monitor_worker(interface):
+    """Continuously refresh passive inventory from observed ARP-cache entries."""
+    while True:
+        with passive_monitor_lock:
+            job = passive_monitor_jobs.get(interface)
+            if not job or not job.get('enabled'):
+                return
+            interval = job.get('interval', 10)
+        try:
+            devices = classify_scan_results(passive_scan(interface), interface)
+            enriched = record_inventory_devices(devices, 'passive-monitor', interface)
+            with passive_monitor_lock:
+                current = passive_monitor_jobs.get(interface)
+                if current:
+                    current.update({
+                        'last_update': time.time(),
+                        'last_count': len(enriched),
+                        'error': None,
+                    })
+        except Exception as exc:
+            with passive_monitor_lock:
+                current = passive_monitor_jobs.get(interface)
+                if current:
+                    current.update({'last_update': time.time(), 'error': str(exc)})
+        time.sleep(interval)
+
+
+def set_passive_monitor(interface, enabled, interval=10):
+    """Start or stop a background passive monitor for an interface."""
+    interface = (interface or '').strip()
+    if not interface:
+        raise ValueError('Missing interface')
+    interval = max(5, min(parse_int(interval, 'Interval must be an integer'), 300))
+    with passive_monitor_lock:
+        job = passive_monitor_jobs.get(interface, {'interface': interface})
+        job.update({
+            'enabled': bool(enabled),
+            'interval': interval,
+            'updated_at': time.time(),
+        })
+        if enabled and not job.get('started_at'):
+            job['started_at'] = time.time()
+        passive_monitor_jobs[interface] = job
+        should_start = enabled and not job.get('thread_alive')
+        if should_start:
+            job['thread_alive'] = True
+    if should_start:
+        def runner():
+            try:
+                _passive_monitor_worker(interface)
+            finally:
+                with passive_monitor_lock:
+                    current = passive_monitor_jobs.get(interface)
+                    if current:
+                        current['thread_alive'] = False
+        threading.Thread(target=runner, daemon=True).start()
+    return passive_monitor_snapshot(interface)
+
+
+def comprehensive_network_device_scan(selected_interface, include_passive=True, include_services=True, sweep_cidr=None):
+    """Combine active, passive, ARP/neighbor, service, and optional ping-sweep discovery."""
+    if not selected_interface:
+        raise ValueError('Missing interface')
+    groups = []
+    errors = []
+    try:
+        groups.append(('active-arp', classify_scan_results(active_scan(selected_interface), selected_interface)))
+    except Exception as exc:
+        errors.append(f'active scan: {exc}')
+    if include_passive:
+        try:
+            groups.append(('passive-observation', classify_scan_results(passive_scan(selected_interface), selected_interface)))
+        except Exception as exc:
+            errors.append(f'passive scan: {exc}')
+    if os.name != 'nt':
+        neigh = _run_text_command(['ip', 'neigh', 'show', 'dev', selected_interface], timeout=5)
+        groups.append(('neighbor-table', parse_neighbor_table(neigh.get('output'))))
+        arp = _run_text_command(['arp', '-an'], timeout=5)
+        groups.append(('arp-cache', parse_neighbor_table(arp.get('output'))))
+    if sweep_cidr:
+        try:
+            sweep = run_ping_sweep(sweep_cidr, count=1, timeout=1)
+            groups.append(('ping-sweep', [{'ip': item.get('host'), 'discovery_methods': ['ping-sweep'], 'reachable': item.get('reachable')} for item in sweep.get('results', []) if item.get('reachable')]))
+        except Exception as exc:
+            errors.append(f'ping sweep: {exc}')
+    if include_services:
+        mdns = discover_mdns_services(selected_interface)
+        groups.append(('mdns', [{'ip': service.get('ip'), 'hostname': service.get('hostname'), 'name': service.get('name'), 'device_type': service.get('role'), 'service_metadata': service, 'discovery_methods': ['mdns']} for service in mdns.get('services', [])]))
+        upnp = discover_upnp_devices(timeout=2)
+        groups.append(('upnp-ssdp', [{'ip': device.get('ip'), 'name': device.get('friendly_name'), 'manufacturer': device.get('manufacturer'), 'device_type': device.get('role'), 'service_metadata': device, 'discovery_methods': ['upnp-ssdp']} for device in upnp.get('devices', [])]))
+        lldp = discover_lldp_neighbors(selected_interface)
+        groups.append(('lldp-cdp', [{'ip': neighbor.get('management_address'), 'name': neighbor.get('name'), 'device_type': neighbor.get('role'), 'service_metadata': neighbor, 'discovery_methods': ['lldp-cdp']} for neighbor in lldp.get('neighbors', [])]))
+    merged = merge_discovered_devices(groups)
+    enriched = record_inventory_devices(merged, 'comprehensive-network-scan', selected_interface)
+    return {
+        'devices': enriched,
+        'methods': [method for method, _devices in groups],
+        'errors': errors,
+        'summary': {
+            'total_devices': len(enriched),
+            'host_like': len([item for item in enriched if not item.get('is_control_traffic')]),
+            'with_services': len([item for item in enriched if item.get('service_metadata') or item.get('service_metadata_list')]),
+        },
+    }
 
 
 def _scan_result_counts(result):
@@ -956,13 +2238,7 @@ def _run_scan_job(job_id, scan_type, selected_interface):
 
 
 def _port_scan_job_snapshot(job):
-    return {
-        **job,
-        'kind': 'port-scan',
-        'open_ports': list(job.get('open_ports', [])),
-        'open_port_details': list(job.get('open_port_details', [])),
-        'cancelable': job.get('status') in {'queued', 'running'},
-    }
+    return port_scan_service.job_snapshot(job)
 
 
 def _scan_job_snapshot(job):
@@ -985,92 +2261,27 @@ def all_job_snapshots():
     jobs = []
     with scan_jobs_lock:
         jobs.extend(_scan_job_snapshot(job) for job in scan_jobs.values())
-    with port_scan_jobs_lock:
-        jobs.extend(_port_scan_job_snapshot(job) for job in port_scan_jobs.values())
+    jobs.extend(port_scan_service.all_snapshots(port_scan_jobs, port_scan_jobs_lock))
     return sorted(jobs, key=lambda item: item.get('updated_at') or item.get('created_at') or 0, reverse=True)
 
 
 def running_job_count():
-    return len([job for job in all_job_snapshots() if job.get('status') in {'queued', 'running'}])
+    scan_count = len([job for job in all_job_snapshots() if job.get('kind') == 'scan' and job.get('status') in {'queued', 'running'}])
+    return scan_count + port_scan_service.running_count(port_scan_jobs, port_scan_jobs_lock)
 
 
 def update_port_scan_job(job_id, **updates):
-    with port_scan_jobs_lock:
-        job = port_scan_jobs.get(job_id)
-        if not job:
-            return None
-        job.update(updates)
-        job['updated_at'] = time.time()
-        return _port_scan_job_snapshot(job)
+    return port_scan_service.update_job(port_scan_jobs, port_scan_jobs_lock, job_id, **updates)
 
 
 def run_port_scan_job(job_id):
-    from scripts.portScanner import PortScanError, describe_open_ports, identify_port_service, scan_ports
-
-    with port_scan_jobs_lock:
-        job = port_scan_jobs.get(job_id)
-        if not job:
-            return
-        host = job['host']
-        start = job['start']
-        end = job['end']
-        total = job['total_ports']
-        job['status'] = 'running'
-        job['started_at'] = time.time()
-        job['updated_at'] = job['started_at']
-
-    scanned = 0
-
-    def on_open(port):
-        service_detail = identify_port_service(port)
-        with port_scan_jobs_lock:
-            current = port_scan_jobs.get(job_id)
-            if not current:
-                return
-            if port not in current['open_ports']:
-                current['open_ports'].append(port)
-                current['open_ports'].sort()
-                current.setdefault('open_port_details', []).append(service_detail)
-                current['open_port_details'] = sorted(current['open_port_details'], key=lambda item: item['port'])
-            current['message'] = f"Open port found: {port} ({service_detail['service']})"
-            current['updated_at'] = time.time()
-
-    def should_cancel():
-        with port_scan_jobs_lock:
-            return bool(port_scan_jobs.get(job_id, {}).get('cancel_requested'))
-
-    def on_progress(port):
-        nonlocal scanned
-        scanned += 1
-        with port_scan_jobs_lock:
-            current = port_scan_jobs.get(job_id)
-            if not current:
-                return
-            current['scanned_ports'] = scanned
-            current['current_port'] = port
-            current['progress'] = round((scanned / total) * 100, 1) if total else 100
-            current['updated_at'] = time.time()
-
-    try:
-        ports = scan_ports(host, start, end, on_open=on_open, on_progress=on_progress, should_cancel=should_cancel, max_ports=None)
-        if should_cancel():
-            update_port_scan_job(job_id, status='cancelled', completed_at=time.time(), message='Port scan cancelled.')
-            return
-        update_port_scan_job(
-            job_id,
-            status='complete',
-            open_ports=ports,
-            open_port_details=describe_open_ports(ports),
-            scanned_ports=total,
-            current_port=end,
-            progress=100,
-            completed_at=time.time(),
-            message=f'Port scan complete: {len(ports)} open port(s) found.',
-        )
-    except PortScanError as e:
-        update_port_scan_job(job_id, status='failed', error=str(e), message=str(e), completed_at=time.time())
-    except Exception as e:
-        update_port_scan_job(job_id, status='failed', error=str(e), message=f'Port scan failed: {e}', completed_at=time.time())
+    return port_scan_service.run_job(
+        job_id,
+        port_scan_jobs,
+        port_scan_jobs_lock,
+        enrich_web_port_metadata,
+        record_device_open_ports,
+    )
 
 
 def create_port_scan_job(host, start, end, label=None):
@@ -1466,15 +2677,39 @@ def network_scan():
 
 
 @app.route('/inventory')
-def inventory_page():
+def inventory_page(import_result=None):
     records = inventory_records()
     return render_template(
         'inventory.html',
         title='Device Inventory',
         devices=records,
         insights=manufacturer_insights(records),
+        import_result=import_result,
         **current_context(),
     )
+
+
+@app.route('/inventory/export.json')
+def inventory_export_json():
+    return jsonify(inventory_export_payload())
+
+
+@app.route('/inventory/import', methods=['POST'])
+def inventory_import_route():
+    artifact = request.files.get('inventoryFile')
+    try:
+        if artifact and artifact.filename:
+            payload = json.load(artifact.stream)
+        else:
+            payload = request.get_json(silent=True) or json.loads(request.form.get('inventoryJson') or '{}')
+        result = import_inventory_payload(payload)
+    except (ValueError, json.JSONDecodeError) as e:
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return json_error(str(e))
+        return inventory_page(import_result={'status': 'error', 'message': str(e)})
+    if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+        return json_success(**result)
+    return inventory_page(import_result={'status': 'success', **result})
 
 
 @app.route('/alerts')
@@ -1522,6 +2757,40 @@ def traceroute_page():
     return render_template('traceroute.html', title='Traceroute', **current_context())
 
 
+@app.route('/diagnostics')
+def diagnostics_page():
+    return render_template('diagnostics.html', title='Diagnostics', **current_context())
+
+
+@app.route('/service-discovery')
+def service_discovery_page():
+    return render_template('service_discovery.html', title='Service Discovery', **current_context())
+
+
+@app.route('/advanced-diagnostics')
+def advanced_diagnostics_page():
+    return render_template('advanced_diagnostics.html', title='Advanced Diagnostics', **current_context())
+
+
+
+
+@app.route('/http-previews/<path:filename>')
+def http_preview_file(filename):
+    """Serve locally captured HTTP preview thumbnails."""
+    return send_from_directory(HTTP_PREVIEW_DIR, filename)
+
+
+@app.route('/clients/<identifier>/services/<int:port>')
+def client_service_detail(identifier, port):
+    """Show a focused saved-service detail page for an IP client port."""
+    device = enrich_ip_client_display_name(identifier, find_inventory_device(identifier) or {})
+    host = device.get('ip') or identifier
+    service = next((dict(item) for item in device.get('open_port_details', []) if int(item.get('port') or 0) == int(port)), None)
+    if not service:
+        return render_template('service_detail.html', title='Service not found', host=host, port=port, service=None, device=device, **current_context()), 404
+    return render_template('service_detail.html', title=f"{host}:{port} Service", host=host, port=port, service=service, device=device, **current_context())
+
+
 @app.route('/clients/<identifier>')
 def client_detail(identifier):
     """Display details for a client identified by MAC or IP address."""
@@ -1544,14 +2813,21 @@ def client_detail(identifier):
     if is_bluetooth:
         ip = None
 
+    if not is_bluetooth and ip:
+        inventory_device = enrich_ip_client_display_name(ip, inventory_device)
+        mac = (inventory_device or {}).get('mac') or mac
+
     manufacturer = (inventory_device or {}).get('manufacturer') or (lookup_manufacturer(mac) if mac else 'Unknown')
-    display_name = (
-        (inventory_device or {}).get('name')
-        or (inventory_device or {}).get('display_name')
-        or mac
-        or ip
-        or identifier
-    )
+    display_name = display_name_for_inventory_device(inventory_device or {}, mac or ip or identifier)
+
+    last_port_scan = None if is_bluetooth else (inventory_device or {}).get('last_port_scan')
+    health_summary = None if is_bluetooth else client_health_summary(inventory_device or {}, ip)
+    timeline = [] if is_bluetooth else client_timeline(ip or mac or identifier, inventory_device)
+    watched = False if is_bluetooth else is_client_watched(ip or identifier)
+    reachability = [] if is_bluetooth else client_reachability_history(ip or identifier)
+    baseline_diff = None if is_bluetooth else client_baseline_diff(inventory_device or {})
+    relationship_map = None if is_bluetooth else client_relationship_map(ip or identifier)
+    scheduled_check = None if is_bluetooth else scheduled_client_checks.get(ip or identifier)
 
     return render_template(
         'client_detail.html',
@@ -1560,7 +2836,23 @@ def client_detail(identifier):
         mac=mac,
         manufacturer=manufacturer,
         display_name=display_name,
+        display_name_source=(inventory_device or {}).get('display_name_source'),
+        inventory_device=inventory_device or {},
         is_bluetooth=is_bluetooth,
+        open_port_details=[] if is_bluetooth else (inventory_device or {}).get('open_port_details', []),
+        open_ports=[] if is_bluetooth else (inventory_device or {}).get('open_ports', []),
+        last_port_scan_label=(
+            time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(last_port_scan))
+            if last_port_scan
+            else None
+        ),
+        health_summary=health_summary,
+        client_timeline=timeline,
+        watched_client=watched,
+        reachability_history=reachability,
+        baseline_diff=baseline_diff,
+        relationship_map=relationship_map,
+        scheduled_check=scheduled_check,
         bluetooth_fields=bluetooth_detail_fields(inventory_device) if is_bluetooth else [],
         bluetooth_action_capability=bluetooth_action_capability() if is_bluetooth else None,
         bluetooth_actions=bluetooth_contextual_actions(inventory_device) if is_bluetooth else [],
@@ -1568,6 +2860,141 @@ def client_detail(identifier):
         bluetooth_action_history=bluetooth_action_history(mac) if is_bluetooth else [],
         **current_context(),
     )
+
+
+@app.route('/clients/<identifier>/watch', methods=['POST'])
+def watch_client(identifier):
+    """Toggle watch notifications for an IP client."""
+    watch = request.form.get('watch', 'on') == 'on'
+    target = str(identifier or '').strip()
+    if not target:
+        return json_error('Missing client identifier')
+    if watch:
+        watched_clients.add(target)
+        append_client_timeline_event(target, 'Watch enabled', 'This client will create alerts for notable profile changes.', 'client-watch')
+        return json_success(watched=True, message='Client watch enabled.')
+    watched_clients.discard(target)
+    append_client_timeline_event(target, 'Watch disabled', 'Client watch notifications were disabled.', 'client-watch')
+    return json_success(watched=False, message='Client watch disabled.')
+
+
+@app.route('/clients/<identifier>/http-inspect', methods=['POST'])
+def client_http_inspect(identifier):
+    """Inspect saved or supplied HTTP-like services for an IP client."""
+    inventory_device = find_inventory_device(identifier) or {}
+    host = inventory_device.get('ip') or identifier
+    raw_ports = request.form.get('ports')
+    try:
+        if raw_ports:
+            candidates = [parse_int(item.strip(), 'Ports must be integers') for item in raw_ports.split(',') if item.strip()]
+        else:
+            http_names = ('http', 'https', 'web', 'proxy')
+            candidates = [
+                item['port'] for item in inventory_device.get('open_port_details', [])
+                if any(name in str(item.get('service', '')).lower() for name in http_names) or item.get('port') in (80, 443, 8080, 8443, 8000, 9443)
+            ]
+    except ValueError as e:
+        return json_error(str(e))
+    candidates = sorted(set(port for port in candidates if 1 <= port <= 65535))[:8]
+    if not candidates:
+        return json_error('No HTTP-like saved ports are available for this client. Run a port scan first or supply ports.', 400)
+    results = inspect_http_services(host, candidates)
+    append_client_timeline_event(host, 'HTTP inspected', f"Inspected {len(results)} web service candidate(s).", 'http-inspector')
+    return json_success(results=results)
+
+
+
+
+@app.route('/clients/<identifier>/summary')
+def client_summary_route(identifier):
+    """Return the latest saved profile fields needed by inline device cards."""
+    device = enrich_ip_client_display_name(identifier, find_inventory_device(identifier) or {})
+    host = device.get('ip') or identifier
+    return json_success(device={
+        'ip': host,
+        'mac': device.get('mac'),
+        'display_name': display_name_for_inventory_device(device, host),
+        'manufacturer': device.get('manufacturer') or 'Unknown',
+        'open_port_details': device.get('open_port_details', []),
+        'open_ports': device.get('open_ports', []),
+        'client_tags': device.get('client_tags', []),
+        'client_notes': device.get('client_notes'),
+        'last_port_scan': device.get('last_port_scan'),
+    })
+
+
+@app.route('/clients/<identifier>/metadata', methods=['POST'])
+def client_metadata_route(identifier):
+    """Save user-maintained IP client profile metadata."""
+    try:
+        device = update_client_metadata(identifier, request.form)
+    except ValueError as e:
+        return json_error(str(e))
+    return json_success(device=device, message='Client profile metadata saved.')
+
+
+@app.route('/clients/<identifier>/baseline', methods=['POST'])
+def client_baseline_route(identifier):
+    """Save current device observations as the expected baseline."""
+    device = save_client_baseline(identifier)
+    return json_success(device=device, baseline=client_baseline_diff(device), message='Client baseline saved.')
+
+
+@app.route('/clients/<identifier>/export.<fmt>')
+def client_export_route(identifier, fmt):
+    """Export an individual IP client profile."""
+    profile = client_profile_export(identifier)
+    if fmt == 'json':
+        return jsonify(profile)
+    if fmt == 'md':
+        device = profile['device']
+        lines = [
+            f"# Client profile: {profile['host']}",
+            '',
+            f"- Manufacturer: {device.get('manufacturer') or 'Unknown'}",
+            f"- MAC: {device.get('mac') or 'Unknown'}",
+            f"- Tags: {', '.join(device.get('client_tags', [])) or 'None'}",
+            f"- Owner: {device.get('client_owner') or 'Unknown'}",
+            f"- Location: {device.get('client_location') or 'Unknown'}",
+            f"- Health: {profile['health']['level']} ({profile['health']['score']}/100)",
+            f"- Baseline: {profile['baseline']['status']}",
+            '',
+            '## Open ports',
+        ]
+        for item in device.get('open_port_details', []):
+            lines.append(f"- {item.get('port')}/tcp {item.get('service') or 'Unknown'} — {item.get('description') or ''}")
+        if not device.get('open_port_details'):
+            lines.append('- No open ports saved.')
+        lines.extend(['', '## Timeline'])
+        for event in profile['timeline']:
+            lines.append(f"- {event.get('time_label')}: {event.get('type')} — {event.get('message')}")
+        return Response('\n'.join(lines), mimetype='text/markdown', headers={'Content-Disposition': f'attachment; filename=client-{profile["host"]}.md'})
+    return json_error('Unsupported client export format', 404)
+
+
+@app.route('/clients/<identifier>/relationship-map')
+def client_relationship_map_route(identifier):
+    return json_success(map=client_relationship_map(identifier))
+
+
+@app.route('/clients/<identifier>/intelligence', methods=['POST'])
+def client_intelligence_route(identifier):
+    active_probe = request.form.get('activeProbe') in {'on', 'true', '1'}
+    return json_success(intelligence=client_intelligence_profile(identifier, active_probe=active_probe))
+
+
+@app.route('/clients/<identifier>/fingerprint', methods=['POST'])
+def client_fingerprint_route(identifier):
+    return json_success(fingerprints=fingerprint_client_services(identifier))
+
+
+@app.route('/clients/<identifier>/scheduled-check', methods=['POST'])
+def client_scheduled_check_route(identifier):
+    try:
+        plan = save_scheduled_client_check(identifier, request.form)
+    except ValueError as e:
+        return json_error(str(e))
+    return json_success(plan=plan, message='Scheduled client check saved.')
 
 
 @app.route('/active-scan', methods=['POST'])
@@ -1590,6 +3017,41 @@ def passive_scan_route():
     return jsonify({'devices': enriched_devices})
 
 
+
+@app.route('/passive-monitor/status')
+def passive_monitor_status_route():
+    interface = request.args.get('selectedInterface') or request.args.get('interface')
+    status = passive_monitor_snapshot(interface)
+    return jsonify({'status': status})
+
+
+@app.route('/passive-monitor/toggle', methods=['POST'])
+def passive_monitor_toggle_route():
+    data = request.form
+    interface = data.get('selectedInterface') or data.get('interface')
+    enabled = str(data.get('enabled') or '').strip().lower() in {'1', 'true', 'yes', 'on'}
+    try:
+        status = set_passive_monitor(interface, enabled, data.get('interval') or 10)
+    except ValueError as exc:
+        return json_error(str(exc))
+    message = 'Continuous passive capture enabled.' if enabled else 'Continuous passive capture disabled.'
+    return json_success(message=message, status=status)
+
+
+@app.route('/comprehensive-scan', methods=['POST'])
+def comprehensive_scan_route():
+    try:
+        result = comprehensive_network_device_scan(
+            request.form.get('selectedInterface'),
+            include_passive=request.form.get('includePassive', 'on') == 'on',
+            include_services=request.form.get('includeServices', 'on') == 'on',
+            sweep_cidr=(request.form.get('sweepCidr') or '').strip() or None,
+        )
+    except ValueError as e:
+        return json_error(str(e))
+    return json_success(result=result)
+
+
 @app.route('/port-scan', methods=['POST'])
 def port_scan_route():
     data = request.form
@@ -1609,7 +3071,9 @@ def port_scan_route():
     except PortScanError as e:
         return json_error(str(e))
 
-    return jsonify({'ports': ports, 'port_details': describe_open_ports(ports)})
+    port_details = [enrich_web_port_metadata(data.get('host'), detail) for detail in describe_open_ports(ports)]
+    record_device_open_ports(data.get('host'), port_details, source='port-scan')
+    return jsonify({'ports': ports, 'port_details': port_details})
 
 
 @app.route('/port-scan-jobs', methods=['POST'])
@@ -1674,6 +3138,136 @@ def traceroute_route():
     return jsonify({'hops': hops})
 
 
+@app.route('/ping', methods=['POST'])
+def ping_route():
+    try:
+        result = run_ping_check(request.form.get('host'), request.form.get('count') or 4, request.form.get('timeout') or 2)
+    except ValueError as e:
+        return json_error(str(e))
+    except subprocess.TimeoutExpired:
+        return json_error('Ping timed out', 504)
+    return json_success(result=result, history=ping_history[-10:])
+
+
+@app.route('/ping-sweep', methods=['POST'])
+def ping_sweep_route():
+    try:
+        sweep = run_ping_sweep(request.form.get('cidr'), request.form.get('count') or 1, request.form.get('timeout') or 1)
+    except ValueError as e:
+        return json_error(str(e))
+    return json_success(sweep=sweep, history=ping_history[-10:])
+
+
+@app.route('/route-diagnostics', methods=['POST'])
+def route_diagnostics_route():
+    diagnostics = build_route_diagnostics(request.form.get('target'))
+    return json_success(diagnostics=diagnostics)
+
+
+@app.route('/mdns-discovery', methods=['POST'])
+def mdns_discovery_route():
+    result = discover_mdns_services(request.form.get('selectedInterface'))
+    return json_success(result=result)
+
+
+@app.route('/upnp-discovery', methods=['POST'])
+def upnp_discovery_route():
+    try:
+        timeout = parse_int(request.form.get('timeout') or 2, 'Timeout must be an integer')
+    except ValueError as e:
+        return json_error(str(e))
+    result = discover_upnp_devices(timeout=max(1, min(timeout, 5)))
+    return json_success(result=result)
+
+
+@app.route('/neighbor-discovery', methods=['POST'])
+def neighbor_discovery_route():
+    result = discover_lldp_neighbors(request.form.get('selectedInterface'))
+    return json_success(result=result)
+
+
+@app.route('/vlan-discovery', methods=['POST'])
+def vlan_discovery_route():
+    result = discover_vlan_context(request.form.get('ssid'), request.form.get('vlanId'), request.form.get('notes'))
+    return json_success(result=result)
+
+
+@app.route('/egress-diagnostics', methods=['POST'])
+def egress_diagnostics_route():
+    return json_success(result=build_egress_diagnostics(request.form.get('selectedInterface')))
+
+
+@app.route('/iperf3-test', methods=['POST'])
+def iperf3_test_route():
+    try:
+        result = run_iperf3_test(request.form.get('mode'), request.form.get('host'), request.form.get('port') or 5201, request.form.get('seconds') or 5)
+    except (ValueError, subprocess.TimeoutExpired) as e:
+        return json_error(str(e))
+    return json_success(result=result)
+
+
+@app.route('/snmp-discovery', methods=['POST'])
+def snmp_discovery_route():
+    if request.form.get('authorized') != 'on':
+        return json_error('Confirm this is an authorized SNMP inventory check')
+    try:
+        result = run_snmp_inventory(request.form.get('host'), request.form.get('community'), request.form.get('version') or '2c', request.form.get('oid') or 'system')
+    except ValueError as e:
+        return json_error(str(e))
+    return json_success(result=result)
+
+
+@app.route('/ipv6-assessment', methods=['POST'])
+def ipv6_assessment_route():
+    result = run_ipv6_assessment(request.form.get('host'), request.form.get('ports'))
+    return json_success(result=result)
+
+
+@app.route('/wireless/network/label', methods=['POST'])
+def wireless_network_client_label_route():
+    """Save an SSID-scoped custom label for a network client card."""
+    interface = request.form.get('interface')
+    ssid = request.form.get('ssid')
+    bssid = request.form.get('bssid')
+    identity = request.form.get('identity') or request.form.get('ip') or request.form.get('mac')
+    label = (request.form.get('label') or '').strip()[:80]
+    if not interface or not ssid or not identity:
+        return json_error('Interface, SSID, and client identity are required')
+    key = wireless_network_client_label_key(interface, ssid, bssid, identity)
+    if label:
+        wireless_network_labels[key] = label
+    else:
+        wireless_network_labels.pop(key, None)
+    return json_success(label=label, message='Network client label saved.')
+
+
+@app.route('/wireless/network/clients.csv')
+def wireless_network_clients_export():
+    """Export the persisted Wi-Fi network device list as CSV."""
+    from scripts.wifi import utils as wifi_utils
+    network = wifi_utils.get_network_detail(ssid=request.args.get('ssid'), bssid=request.args.get('bssid'), interface_name=request.args.get('interface'))
+    network = merge_wireless_network_clients(network)
+    output = io.StringIO()
+    writer = csv.DictWriter(output, fieldnames=['display_name', 'ip', 'mac', 'manufacturer', 'tags', 'notes', 'open_ports', 'open_port_details_json', 'first_seen', 'last_seen', 'state'])
+    writer.writeheader()
+    for client in network.get('clients', []) + network.get('disappeared_clients', []):
+        writer.writerow({
+            'display_name': client.get('display_name'),
+            'ip': client.get('ip'),
+            'mac': client.get('mac'),
+            'manufacturer': client.get('manufacturer'),
+            'tags': ', '.join(client.get('client_tags') or []),
+            'notes': client.get('client_notes') or '',
+            'open_ports': ', '.join(str(item.get('port')) for item in client.get('open_port_details') or []),
+            'open_port_details_json': json.dumps(client.get('open_port_details') or []),
+            'first_seen': client.get('network_first_seen'),
+            'last_seen': client.get('network_last_seen'),
+            'state': 'disappeared' if client in network.get('disappeared_clients', []) else 'visible',
+        })
+    filename = secure_filename(f"{network.get('ssid') or 'wireless-network'}-clients.csv")
+    return Response(output.getvalue(), mimetype='text/csv', headers={'Content-Disposition': f'attachment; filename="{filename}"'})
+
+
 @app.route('/wireless/network')
 def wireless_network_detail():
     ssid = request.args.get('ssid')
@@ -1685,6 +3279,7 @@ def wireless_network_detail():
 
     from scripts.wifi import utils as wifi_utils
     network = wifi_utils.get_network_detail(ssid=ssid, bssid=bssid, interface_name=selected_interface)
+    network = merge_wireless_network_clients(network)
     back_url = f"/wireless/{selected_interface}" if selected_interface else "/wireless"
     return render_template(
         'wireless_network_detail.html',
@@ -1990,6 +3585,68 @@ def deauth_route():
         return json_success(message=f'Sent {frames} authorized lab deauth frames on {selected_interface}')
     except Exception as e:
         return json_error(f'Deauth error: {str(e)}', 500)
+
+
+@app.route('/evil-twin-lab', methods=['POST'])
+def evil_twin_lab_route():
+    data = request.form
+    selected_interface = data.get('selectedInterface')
+
+    if missing_fields(data, 'selectedInterface', 'ssid', 'bssid', 'channel'):
+        return json_error('Missing required parameters')
+
+    try:
+        lab = validate_evil_twin_lab_request(data)
+        run = record_evil_twin_lab_run(selected_interface, lab)
+    except ValueError as e:
+        return json_error(str(e))
+
+    action_messages = {
+        'plan': 'Prepared evil twin and captive portal lab plan; no radio services were started by Mobile Router.',
+        'start': 'Logged authorized evil twin lab start checklist; run AP services only in your isolated lab environment.',
+        'cleanup': 'Logged evil twin lab cleanup checklist; verify rogue AP, DHCP, DNS, and portal services are stopped.',
+    }
+    return json_success(message=action_messages[run['action']], run=run)
+
+
+@app.route('/pineap-lab', methods=['POST'])
+def pineap_lab_route():
+    data = request.form
+    selected_interface = data.get('selectedInterface')
+    if missing_fields(data, 'selectedInterface'):
+        return json_error('Missing required parameters')
+    try:
+        lab = validate_pineap_lab_request(data)
+        run = build_pineap_lab_result(selected_interface, lab)
+    except ValueError as e:
+        return json_error(str(e))
+    except Exception as e:
+        return json_error(f'PineAP-style lab error: {str(e)}', 500)
+    return json_success(message=f"Recorded {run['action']} workflow with {len(run['module_status'])} module(s).", run=run)
+
+
+@app.route('/handshake-lab', methods=['POST'])
+def handshake_lab_route():
+    data = request.form
+    selected_interface = data.get('selectedInterface')
+    if missing_fields(data, 'selectedInterface', 'ssid', 'bssid', 'channel'):
+        return json_error('Missing required parameters')
+    try:
+        lab = validate_handshake_lab_request(data)
+        record = record_handshake_lab_evidence(selected_interface, lab, request.files.get('capture'))
+    except ValueError as e:
+        return json_error(str(e))
+    return json_success(message='Cataloged WPA handshake/PMKID lab evidence for validation and export.', record=record)
+
+
+@app.route('/handshake-lab.<fmt>')
+def export_handshake_lab(fmt):
+    records = handshake_lab_export_records()
+    if fmt == 'json':
+        return jsonify({'handshakes': records, 'exported_at': time.time()})
+    if fmt == 'csv':
+        return Response(handshake_records_as_csv(records), mimetype='text/csv', headers={'Content-Disposition': 'attachment; filename=handshake-lab.csv'})
+    return json_error('Unsupported handshake export format', 404)
 
 
 @app.route('/aireplay-deauth', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -26,6 +26,7 @@ from services import wireless_clients as wireless_client_service
 from services import persistence as persistence_service
 from services import oui as oui_service
 from services import labs as labs_service
+from services import reports as reports_service
 from scripts.interfaceTools import (
     get_bluetooth_devices,
     get_network_interfaces,
@@ -2375,96 +2376,18 @@ def create_scan_job(scan_type, selected_interface):
 def build_report_data():
     """Collect the current application state for report exports."""
     from scripts.capabilities import build_capabilities
-
-    devices = inventory_records()
-    exported_at = time.time()
-    return {
-        'exported_at': exported_at,
-        'exported_at_label': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(exported_at)),
-        'interfaces': [iface.to_dict() for iface in network_interfaces],
-        'devices': devices,
-        'insights': manufacturer_insights(devices),
-        'jobs': all_job_snapshots(),
-        'alerts': alert_records(),
-        'evidence': evidence_records(),
-        'capabilities': build_capabilities(),
-    }
+    return reports_service.build_report_data(
+        network_interfaces, inventory_records, manufacturer_insights, all_job_snapshots,
+        alert_records, evidence_records, build_capabilities,
+    )
 
 
 def report_as_csv(report):
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerow(['Mobile Router Report'])
-    writer.writerow(['Exported at', report['exported_at_label']])
-    writer.writerow([])
-    writer.writerow(['Devices'])
-    writer.writerow(['Name', 'IP', 'MAC', 'Manufacturer', 'Sources', 'Interfaces', 'First seen', 'Last seen'])
-    for device in report['devices']:
-        writer.writerow([
-            device.get('display_name'),
-            device.get('ip'),
-            device.get('mac') or device.get('bssid'),
-            device.get('manufacturer'),
-            ', '.join(device.get('sources', [])),
-            ', '.join(device.get('interfaces', [])),
-            device.get('first_seen_label'),
-            device.get('last_seen_label'),
-        ])
-    writer.writerow([])
-    writer.writerow(['Interfaces'])
-    writer.writerow(['Name', 'Type', 'State', 'Manufacturer'])
-    for iface in report['interfaces']:
-        writer.writerow([iface.get('name'), iface.get('interface_type'), iface.get('state'), iface.get('manufacturer')])
-    writer.writerow([])
-    writer.writerow(['Jobs'])
-    writer.writerow(['ID', 'Kind', 'Label', 'Status', 'Progress'])
-    for job in report['jobs']:
-        writer.writerow([job.get('id'), job.get('kind'), job.get('label') or job.get('scan_type'), job.get('status'), job.get('progress')])
-    writer.writerow([])
-    writer.writerow(['Evidence'])
-    writer.writerow(['Title', 'Category', 'Source', 'Device', 'File', 'Created'])
-    for item in report['evidence']:
-        writer.writerow([item.get('title'), item.get('category'), item.get('source'), item.get('device'), item.get('file_name'), item.get('created_at_label')])
-    writer.writerow([])
-    writer.writerow(['Alerts'])
-    writer.writerow(['Device', 'IP', 'MAC', 'Manufacturer', 'Source', 'Read', 'Created'])
-    for alert in report['alerts']:
-        writer.writerow([alert.get('display_name'), alert.get('ip'), alert.get('mac'), alert.get('manufacturer'), alert.get('source'), alert.get('read'), alert.get('created_at_label')])
-    return output.getvalue()
+    return reports_service.report_as_csv(report)
 
 
 def report_as_markdown(report):
-    lines = [
-        '# Mobile Router Report',
-        '',
-        f"Exported at: {report['exported_at_label']}",
-        '',
-        '## Summary',
-        f"- Devices: {report['insights']['total_devices']}",
-        f"- Known manufacturers: {report['insights']['known_manufacturers']}",
-        f"- Unknown manufacturers: {report['insights']['unknown_manufacturers']}",
-        f"- Interfaces: {len(report['interfaces'])}",
-        f"- Jobs: {len(report['jobs'])}",
-        f"- Alerts: {len(report['alerts'])}",
-        f"- Evidence records: {len(report['evidence'])}",
-        '',
-        '## Devices',
-        '| Name | IP | MAC/BSSID | Manufacturer | Sources |',
-        '| --- | --- | --- | --- | --- |',
-    ]
-    for device in report['devices']:
-        lines.append(f"| {device.get('display_name', '')} | {device.get('ip') or ''} | {device.get('mac') or device.get('bssid') or ''} | {device.get('manufacturer') or ''} | {', '.join(device.get('sources', []))} |")
-    lines.extend(['', '## Interfaces', '| Name | Type | State | Manufacturer |', '| --- | --- | --- | --- |'])
-    for iface in report['interfaces']:
-        lines.append(f"| {iface.get('name', '')} | {iface.get('interface_type', '')} | {iface.get('state', '')} | {iface.get('manufacturer', '')} |")
-    lines.extend(['', '## Evidence', '| Title | Category | Source | Device | File | Created |', '| --- | --- | --- | --- | --- | --- |'])
-    for item in report['evidence']:
-        lines.append(f"| {item.get('title', '')} | {item.get('category', '')} | {item.get('source') or ''} | {item.get('device') or ''} | {item.get('file_name') or ''} | {item.get('created_at_label') or ''} |")
-    lines.extend(['', '## Alerts', '| Device | IP | MAC | Source | Read |', '| --- | --- | --- | --- | --- |'])
-    for alert in report['alerts']:
-        lines.append(f"| {alert.get('display_name', '')} | {alert.get('ip') or ''} | {alert.get('mac') or ''} | {alert.get('source') or ''} | {alert.get('read')} |")
-    return '\n'.join(lines) + '\n'
-
+    return reports_service.report_as_markdown(report)
 
 
 def bluetooth_phone_card_context():

--- a/app.py
+++ b/app.py
@@ -195,7 +195,7 @@ ROADMAP_SECTIONS = [
             {'title': 'IP client profiles and watchlists', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Client pages now include health scoring, saved service history, web inspection, watch alerts, timeline events, owner/location/tags, baselines, drift checks, reachability history, and per-client JSON/Markdown exports.', 'description': 'Turn discovered IP clients into investigation profiles with health, ownership, baseline, watch, timeline, and export workflows.'},
             {'title': 'Network map', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Visualize adapters, SSIDs, access points, clients, and wired hosts as a simple topology map.'},
             {'title': 'Client relationship map', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Client profiles now show relationship nodes and links for interfaces, discovery sources, saved services, and related evidence records.', 'description': 'Show each IP client connected to interfaces, SSIDs, gateways, VLAN context, services, evidence records, and alerts.'},
-            {'title': 'Scheduled client checks', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Client profiles can save recurring check plans for ping, common ports, HTTP inspection, service fingerprinting, and baseline drift so a scheduler can run them.', 'description': 'Run recurring reachability, common-port, service-fingerprint, and drift checks for watched clients with alerting.'},
+            {'title': 'Scheduled client checks', 'priority': 'Medium', 'priority_class': 'warning', 'status': 'Done', 'completed_note': 'Client profiles can save recurring check plans and run due/on-demand ping, bounded common-port refresh, HTTP inspection, service fingerprinting, and baseline drift checks.', 'description': 'Run recurring reachability, common-port, service-fingerprint, and drift checks for watched clients with alerting.'},
             {'title': 'Client remediation checklist', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Turn baseline drift, sensitive services, and unknown identity hints into suggested remediation tasks with resolved/accepted-risk state.'},
             {'title': 'Client change approval log', 'priority': 'Low', 'priority_class': 'secondary', 'description': 'Let users approve expected port, owner, location, and tag changes with reviewer notes for audit-friendly inventory maintenance.'},
             {'title': 'Dedicated wireless occupancy report page', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Create a drill-down page that compares adapters, channel congestion, BSSID detail, historical heatmaps, and exportable recommendations.'},
@@ -1667,6 +1667,81 @@ def save_scheduled_client_check(identifier, data):
     return dict(plan)
 
 
+
+def scan_common_client_ports(host, timeout=0.35):
+    """Run a bounded common-port refresh for scheduled checks."""
+    from scripts.portScanner import COMMON_SERVICE_HINTS, identify_port_service
+
+    target = str(host or '').strip()
+    if not target:
+        return []
+    open_details = []
+    for port in sorted(COMMON_SERVICE_HINTS):
+        try:
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                sock.settimeout(timeout)
+                is_open = sock.connect_ex((target, int(port))) == 0
+        except OSError:
+            is_open = False
+        if is_open:
+            open_details.append(enrich_web_port_metadata(target, identify_port_service(int(port))))
+    if open_details:
+        record_device_open_ports(target, open_details, source='scheduled-common-ports')
+    return open_details
+
+
+def run_scheduled_client_check(identifier, now=None):
+    """Execute one saved scheduled-check plan and persist its summary."""
+    target = str(identifier or '').strip()
+    plan = scheduled_client_checks.get(target)
+    if not plan:
+        raise ValueError('No scheduled check plan found for this client')
+    now = now or time.time()
+    results = {}
+    checks = plan.get('checks') or []
+    if 'ping' in checks:
+        results['ping'] = run_ping_check(target, count=2, timeout=2)
+    if 'common-ports' in checks:
+        results['common_ports'] = scan_common_client_ports(target)
+    if 'http-inspect' in checks:
+        device = find_inventory_device(target) or {}
+        ports = [item.get('port') for item in device.get('open_port_details', []) if item.get('web_url') or str(item.get('service') or '').lower().startswith('http')]
+        results['http_inspect'] = inspect_http_services(target, sorted({int(port) for port in ports if port})[:8])
+    if 'service-fingerprint' in checks:
+        results['service_fingerprint'] = fingerprint_client_services(target)
+    if 'baseline-drift' in checks:
+        results['baseline_drift'] = client_baseline_diff(find_inventory_device(target) or {})
+    plan.update({
+        'last_run': now,
+        'next_run': now + (int(plan.get('interval_minutes') or 60) * 60),
+        'last_result': results,
+        'status': 'completed',
+    })
+    append_client_timeline_event(target, 'Scheduled check run', f"Completed scheduled checks: {', '.join(checks)}.", 'scheduled-checks')
+    drift = (results.get('baseline_drift') or {})
+    if is_client_watched(target) and drift.get('status') == 'Drift detected':
+        create_client_watch_alert(target, 'Scheduled check drift detected', f"Baseline drift detected for {target}.")
+    save_runtime_state('scheduled-check-run')
+    return dict(plan)
+
+
+def run_due_scheduled_client_checks(now=None):
+    """Run every scheduled client check whose interval has elapsed."""
+    now = now or time.time()
+    due = []
+    for target, plan in list(scheduled_client_checks.items()):
+        last_run = plan.get('last_run')
+        interval_seconds = int(plan.get('interval_minutes') or 60) * 60
+        if last_run is None or now - float(last_run or 0) >= interval_seconds:
+            due.append(target)
+    results = []
+    for target in due[:25]:
+        try:
+            results.append(run_scheduled_client_check(target, now=now))
+        except ValueError:
+            continue
+    return results
+
 def is_client_watched(identifier):
     key = str(identifier or '').strip()
     return key in watched_clients
@@ -3075,6 +3150,21 @@ def client_scheduled_check_route(identifier):
     except ValueError as e:
         return json_error(str(e))
     return json_success(plan=plan, message='Scheduled client check saved.')
+
+
+@app.route('/clients/<identifier>/scheduled-check/run', methods=['POST'])
+def client_scheduled_check_run_route(identifier):
+    try:
+        plan = run_scheduled_client_check(identifier)
+    except ValueError as e:
+        return json_error(str(e), 404)
+    return json_success(plan=plan, message='Scheduled client check ran.')
+
+
+@app.route('/scheduled-checks/run-due', methods=['POST'])
+def scheduled_checks_run_due_route():
+    results = run_due_scheduled_client_checks()
+    return json_success(results=results, count=len(results), message=f'Ran {len(results)} due scheduled check(s).')
 
 
 @app.route('/active-scan', methods=['POST'])

--- a/app.py
+++ b/app.py
@@ -83,6 +83,8 @@ wireless_network_client_cache = {}
 wireless_network_labels = {}
 passive_monitor_jobs = {}
 passive_monitor_lock = threading.Lock()
+passive_observation_analytics = {}
+passive_analytics_lock = threading.Lock()
 HTTP_PREVIEW_DIR = os.path.join(app.instance_path, 'http_previews')
 EVIDENCE_DIR = os.path.join(app.instance_path, 'evidence_vault')
 MAC_RE = re.compile(r'^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$')
@@ -110,6 +112,7 @@ def runtime_state_snapshot():
         'scheduled_client_checks': dict(scheduled_client_checks),
         'wireless_network_client_cache': wireless_network_client_cache,
         'wireless_network_labels': dict(wireless_network_labels),
+        'passive_observation_analytics': passive_observation_analytics,
         'bluetooth_action_histories': bluetooth_action_histories,
         'evil_twin_lab_runs': evil_twin_lab_runs,
         'pineap_lab_runs': pineap_lab_runs,
@@ -145,6 +148,7 @@ def load_runtime_state():
     scheduled_client_checks.update(state.get('scheduled_client_checks') or {})
     wireless_network_client_cache.update(state.get('wireless_network_client_cache') or {})
     wireless_network_labels.update(state.get('wireless_network_labels') or {})
+    passive_observation_analytics.update(state.get('passive_observation_analytics') or {})
     bluetooth_action_histories.update(state.get('bluetooth_action_histories') or {})
     evil_twin_lab_runs.extend(state.get('evil_twin_lab_runs') or [])
     pineap_lab_runs.extend(state.get('pineap_lab_runs') or [])
@@ -2200,6 +2204,112 @@ def merge_discovered_devices(groups):
     return list(merged.values())
 
 
+def passive_device_identity(device):
+    """Return a stable identity key for passive observation analytics."""
+    mac = normalize_mac((device or {}).get('mac') or (device or {}).get('address'))
+    if mac:
+        return mac
+    ip = str((device or {}).get('ip') or '').strip()
+    if ip:
+        return f'ip:{ip}'
+    name = str((device or {}).get('hostname') or (device or {}).get('name') or '').strip()
+    if name:
+        return f'name:{name.lower()}'
+    return None
+
+
+def record_passive_observation_analytics(interface, devices, source='passive-scan'):
+    """Track passive-only observation counts, churn, and quiet devices per interface."""
+    iface = str(interface or 'unknown').strip() or 'unknown'
+    now = time.time()
+    seen_identities = []
+    with passive_analytics_lock:
+        analytics = passive_observation_analytics.setdefault(iface, {
+            'interface': iface,
+            'started_at': now,
+            'last_update': None,
+            'total_samples': 0,
+            'devices': {},
+            'history': [],
+            'last_seen_identities': [],
+        })
+        known_before = set((analytics.get('devices') or {}).keys())
+        devices_map = analytics.setdefault('devices', {})
+        for device in devices or []:
+            identity = passive_device_identity(device)
+            if not identity:
+                continue
+            seen_identities.append(identity)
+            record = devices_map.setdefault(identity, {
+                'identity': identity,
+                'first_seen': now,
+                'seen_count': 0,
+                'sources': [],
+            })
+            record.update({
+                'last_seen': now,
+                'ip': device.get('ip') or record.get('ip'),
+                'mac': normalize_mac(device.get('mac') or device.get('address')) or record.get('mac'),
+                'hostname': device.get('hostname') or device.get('name') or record.get('hostname'),
+                'manufacturer': device.get('manufacturer') or record.get('manufacturer') or 'Unknown',
+            })
+            record['seen_count'] = int(record.get('seen_count') or 0) + 1
+            sources = set(record.get('sources') or [])
+            sources.add(source)
+            record['sources'] = sorted(sources)
+        seen_set = set(seen_identities)
+        new_count = len(seen_set - known_before)
+        quiet = [identity for identity in known_before if identity not in seen_set]
+        analytics['last_update'] = now
+        analytics['total_samples'] = int(analytics.get('total_samples') or 0) + 1
+        analytics['last_seen_identities'] = sorted(seen_set)
+        analytics['history'] = ([{
+            'timestamp': now,
+            'source': source,
+            'observed_count': len(seen_set),
+            'new_count': new_count,
+            'quiet_count': len(quiet),
+        }] + list(analytics.get('history') or []))[:100]
+        snapshot = passive_observation_summary(iface, _locked=True)
+    save_runtime_state(f'passive-analytics:{source}')
+    return snapshot
+
+
+def passive_observation_summary(interface=None, _locked=False):
+    """Return passive-only analytics for one interface or all interfaces."""
+    def build(iface, analytics):
+        devices = list((analytics.get('devices') or {}).values())
+        last_seen = set(analytics.get('last_seen_identities') or [])
+        recently_disappeared = sorted(
+            [dict(item) for item in devices if item.get('identity') not in last_seen],
+            key=lambda item: item.get('last_seen') or 0,
+            reverse=True,
+        )[:25]
+        active = sorted(
+            [dict(item) for item in devices if item.get('identity') in last_seen],
+            key=lambda item: item.get('last_seen') or 0,
+            reverse=True,
+        )[:25]
+        return {
+            'interface': iface,
+            'started_at': analytics.get('started_at'),
+            'last_update': analytics.get('last_update'),
+            'total_samples': analytics.get('total_samples') or 0,
+            'known_device_count': len(devices),
+            'active_device_count': len(active),
+            'recently_disappeared_count': len(recently_disappeared),
+            'active_devices': active,
+            'recently_disappeared': recently_disappeared,
+            'history': list(analytics.get('history') or [])[:25],
+        }
+    if _locked:
+        if interface:
+            return build(interface, passive_observation_analytics.get(interface, {'interface': interface, 'devices': {}, 'history': []}))
+        return {iface: build(iface, analytics) for iface, analytics in passive_observation_analytics.items()}
+    with passive_analytics_lock:
+        if interface:
+            return build(interface, passive_observation_analytics.get(interface, {'interface': interface, 'devices': {}, 'history': []}))
+        return {iface: build(iface, analytics) for iface, analytics in passive_observation_analytics.items()}
 
 def passive_monitor_snapshot(interface=None):
     """Return passive ARP-cache monitor state for one interface or all interfaces."""
@@ -2221,12 +2331,14 @@ def _passive_monitor_worker(interface):
         try:
             devices = classify_scan_results(passive_scan(interface), interface)
             enriched = record_inventory_devices(devices, 'passive-monitor', interface)
+            analytics = record_passive_observation_analytics(interface, enriched, 'passive-monitor')
             with passive_monitor_lock:
                 current = passive_monitor_jobs.get(interface)
                 if current:
                     current.update({
                         'last_update': time.time(),
                         'last_count': len(enriched),
+                        'analytics': analytics,
                         'error': None,
                     })
         except Exception as exc:
@@ -3184,8 +3296,14 @@ def passive_scan_route():
         return json_error('Missing interface')
     devices = classify_scan_results(passive_scan(iface), iface)
     enriched_devices = record_inventory_devices(devices, 'passive-scan', iface)
-    return jsonify({'devices': enriched_devices})
+    analytics = record_passive_observation_analytics(iface, enriched_devices, 'passive-scan')
+    return jsonify({'devices': enriched_devices, 'analytics': analytics})
 
+
+@app.route('/passive-analytics.json')
+def passive_analytics_route():
+    interface = request.args.get('selectedInterface') or request.args.get('interface')
+    return json_success(analytics=passive_observation_summary(interface))
 
 
 @app.route('/passive-monitor/status')

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from services import inventory as inventory_service
 from services import diagnostics as diagnostics_service
 from services import port_scans as port_scan_service
 from services import wireless_clients as wireless_client_service
+from services import persistence as persistence_service
 from scripts.interfaceTools import (
     get_bluetooth_devices,
     get_network_interfaces,
@@ -87,6 +88,72 @@ EVIDENCE_DIR = os.path.join(app.instance_path, 'evidence_vault')
 MAC_RE = re.compile(r'^([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}$')
 
 
+runtime_state_lock = threading.Lock()
+
+
+def runtime_state_snapshot():
+    """Build a durable snapshot of inventory/profile state worth keeping across restarts."""
+    with device_inventory_lock:
+        inventory = {key: dict(value) for key, value in device_inventory.items()}
+    with new_device_alerts_lock:
+        alerts = [dict(item) for item in new_device_alerts]
+    with evidence_vault_lock:
+        evidence = [dict(item) for item in evidence_vault]
+    with client_timelines_lock:
+        timelines = {key: [dict(item) for item in value] for key, value in client_timelines.items()}
+    return {
+        'device_inventory': inventory,
+        'new_device_alerts': alerts,
+        'evidence_vault': evidence,
+        'watched_clients': sorted(watched_clients),
+        'client_timelines': timelines,
+        'scheduled_client_checks': dict(scheduled_client_checks),
+        'wireless_network_client_cache': wireless_network_client_cache,
+        'wireless_network_labels': dict(wireless_network_labels),
+        'bluetooth_action_histories': bluetooth_action_histories,
+        'evil_twin_lab_runs': evil_twin_lab_runs,
+        'pineap_lab_runs': pineap_lab_runs,
+        'handshake_lab_records': handshake_lab_records,
+    }
+
+
+def save_runtime_state(reason='state-update'):
+    """Persist runtime state best-effort so scan profiles survive restarts."""
+    try:
+        with runtime_state_lock:
+            return persistence_service.save_state({'reason': reason, **runtime_state_snapshot()})
+    except OSError as exc:
+        app.logger.warning('Unable to persist runtime state after %s: %s', reason, exc)
+        return None
+
+
+def load_runtime_state():
+    """Load persisted runtime state into the in-memory stores on startup."""
+    state = persistence_service.load_state()
+    if not state:
+        return None
+    with device_inventory_lock:
+        device_inventory.update(state.get('device_inventory') or {})
+    with new_device_alerts_lock:
+        new_device_alerts.extend(state.get('new_device_alerts') or [])
+        del new_device_alerts[200:]
+    with evidence_vault_lock:
+        evidence_vault.extend(state.get('evidence_vault') or [])
+    with client_timelines_lock:
+        client_timelines.update(state.get('client_timelines') or {})
+    watched_clients.update(state.get('watched_clients') or [])
+    scheduled_client_checks.update(state.get('scheduled_client_checks') or {})
+    wireless_network_client_cache.update(state.get('wireless_network_client_cache') or {})
+    wireless_network_labels.update(state.get('wireless_network_labels') or {})
+    bluetooth_action_histories.update(state.get('bluetooth_action_histories') or {})
+    evil_twin_lab_runs.extend(state.get('evil_twin_lab_runs') or [])
+    pineap_lab_runs.extend(state.get('pineap_lab_runs') or [])
+    handshake_lab_records.extend(state.get('handshake_lab_records') or [])
+    return state
+
+
+load_runtime_state()
+
 
 ROADMAP_SECTIONS = [
     {
@@ -123,6 +190,7 @@ ROADMAP_SECTIONS = [
         'title': 'Network visibility',
         'items': [
             {'title': 'Device inventory page', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'The /inventory page aggregates discovered devices, sources, interfaces, manufacturers, and first/last seen timestamps.', 'description': 'Aggregate discovered IPs, MACs, manufacturers, ports, SSIDs, and first/last seen timestamps.'},
+            {'title': 'Persistent local inventory state', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Inventory devices, saved port profiles, client timelines, labels, watched clients, scheduled check plans, evidence, alerts, and lab records are now snapshotted to data/runtime_state.json and loaded on startup.', 'description': 'Persist device profiles, ports, labels, timelines, alerts, and evidence locally so large scans do not need to be rerun after restart.'},
             {'title': 'Comprehensive network device scan', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Network Scan now combines active ARP, passive observations, local ARP/neighbor tables, optional ping sweeps, mDNS, UPnP/SSDP, and LLDP/CDP metadata into one inventory-building workflow.', 'description': 'Scan local networks for devices using multiple discovery methods and merge results into inventory with source attribution.'},
             {'title': 'IP client profiles and watchlists', 'priority': 'High', 'priority_class': 'danger', 'status': 'Done', 'completed_note': 'Client pages now include health scoring, saved service history, web inspection, watch alerts, timeline events, owner/location/tags, baselines, drift checks, reachability history, and per-client JSON/Markdown exports.', 'description': 'Turn discovered IP clients into investigation profiles with health, ownership, baseline, watch, timeline, and export workflows.'},
             {'title': 'Network map', 'priority': 'Medium', 'priority_class': 'warning', 'description': 'Visualize adapters, SSIDs, access points, clients, and wired hosts as a simple topology map.'},
@@ -344,6 +412,7 @@ def record_evil_twin_lab_run(selected_interface, lab):
     with evil_twin_lab_lock:
         evil_twin_lab_runs.append(run)
         del evil_twin_lab_runs[:-25]
+    save_runtime_state('evil-twin-lab')
     app.logger.info(
         'Evil twin lab %s recorded for SSID %r BSSID %s channel %s on %s',
         run['action'], run['ssid'], run['bssid'], run['channel'], selected_interface,
@@ -420,6 +489,7 @@ def build_pineap_lab_result(selected_interface, lab):
     with pineap_lab_lock:
         pineap_lab_runs.insert(0, run)
         del pineap_lab_runs[100:]
+    save_runtime_state('pineap-lab')
     app.logger.info('PineAP-style lab %s recorded for SSID %r on %s', run['action'], run['ssid'], selected_interface)
     return run
 
@@ -491,6 +561,7 @@ def record_handshake_lab_evidence(selected_interface, lab, uploaded_file=None):
     with handshake_lab_lock:
         handshake_lab_records.insert(0, record)
         del handshake_lab_records[200:]
+    save_runtime_state('handshake-lab')
     app.logger.info('Handshake lab evidence %s cataloged for SSID %r BSSID %s', record['capture_type'], record['ssid'], record['bssid'])
     return record
 
@@ -783,6 +854,7 @@ def create_evidence_record(title, category='note', source=None, device=None, not
     with evidence_vault_lock:
         evidence_vault.insert(0, record)
         del evidence_vault[500:]
+    save_runtime_state('evidence')
     return dict(record)
 
 
@@ -1070,11 +1142,14 @@ def unread_alert_count():
         return len([alert for alert in new_device_alerts if not alert.get('read')])
 
 def record_inventory_devices(devices, source, interface=None):
-    return inventory_service.merge_devices(
+    merged = inventory_service.merge_devices(
         devices, source, interface, device_inventory, device_inventory_lock,
         normalize_mac, inventory_key, lookup_manufacturer,
         create_new_device_alert, create_grouped_device_alert,
     )
+    if merged:
+        save_runtime_state(f'inventory:{source}')
+    return merged
 
 
 def record_device_open_ports(host, port_details, source='port-scan'):
@@ -1090,6 +1165,7 @@ def record_device_open_ports(host, port_details, source='port-scan'):
             if key in device_inventory:
                 device_inventory[key]['device_role_guess'] = role_guess
                 updated = dict(device_inventory[key])
+        save_runtime_state(f'ports:{source}')
     return updated
 
 
@@ -1237,6 +1313,7 @@ def append_client_timeline_event(identifier, event_type, message, source=None):
     with client_timelines_lock:
         client_timelines.setdefault(key, []).insert(0, event)
         del client_timelines[key][50:]
+    save_runtime_state('client-timeline')
     return event
 
 
@@ -1586,6 +1663,7 @@ def save_scheduled_client_check(identifier, data):
     }
     scheduled_client_checks[target] = plan
     append_client_timeline_event(target, 'Scheduled checks updated', f"Scheduled {', '.join(checks)} every {interval} minute(s).", 'scheduled-checks')
+    save_runtime_state('scheduled-check')
     return dict(plan)
 
 
@@ -2872,9 +2950,11 @@ def watch_client(identifier):
     if watch:
         watched_clients.add(target)
         append_client_timeline_event(target, 'Watch enabled', 'This client will create alerts for notable profile changes.', 'client-watch')
+        save_runtime_state('client-watch')
         return json_success(watched=True, message='Client watch enabled.')
     watched_clients.discard(target)
     append_client_timeline_event(target, 'Watch disabled', 'Client watch notifications were disabled.', 'client-watch')
+    save_runtime_state('client-watch')
     return json_success(watched=False, message='Client watch disabled.')
 
 
@@ -3238,6 +3318,7 @@ def wireless_network_client_label_route():
         wireless_network_labels[key] = label
     else:
         wireless_network_labels.pop(key, None)
+    save_runtime_state('wireless-label')
     return json_success(label=label, message='Network client label saved.')
 
 

--- a/app.py
+++ b/app.py
@@ -25,12 +25,14 @@ from services import diagnostics as diagnostics_service
 from services import port_scans as port_scan_service
 from services import wireless_clients as wireless_client_service
 from services import persistence as persistence_service
+from services import oui as oui_service
 from scripts.interfaceTools import (
     get_bluetooth_devices,
     get_network_interfaces,
-    lookup_manufacturer,
     spoof_mac,
 )
+
+lookup_manufacturer = oui_service.lookup_manufacturer
 from scripts.bluetooth_phone import (
     BluetoothPhoneSettingsError,
     bluetooth_pairing_mode_capability,

--- a/app.py
+++ b/app.py
@@ -1873,7 +1873,7 @@ def sorted_network_clients(clients):
 def merge_wireless_network_clients(network):
     return wireless_client_service.merge_network_clients(
         network, wireless_network_client_cache, wireless_network_labels, normalize_mac,
-        inventory_records,
+        inventory_records, lookup_manufacturer,
     )
 
 

--- a/app.py
+++ b/app.py
@@ -2336,6 +2336,76 @@ def passive_observation_summary(interface=None, _locked=False):
             return build(interface, passive_observation_analytics.get(interface, {'interface': interface, 'devices': {}, 'history': []}))
         return {iface: build(iface, analytics) for iface, analytics in passive_observation_analytics.items()}
 
+
+def packet_passive_scan(interface, timeout=2, packet_limit=250):
+    """Capture passive packet metadata for devices visible on an interface.
+
+    This stores only endpoint metadata (MAC/IP/vendor/protocol), never packet
+    payloads. It is intentionally bounded by a short timeout and packet count so
+    live passive monitoring can run continuously without unbounded memory growth.
+    """
+    interface = (interface or '').strip()
+    if not interface:
+        raise ValueError('Missing interface')
+    timeout = max(1, min(parse_int(timeout, 'Capture window must be an integer'), 10))
+    packet_limit = max(25, min(parse_int(packet_limit, 'Packet limit must be an integer'), 1000))
+    try:
+        from scapy.all import ARP, Ether, IP, IPv6, sniff
+    except ImportError as exc:
+        raise RuntimeError('Live packet capture requires scapy to be installed') from exc
+
+    devices = {}
+
+    def remember(mac=None, ip=None, protocol=None):
+        mac = (mac or '').strip().lower()
+        ip = (ip or '').strip()
+        if not mac and not ip:
+            return
+        if mac in {'ff:ff:ff:ff:ff:ff', '00:00:00:00:00:00'}:
+            return
+        key = mac or ip
+        entry = devices.setdefault(key, {
+            'ip': ip or 'Unknown',
+            'mac': mac or 'Unknown',
+            'hostname': 'Unknown',
+            'manufacturer': lookup_manufacturer(mac) if mac else 'Unknown',
+            'source': 'packet-observation',
+            'protocols': [],
+        })
+        if ip and entry.get('ip') in {'Unknown', ''}:
+            entry['ip'] = ip
+        if mac and entry.get('mac') in {'Unknown', ''}:
+            entry['mac'] = mac
+            entry['manufacturer'] = lookup_manufacturer(mac)
+        if protocol and protocol not in entry['protocols']:
+            entry['protocols'].append(protocol)
+
+    def observe(packet):
+        try:
+            src_mac = packet[Ether].src if packet.haslayer(Ether) else None
+            if packet.haslayer(ARP):
+                arp = packet[ARP]
+                remember(arp.hwsrc, arp.psrc, 'arp')
+                remember(arp.hwdst, arp.pdst, 'arp')
+            elif packet.haslayer(IP):
+                remember(src_mac, packet[IP].src, 'ipv4')
+            elif packet.haslayer(IPv6):
+                remember(src_mac, packet[IPv6].src, 'ipv6')
+            elif src_mac:
+                remember(src_mac, None, 'ethernet')
+        except Exception:
+            return
+
+    capture_filter = 'arp or udp port 67 or udp port 68 or udp port 5353 or udp port 1900 or icmp6'
+    try:
+        sniff(iface=interface, store=False, prn=observe, timeout=timeout, count=packet_limit, filter=capture_filter)
+    except Exception as exc:
+        message = str(exc).lower()
+        if 'filter' not in message and 'libpcap' not in message and 'bpf' not in message:
+            raise
+        sniff(iface=interface, store=False, prn=observe, timeout=timeout, count=packet_limit)
+    return list(devices.values())
+
 def passive_monitor_snapshot(interface=None):
     """Return passive ARP-cache monitor state for one interface or all interfaces."""
     with passive_monitor_lock:
@@ -2346,17 +2416,25 @@ def passive_monitor_snapshot(interface=None):
 
 
 def _passive_monitor_worker(interface):
-    """Continuously refresh passive inventory from observed ARP-cache entries."""
+    """Continuously refresh passive inventory from cache or packet observations."""
     while True:
         with passive_monitor_lock:
             job = passive_monitor_jobs.get(interface)
             if not job or not job.get('enabled'):
                 return
             interval = job.get('interval', 10)
+            mode = job.get('mode', 'cache')
+        sleep_for = 0.1 if mode == 'packet' else interval
         try:
-            devices = classify_scan_results(passive_scan(interface), interface)
-            enriched = record_inventory_devices(devices, 'passive-monitor', interface)
-            analytics = record_passive_observation_analytics(interface, enriched, 'passive-monitor')
+            if mode == 'packet':
+                source = 'passive-packet-monitor'
+                raw_devices = packet_passive_scan(interface, timeout=interval, packet_limit=250)
+            else:
+                source = 'passive-monitor'
+                raw_devices = passive_scan(interface)
+            devices = classify_scan_results(raw_devices, interface)
+            enriched = record_inventory_devices(devices, source, interface)
+            analytics = record_passive_observation_analytics(interface, enriched, source)
             with passive_monitor_lock:
                 current = passive_monitor_jobs.get(interface)
                 if current:
@@ -2364,27 +2442,33 @@ def _passive_monitor_worker(interface):
                         'last_update': time.time(),
                         'last_count': len(enriched),
                         'analytics': analytics,
+                        'mode': mode,
                         'error': None,
                     })
         except Exception as exc:
             with passive_monitor_lock:
                 current = passive_monitor_jobs.get(interface)
                 if current:
-                    current.update({'last_update': time.time(), 'error': str(exc)})
-        time.sleep(interval)
+                    current.update({'last_update': time.time(), 'error': str(exc), 'mode': mode})
+        time.sleep(sleep_for)
 
 
-def set_passive_monitor(interface, enabled, interval=10):
+def set_passive_monitor(interface, enabled, interval=10, mode='cache'):
     """Start or stop a background passive monitor for an interface."""
     interface = (interface or '').strip()
     if not interface:
         raise ValueError('Missing interface')
-    interval = max(5, min(parse_int(interval, 'Interval must be an integer'), 300))
+    mode = 'packet' if str(mode or '').strip().lower() in {'packet', 'live', 'live-packet'} else 'cache'
+    if mode == 'packet':
+        interval = max(1, min(parse_int(interval, 'Capture window must be an integer'), 10))
+    else:
+        interval = max(5, min(parse_int(interval, 'Interval must be an integer'), 300))
     with passive_monitor_lock:
         job = passive_monitor_jobs.get(interface, {'interface': interface})
         job.update({
             'enabled': bool(enabled),
             'interval': interval,
+            'mode': mode,
             'updated_at': time.time(),
         })
         if enabled and not job.get('started_at'):
@@ -3350,7 +3434,7 @@ def passive_monitor_toggle_route():
     interface = data.get('selectedInterface') or data.get('interface')
     enabled = str(data.get('enabled') or '').strip().lower() in {'1', 'true', 'yes', 'on'}
     try:
-        status = set_passive_monitor(interface, enabled, data.get('interval') or 10)
+        status = set_passive_monitor(interface, enabled, data.get('interval') or 10, data.get('mode') or 'cache')
     except ValueError as exc:
         return json_error(str(exc))
     message = 'Continuous passive capture enabled.' if enabled else 'Continuous passive capture disabled.'

--- a/app.py
+++ b/app.py
@@ -3241,6 +3241,19 @@ def wireless_network_client_label_route():
     return json_success(label=label, message='Network client label saved.')
 
 
+@app.route('/wireless/network/clients.json')
+def wireless_network_clients_json():
+    """Return the persisted Wi-Fi network device list for in-page refreshes."""
+    from scripts.wifi import utils as wifi_utils
+    network = wifi_utils.get_network_detail(ssid=request.args.get('ssid'), bssid=request.args.get('bssid'), interface_name=request.args.get('interface'))
+    network = merge_wireless_network_clients(network)
+    return json_success(
+        clients=network.get('clients', []),
+        disappeared_clients=network.get('disappeared_clients', []),
+        client_count=network.get('client_count', 0),
+    )
+
+
 @app.route('/wireless/network/clients.csv')
 def wireless_network_clients_export():
     """Export the persisted Wi-Fi network device list as CSV."""

--- a/app.py
+++ b/app.py
@@ -11,7 +11,6 @@ import shutil
 import subprocess
 import csv
 import io
-import ipaddress
 import socket
 from urllib.parse import quote
 from urllib.request import Request, urlopen
@@ -26,6 +25,7 @@ from services import port_scans as port_scan_service
 from services import wireless_clients as wireless_client_service
 from services import persistence as persistence_service
 from services import oui as oui_service
+from services import labs as labs_service
 from scripts.interfaceTools import (
     get_bluetooth_devices,
     get_network_interfaces,
@@ -317,279 +317,6 @@ BLUETOOTHCTL_ACTIONS = {
     'remove': 'remove',
 }
 BLUETOOTH_MAC_RE = re.compile(r'^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$')
-
-DEAUTH_FRAME_LIMIT = 5
-BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
-EVIL_TWIN_MAX_DURATION_MINUTES = 30
-EVIL_TWIN_ACTIONS = {'plan', 'start', 'cleanup'}
-PINEAP_ACTIONS = {'recon', 'campaign', 'handshake', 'module'}
-PINEAP_MODULES = {'recon', 'evil-twin-lab', 'handshake-capture', 'portal-awareness', 'detection-report'}
-HANDSHAKE_CAPTURE_TYPES = {'wpa-handshake', 'pmkid'}
-
-
-def require_normalized_mac(value):
-    """Return a normalized MAC address or raise ValueError for required lab inputs."""
-    mac = normalize_mac(value)
-    if not mac:
-        raise ValueError('Enter a valid MAC address in the form aa:bb:cc:dd:ee:ff')
-    return mac
-
-
-def validate_lab_deauth_request(data):
-    """Validate bounded deauth lab inputs for an authorized classroom exercise."""
-    ap_mac = require_normalized_mac(data.get('ap'))
-    target_mac = require_normalized_mac(data.get('target') or BROADCAST_MAC)
-    if ap_mac == BROADCAST_MAC:
-        raise ValueError('AP MAC must be a specific lab access point, not broadcast')
-    if data.get('authorized') != 'on':
-        raise ValueError('Confirm this is an authorized isolated lab network before running deauth')
-    frames = parse_int(data.get('frames'), 'Frames must be an integer')
-    if frames < 1 or frames > DEAUTH_FRAME_LIMIT:
-        raise ValueError(f'Frames must be between 1 and {DEAUTH_FRAME_LIMIT} for first-year labs')
-    return ap_mac, target_mac, frames
-
-
-def validate_evil_twin_lab_request(data):
-    """Validate a controlled rogue-AP/captive-portal lab workflow request."""
-    action = (data.get('action') or 'plan').strip().lower()
-    if action not in EVIL_TWIN_ACTIONS:
-        raise ValueError('Choose plan, start, or cleanup for the lab workflow')
-    if data.get('authorized') != 'on':
-        raise ValueError('Confirm this is an authorized isolated lab before preparing an evil twin lab workflow')
-
-    ssid = (data.get('ssid') or '').strip()
-    if not ssid or len(ssid) > 32:
-        raise ValueError('Enter the exact lab SSID, up to 32 characters')
-
-    bssid = require_normalized_mac(data.get('bssid'))
-    channel = parse_int(data.get('channel'), 'Channel must be an integer')
-    if channel < 1 or channel > 196:
-        raise ValueError('Channel must be between 1 and 196')
-
-    duration = parse_int(data.get('durationMinutes') or '10', 'Duration must be an integer')
-    if duration < 1 or duration > EVIL_TWIN_MAX_DURATION_MINUTES:
-        raise ValueError(f'Duration must be between 1 and {EVIL_TWIN_MAX_DURATION_MINUTES} minutes')
-
-    portal_message = (data.get('portalMessage') or 'Training portal: do not enter real credentials.').strip()
-    if len(portal_message) > 200:
-        raise ValueError('Portal message must be 200 characters or fewer')
-
-    return {
-        'action': action,
-        'ssid': ssid,
-        'bssid': bssid,
-        'channel': channel,
-        'duration_minutes': duration,
-        'portal_message': portal_message,
-    }
-
-
-def build_evil_twin_lab_guidance(run):
-    """Return safe operator, cleanup, and defensive guidance for the lab."""
-    return {
-        'operator_steps': [
-            f"Verify the isolated lab AP broadcasting '{run['ssid']}' has BSSID {run['bssid']} on channel {run['channel']}.",
-            'Use a dedicated lab radio and avoid bridging the portal to production networks.',
-            'Display only the training message; do not request, collect, or store credentials.',
-            f"Stop the workflow within {run['duration_minutes']} minutes and confirm clients reconnect to the legitimate lab AP.",
-        ],
-        'cleanup_steps': [
-            'Stop hostapd/dnsmasq or any lab AP service started outside Mobile Router.',
-            'Remove temporary DHCP/DNS/portal configuration files for this SSID.',
-            'Restore interface mode, channel, IP addressing, forwarding, and firewall rules.',
-            'Record the cleanup result in the lab log and evidence notes.',
-        ],
-        'detection_guidance': [
-            'Alert on duplicate SSIDs with a new BSSID, mismatched channel, or weaker security than baseline.',
-            'Compare beacon RSN/capability fields and vendor OUIs against the approved AP inventory.',
-            'Watch DHCP/DNS gateway changes and captive-portal redirects from unknown MAC addresses.',
-            'Train users to report unexpected portal prompts and never enter real credentials in drills.',
-        ],
-    }
-
-
-def record_evil_twin_lab_run(selected_interface, lab):
-    """Record a non-credential evil-twin/captive-portal lab workflow event."""
-    run = {
-        'id': uuid.uuid4().hex,
-        'created_at': time.time(),
-        'interface': selected_interface,
-        **lab,
-    }
-    run.update(build_evil_twin_lab_guidance(run))
-    with evil_twin_lab_lock:
-        evil_twin_lab_runs.append(run)
-        del evil_twin_lab_runs[:-25]
-    save_runtime_state('evil-twin-lab')
-    app.logger.info(
-        'Evil twin lab %s recorded for SSID %r BSSID %s channel %s on %s',
-        run['action'], run['ssid'], run['bssid'], run['channel'], selected_interface,
-    )
-    return run
-
-
-def _split_module_ids(value):
-    modules = []
-    for item in re.split(r'[,\s]+', value or ''):
-        item = item.strip().lower()
-        if item:
-            modules.append(item)
-    return modules
-
-
-def validate_pineap_lab_request(data):
-    """Validate a WiFi Pineapple-style lab controller request."""
-    if data.get('authorized') != 'on':
-        raise ValueError('Confirm this is an authorized isolated lab before running a campaign workflow')
-    action = (data.get('action') or 'recon').strip().lower()
-    if action not in PINEAP_ACTIONS:
-        raise ValueError('Choose recon, campaign, handshake, or module')
-    ssid = (data.get('ssid') or '').strip()
-    if ssid and len(ssid) > 32:
-        raise ValueError('SSID must be 32 characters or fewer')
-    bssid = require_normalized_mac(data.get('bssid')) if data.get('bssid') else None
-    channel = None
-    if data.get('channel'):
-        channel = parse_int(data.get('channel'), 'Channel must be an integer')
-        if channel < 1 or channel > 196:
-            raise ValueError('Channel must be between 1 and 196')
-    modules = _split_module_ids(data.get('modules') or 'recon,detection-report')
-    unknown = [module for module in modules if module not in PINEAP_MODULES]
-    if unknown:
-        raise ValueError(f"Unknown lab module: {', '.join(unknown)}")
-    if action in {'campaign', 'handshake', 'module'} and not ssid:
-        raise ValueError('Enter an explicit lab SSID for campaign, handshake, or module workflows')
-    return {
-        'action': action,
-        'ssid': ssid,
-        'bssid': bssid,
-        'channel': channel,
-        'modules': modules,
-        'notes': (data.get('notes') or '').strip()[:500],
-    }
-
-
-def build_pineap_lab_result(selected_interface, lab):
-    """Build an auditable, non-destructive PineAP-style lab result."""
-    recon = []
-    if lab['action'] == 'recon':
-        from scripts.wifi import utils as wifi_utils
-        wifi_utils.scan_networks(selected_interface)
-        recon = wifi_utils.get_networks_summary()
-    run = {
-        'id': uuid.uuid4().hex,
-        'created_at': time.time(),
-        'interface': selected_interface,
-        **lab,
-        'recon': recon,
-        'campaign_steps': [
-            'Recon: inventory authorized lab SSIDs, BSSIDs, channels, security, and WPS exposure.',
-            'Campaign: select only approved training modules and log operator intent before execution.',
-            'Handshake: capture or upload WPA/WPA2 handshake or PMKID evidence without password cracking.',
-            'Report: export findings, cleanup actions, and detection opportunities for defenders.',
-        ],
-        'module_status': [
-            {'id': module, 'status': 'queued' if lab['action'] != 'recon' else 'available'}
-            for module in lab['modules']
-        ],
-        'safety': 'This controller records authorized lab workflow state and recon output; it does not collect credentials or run cracking jobs.',
-    }
-    with pineap_lab_lock:
-        pineap_lab_runs.insert(0, run)
-        del pineap_lab_runs[100:]
-    save_runtime_state('pineap-lab')
-    app.logger.info('PineAP-style lab %s recorded for SSID %r on %s', run['action'], run['ssid'], selected_interface)
-    return run
-
-
-def validate_handshake_lab_request(data):
-    """Validate handshake/PMKID evidence catalog inputs."""
-    if data.get('authorized') != 'on':
-        raise ValueError('Confirm this is an authorized isolated lab before cataloging handshake evidence')
-    ssid = (data.get('ssid') or '').strip()
-    if not ssid or len(ssid) > 32:
-        raise ValueError('Enter the exact lab SSID, up to 32 characters')
-    bssid = require_normalized_mac(data.get('bssid'))
-    channel = parse_int(data.get('channel'), 'Channel must be an integer')
-    if channel < 1 or channel > 196:
-        raise ValueError('Channel must be between 1 and 196')
-    capture_type = (data.get('captureType') or 'wpa-handshake').strip().lower()
-    if capture_type not in HANDSHAKE_CAPTURE_TYPES:
-        raise ValueError('Capture type must be WPA handshake or PMKID')
-    return {
-        'ssid': ssid,
-        'bssid': bssid,
-        'channel': channel,
-        'capture_type': capture_type,
-        'client': normalize_mac(data.get('client')) if data.get('client') else '',
-        'validation_notes': (data.get('validationNotes') or '').strip()[:500],
-    }
-
-
-def validate_handshake_evidence(record, uploaded_file=None):
-    """Attach lightweight validation status for uploaded WPA/PMKID evidence."""
-    file_name = uploaded_file.filename if uploaded_file and uploaded_file.filename else ''
-    extension = os.path.splitext(file_name.lower())[1]
-    accepted = {'.cap', '.pcap', '.pcapng', '.hc22000', '.hccapx'}
-    checks = [
-        'SSID/BSSID/channel are explicitly scoped to the authorized lab target.',
-        'Evidence is cataloged for validation/export only; password cracking is out of scope.',
-    ]
-    if file_name:
-        checks.append('Uploaded capture extension is recognized.' if extension in accepted else 'Uploaded capture extension is unusual; verify manually.')
-    else:
-        checks.append('No capture uploaded yet; record is ready for later evidence attachment.')
-    status = 'needs-review' if file_name and extension not in accepted else 'cataloged'
-    return {'validation_status': status, 'validation_checks': checks}
-
-
-def record_handshake_lab_evidence(selected_interface, lab, uploaded_file=None):
-    """Catalog handshake/PMKID lab evidence and mirror it into the evidence vault."""
-    validation = validate_handshake_evidence(lab, uploaded_file=uploaded_file)
-    evidence = create_evidence_record(
-        f"{lab['capture_type'].upper()} evidence for {lab['ssid']}",
-        category='capture',
-        source='WPA handshake capture lab',
-        device=lab['bssid'],
-        notes=lab['validation_notes'],
-        content='\n'.join(validation['validation_checks']),
-        uploaded_file=uploaded_file,
-    )
-    record = {
-        'id': uuid.uuid4().hex,
-        'created_at': time.time(),
-        'interface': selected_interface,
-        **lab,
-        **validation,
-        'evidence_id': evidence['id'],
-        'download_url': evidence.get('download_url'),
-        'file_name': evidence.get('file_name'),
-        'file_size': evidence.get('file_size'),
-    }
-    with handshake_lab_lock:
-        handshake_lab_records.insert(0, record)
-        del handshake_lab_records[200:]
-    save_runtime_state('handshake-lab')
-    app.logger.info('Handshake lab evidence %s cataloged for SSID %r BSSID %s', record['capture_type'], record['ssid'], record['bssid'])
-    return record
-
-
-def handshake_lab_export_records():
-    with handshake_lab_lock:
-        records = [dict(item) for item in handshake_lab_records]
-    for item in records:
-        item['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('created_at', 0)))
-    return records
-
-
-def handshake_records_as_csv(records):
-    output = io.StringIO()
-    writer = csv.writer(output)
-    writer.writerow(['SSID', 'BSSID', 'Channel', 'Type', 'Client', 'Status', 'File', 'Created'])
-    for item in records:
-        writer.writerow([item.get('ssid'), item.get('bssid'), item.get('channel'), item.get('capture_type'), item.get('client'), item.get('validation_status'), item.get('file_name'), item.get('created_at_label')])
-    return output.getvalue()
-
 
 class BluetoothToolUnavailable(RuntimeError):
     """Raised when host-local Bluetooth actions cannot be executed."""
@@ -3918,7 +3645,7 @@ def deauth_route():
         return json_error('Missing required parameters')
 
     try:
-        ap_mac, target_mac, frames = validate_lab_deauth_request(data)
+        ap_mac, target_mac, frames = labs_service.validate_deauth_request(data, normalize_mac, parse_int)
     except ValueError as e:
         return json_error(str(e))
 
@@ -3939,8 +3666,8 @@ def evil_twin_lab_route():
         return json_error('Missing required parameters')
 
     try:
-        lab = validate_evil_twin_lab_request(data)
-        run = record_evil_twin_lab_run(selected_interface, lab)
+        lab = labs_service.validate_evil_twin_request(data, normalize_mac, parse_int)
+        run = labs_service.record_evil_twin_run(selected_interface, lab, evil_twin_lab_runs, evil_twin_lab_lock, save_runtime_state, app.logger)
     except ValueError as e:
         return json_error(str(e))
 
@@ -3959,8 +3686,9 @@ def pineap_lab_route():
     if missing_fields(data, 'selectedInterface'):
         return json_error('Missing required parameters')
     try:
-        lab = validate_pineap_lab_request(data)
-        run = build_pineap_lab_result(selected_interface, lab)
+        lab = labs_service.validate_pineap_request(data, normalize_mac, parse_int)
+        from scripts.wifi import utils as wifi_utils
+        run = labs_service.build_pineap_result(selected_interface, lab, pineap_lab_runs, pineap_lab_lock, save_runtime_state, app.logger, wifi_utils)
     except ValueError as e:
         return json_error(str(e))
     except Exception as e:
@@ -3975,8 +3703,8 @@ def handshake_lab_route():
     if missing_fields(data, 'selectedInterface', 'ssid', 'bssid', 'channel'):
         return json_error('Missing required parameters')
     try:
-        lab = validate_handshake_lab_request(data)
-        record = record_handshake_lab_evidence(selected_interface, lab, request.files.get('capture'))
+        lab = labs_service.validate_handshake_request(data, normalize_mac, parse_int)
+        record = labs_service.record_handshake_evidence(selected_interface, lab, request.files.get('capture'), create_evidence_record, handshake_lab_records, handshake_lab_lock, save_runtime_state, app.logger)
     except ValueError as e:
         return json_error(str(e))
     return json_success(message='Cataloged WPA handshake/PMKID lab evidence for validation and export.', record=record)
@@ -3984,11 +3712,11 @@ def handshake_lab_route():
 
 @app.route('/handshake-lab.<fmt>')
 def export_handshake_lab(fmt):
-    records = handshake_lab_export_records()
+    records = labs_service.export_handshake_records(handshake_lab_records, handshake_lab_lock)
     if fmt == 'json':
         return jsonify({'handshakes': records, 'exported_at': time.time()})
     if fmt == 'csv':
-        return Response(handshake_records_as_csv(records), mimetype='text/csv', headers={'Content-Disposition': 'attachment; filename=handshake-lab.csv'})
+        return Response(labs_service.handshake_records_csv(records), mimetype='text/csv', headers={'Content-Disposition': 'attachment; filename=handshake-lab.csv'})
     return json_error('Unsupported handshake export format', 404)
 
 

--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ from scripts.logging_config import configure_logging
 from scripts.networkScan import (
     active_scan,
     passive_scan,
+    packet_passive_scan,
     classify_scan_results,
     get_mac_by_ip,
     get_ip_by_mac,
@@ -1943,13 +1944,6 @@ def parse_int(value, error_message):
         raise ValueError(error_message) from exc
 
 
-def _ping_command(host, count=4, timeout=2):
-    return diagnostics_service.ping_command(host, count=count, timeout=timeout, os_name=os.name)
-
-
-def _parse_ping_output(output):
-    return diagnostics_service.parse_ping_output(output)
-
 
 def run_ping_check(host, count=4, timeout=2):
     return diagnostics_service.run_ping_check(host, count, timeout, parse_int, subprocess, ping_history)
@@ -1966,9 +1960,6 @@ def _run_text_command(command, timeout=5):
         return {'command': command, 'returncode': 1, 'output': str(exc)}
     return {'command': command, 'returncode': result.returncode, 'output': (result.stdout or result.stderr or '').strip()}
 
-
-def _parse_route_lines(output):
-    return diagnostics_service.parse_route_lines(output)
 
 
 def build_route_diagnostics(target=None):
@@ -2337,75 +2328,6 @@ def passive_observation_summary(interface=None, _locked=False):
         return {iface: build(iface, analytics) for iface, analytics in passive_observation_analytics.items()}
 
 
-def packet_passive_scan(interface, timeout=2, packet_limit=250):
-    """Capture passive packet metadata for devices visible on an interface.
-
-    This stores only endpoint metadata (MAC/IP/vendor/protocol), never packet
-    payloads. It is intentionally bounded by a short timeout and packet count so
-    live passive monitoring can run continuously without unbounded memory growth.
-    """
-    interface = (interface or '').strip()
-    if not interface:
-        raise ValueError('Missing interface')
-    timeout = max(1, min(parse_int(timeout, 'Capture window must be an integer'), 10))
-    packet_limit = max(25, min(parse_int(packet_limit, 'Packet limit must be an integer'), 1000))
-    try:
-        from scapy.all import ARP, Ether, IP, IPv6, sniff
-    except ImportError as exc:
-        raise RuntimeError('Live packet capture requires scapy to be installed') from exc
-
-    devices = {}
-
-    def remember(mac=None, ip=None, protocol=None):
-        mac = (mac or '').strip().lower()
-        ip = (ip or '').strip()
-        if not mac and not ip:
-            return
-        if mac in {'ff:ff:ff:ff:ff:ff', '00:00:00:00:00:00'}:
-            return
-        key = mac or ip
-        entry = devices.setdefault(key, {
-            'ip': ip or 'Unknown',
-            'mac': mac or 'Unknown',
-            'hostname': 'Unknown',
-            'manufacturer': lookup_manufacturer(mac) if mac else 'Unknown',
-            'source': 'packet-observation',
-            'protocols': [],
-        })
-        if ip and entry.get('ip') in {'Unknown', ''}:
-            entry['ip'] = ip
-        if mac and entry.get('mac') in {'Unknown', ''}:
-            entry['mac'] = mac
-            entry['manufacturer'] = lookup_manufacturer(mac)
-        if protocol and protocol not in entry['protocols']:
-            entry['protocols'].append(protocol)
-
-    def observe(packet):
-        try:
-            src_mac = packet[Ether].src if packet.haslayer(Ether) else None
-            if packet.haslayer(ARP):
-                arp = packet[ARP]
-                remember(arp.hwsrc, arp.psrc, 'arp')
-                remember(arp.hwdst, arp.pdst, 'arp')
-            elif packet.haslayer(IP):
-                remember(src_mac, packet[IP].src, 'ipv4')
-            elif packet.haslayer(IPv6):
-                remember(src_mac, packet[IPv6].src, 'ipv6')
-            elif src_mac:
-                remember(src_mac, None, 'ethernet')
-        except Exception:
-            return
-
-    capture_filter = 'arp or udp port 67 or udp port 68 or udp port 5353 or udp port 1900 or icmp6'
-    try:
-        sniff(iface=interface, store=False, prn=observe, timeout=timeout, count=packet_limit, filter=capture_filter)
-    except Exception as exc:
-        message = str(exc).lower()
-        if 'filter' not in message and 'libpcap' not in message and 'bpf' not in message:
-            raise
-        sniff(iface=interface, store=False, prn=observe, timeout=timeout, count=packet_limit)
-    return list(devices.values())
-
 def passive_monitor_snapshot(interface=None):
     """Return passive ARP-cache monitor state for one interface or all interfaces."""
     with passive_monitor_lock:
@@ -2428,7 +2350,7 @@ def _passive_monitor_worker(interface):
         try:
             if mode == 'packet':
                 source = 'passive-packet-monitor'
-                raw_devices = packet_passive_scan(interface, timeout=interval, packet_limit=250)
+                raw_devices = packet_passive_scan(interface, timeout=interval, packet_limit=250, manufacturer_lookup=lookup_manufacturer)
             else:
                 source = 'passive-monitor'
                 raw_devices = passive_scan(interface)

--- a/app.py
+++ b/app.py
@@ -1880,6 +1880,28 @@ def merge_wireless_network_clients(network):
     )
 
 
+def record_scan_devices_for_wireless_network(interface, ssid, bssid, devices):
+    """Scope scan-discovered devices to an explicit Wi-Fi network page."""
+    if not interface or not (ssid or bssid):
+        return []
+    scoped_clients = [
+        {**dict(device), 'network_scan_scoped': True}
+        for device in (devices or [])
+        if not device.get('is_control_traffic') and (device.get('ip') or device.get('mac'))
+    ]
+    if not scoped_clients:
+        return []
+    network = {
+        'interface': interface,
+        'ssid': ssid,
+        'bssid': bssid,
+        'clients': scoped_clients,
+    }
+    merged = merge_wireless_network_clients(network)
+    save_runtime_state('wireless-scan-clients')
+    return merged.get('clients', [])
+
+
 def inventory_export_payload(records=None):
     records = records if records is not None else inventory_records()
     return inventory_service.export_payload(records)
@@ -3289,7 +3311,10 @@ def active_scan_route():
         return json_error('Missing interface')
     hosts = classify_scan_results(active_scan(iface), iface)
     enriched_hosts = record_inventory_devices(hosts, 'active-scan', iface)
-    return jsonify({'hosts': enriched_hosts})
+    network_clients = record_scan_devices_for_wireless_network(
+        iface, request.form.get('ssid'), request.form.get('bssid'), enriched_hosts,
+    )
+    return jsonify({'hosts': enriched_hosts, 'network_clients': network_clients})
 
 
 @app.route('/passive-scan', methods=['POST'])
@@ -3300,7 +3325,10 @@ def passive_scan_route():
     devices = classify_scan_results(passive_scan(iface), iface)
     enriched_devices = record_inventory_devices(devices, 'passive-scan', iface)
     analytics = record_passive_observation_analytics(iface, enriched_devices, 'passive-scan')
-    return jsonify({'devices': enriched_devices, 'analytics': analytics})
+    network_clients = record_scan_devices_for_wireless_network(
+        iface, request.form.get('ssid'), request.form.get('bssid'), enriched_devices,
+    )
+    return jsonify({'devices': enriched_devices, 'analytics': analytics, 'network_clients': network_clients})
 
 
 @app.route('/passive-analytics.json')
@@ -3332,11 +3360,15 @@ def passive_monitor_toggle_route():
 @app.route('/comprehensive-scan', methods=['POST'])
 def comprehensive_scan_route():
     try:
+        selected_interface = request.form.get('selectedInterface')
         result = comprehensive_network_device_scan(
-            request.form.get('selectedInterface'),
+            selected_interface,
             include_passive=request.form.get('includePassive', 'on') == 'on',
             include_services=request.form.get('includeServices', 'on') == 'on',
             sweep_cidr=(request.form.get('sweepCidr') or '').strip() or None,
+        )
+        result['network_clients'] = record_scan_devices_for_wireless_network(
+            selected_interface, request.form.get('ssid'), request.form.get('bssid'), result.get('devices', []),
         )
     except ValueError as e:
         return json_error(str(e))

--- a/oui/oui_db.csv
+++ b/oui/oui_db.csv
@@ -51,3 +51,4 @@ F0:9F:C2,Google Nest
 00:90:4C,Sun Microsystems
 A0:20:A6,Hikvision
 EC:71:DB,Nothing Technology
+8C:49:62,Roku, Inc.

--- a/routes/capabilities.py
+++ b/routes/capabilities.py
@@ -1,7 +1,7 @@
 from flask import Blueprint, jsonify, render_template, request
 
 from scripts.capabilities import build_capabilities, install_host_dependency, install_optional_package
-from scripts.interfaceTools import refresh_oui_database
+from services.oui import refresh_oui_database
 from scripts.update_oui_db import download_oui_database
 
 

--- a/routes/capabilities.py
+++ b/routes/capabilities.py
@@ -1,6 +1,8 @@
 from flask import Blueprint, jsonify, render_template, request
 
 from scripts.capabilities import build_capabilities, install_host_dependency, install_optional_package
+from scripts.interfaceTools import refresh_oui_database
+from scripts.update_oui_db import download_oui_database
 
 
 def create_capabilities_blueprint(context_provider):
@@ -31,6 +33,26 @@ def create_capabilities_blueprint(context_provider):
             return jsonify({'status': 'success', **result})
         except ValueError as e:
             return jsonify({'status': 'error', 'message': str(e)}), 400
+        except Exception as e:
+            return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+    @blueprint.route('/capabilities/update-oui-database', methods=['POST'])
+    def update_oui_database_route():
+        confirm = request.form.get('confirm') == 'download'
+        if not confirm:
+            return jsonify({'status': 'error', 'message': 'Confirm full IEEE OUI database download before continuing.'}), 400
+
+        try:
+            path, count = download_oui_database()
+            oui_status = refresh_oui_database()
+            return jsonify({
+                'status': 'success',
+                'message': f'Downloaded {count} OUI entries.',
+                'path': path,
+                'count': count,
+                'oui_database': oui_status,
+            })
         except Exception as e:
             return jsonify({'status': 'error', 'message': str(e)}), 500
 

--- a/routes/capabilities.py
+++ b/routes/capabilities.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, jsonify, render_template, request
 
-from scripts.capabilities import build_capabilities, install_optional_package
+from scripts.capabilities import build_capabilities, install_host_dependency, install_optional_package
 
 
 def create_capabilities_blueprint(context_provider):
@@ -28,6 +28,24 @@ def create_capabilities_blueprint(context_provider):
 
         try:
             result = install_optional_package(package)
+            return jsonify({'status': 'success', **result})
+        except ValueError as e:
+            return jsonify({'status': 'error', 'message': str(e)}), 400
+        except Exception as e:
+            return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+    @blueprint.route('/capabilities/install-host-dependency', methods=['POST'])
+    def install_host_dependency_route():
+        dependency = request.form.get('dependency')
+        confirm = request.form.get('confirm') == 'install'
+        if not dependency:
+            return jsonify({'status': 'error', 'message': 'Missing dependency'}), 400
+        if not confirm:
+            return jsonify({'status': 'error', 'message': 'Confirm host package installation before continuing.'}), 400
+
+        try:
+            result = install_host_dependency(dependency)
             return jsonify({'status': 'success', **result})
         except ValueError as e:
             return jsonify({'status': 'error', 'message': str(e)}), 400

--- a/scripts/capabilities.py
+++ b/scripts/capabilities.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 from typing import Dict, List
 
-from scripts.interfaceTools import oui_database_status
+from services.oui import oui_database_status
 
 CORE_COMMANDS = ["ip", "ifconfig", "ipconfig", "arp", "ping", "traceroute", "tracepath", "tracert"]
 OPTIONAL_COMMANDS = ["iw", "nmcli", "netsh", "aireplay-ng", "rfkill", "hciconfig", "bluetoothctl", "busctl", "powershell", "pwsh", "wkhtmltoimage", "chromium", "chromium-browser", "google-chrome"]

--- a/scripts/capabilities.py
+++ b/scripts/capabilities.py
@@ -1,12 +1,15 @@
 import importlib.util
+import os
 import platform
 import shutil
 import subprocess
 import sys
 from typing import Dict, List
 
+from scripts.interfaceTools import oui_database_status
+
 CORE_COMMANDS = ["ip", "ifconfig", "ipconfig", "arp", "ping", "traceroute", "tracepath", "tracert"]
-OPTIONAL_COMMANDS = ["iw", "nmcli", "netsh", "aireplay-ng", "rfkill", "hciconfig", "bluetoothctl", "busctl", "powershell", "pwsh"]
+OPTIONAL_COMMANDS = ["iw", "nmcli", "netsh", "aireplay-ng", "rfkill", "hciconfig", "bluetoothctl", "busctl", "powershell", "pwsh", "wkhtmltoimage", "chromium", "chromium-browser", "google-chrome"]
 REQUIRED_PACKAGE_SPECS = {
     "blinker": "blinker==1.8.2",
     "click": "click==8.1.7",
@@ -48,6 +51,15 @@ CENTRAL_CAPABILITY_REGISTRY = [
         "description": "List local network adapters, addresses, status, and manufacturer metadata.",
         "feature": "Interface inventory",
         "commands": ["ip", "ifconfig", "ipconfig"],
+        "packages": [],
+    },
+    {
+        "id": "oui-vendor-lookup",
+        "name": "OUI vendor lookup",
+        "category": "Discovery",
+        "description": "Resolve MAC/BSSID prefixes to vendors using the bundled database with built-in fallbacks.",
+        "feature": "OUI vendor lookup",
+        "commands": [],
         "packages": [],
     },
     {
@@ -179,6 +191,7 @@ def _display_feature_names(system):
         "Minecraft status lab",
         "Minecraft mob toggles",
         "Interface inventory",
+        "OUI vendor lookup",
         "Passive ARP scan",
         "Active ping scan",
         "Traceroute",
@@ -223,6 +236,10 @@ def _bluetooth_actions_available(commands):
     return bool(busctl.get("available") and _busctl_bluez_available(busctl.get("path")))
 
 
+def _browser_screenshot_available(commands):
+    return any(commands.get(name, {}).get("available") for name in ("wkhtmltoimage", "chromium", "chromium-browser", "google-chrome"))
+
+
 def _host_dependencies(system, commands):
     if system != "Linux":
         return []
@@ -230,12 +247,65 @@ def _host_dependencies(system, commands):
     bluetooth_actions_available = _bluetooth_actions_available(commands)
     return [
         {
+            "id": "bluez",
             "name": "BlueZ Bluetooth actions",
             "available": bluetooth_actions_available,
             "details": "Required for Bluetooth device action buttons such as info, connect, disconnect, pair, trust, block, and remove.",
             "install_hint": "Install the distro BlueZ package, then start/enable the bluetooth service. Debian/Ubuntu: sudo apt install bluez && sudo systemctl enable --now bluetooth. Alpine/OpenWrt-style systems may use bluez, bluez-utils, or bluez-daemon packages.",
-        }
+            "install_action": False,
+        },
+        {
+            "id": "browser-screenshot",
+            "name": "Browser screenshot tooling",
+            "available": _browser_screenshot_available(commands),
+            "details": "Enables HTTP service preview thumbnails for long-hover web-port cards and saved service pages.",
+            "install_hint": "Install one of: chromium, chromium-browser, google-chrome, or wkhtmltoimage. Debian/Ubuntu: sudo apt install chromium (or wkhtmltopdf for wkhtmltoimage).",
+            "install_action": True,
+        },
     ]
+
+
+def _privilege_prefix():
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        return []
+    sudo = shutil.which("sudo")
+    return [sudo, "-n"] if sudo else []
+
+
+def browser_screenshot_install_plan():
+    """Return package-manager commands to install browser screenshot tooling."""
+    prefix = _privilege_prefix()
+    if shutil.which("apt-get"):
+        return [prefix + ["apt-get", "update"], prefix + ["apt-get", "install", "-y", "chromium"]]
+    if shutil.which("apk"):
+        return [prefix + ["apk", "add", "--no-cache", "chromium"]]
+    if shutil.which("dnf"):
+        return [prefix + ["dnf", "install", "-y", "chromium"]]
+    if shutil.which("yum"):
+        return [prefix + ["yum", "install", "-y", "chromium"]]
+    if shutil.which("pacman"):
+        return [prefix + ["pacman", "-Sy", "--noconfirm", "chromium"]]
+    raise RuntimeError("No supported package manager found. Install chromium, chromium-browser, google-chrome, or wkhtmltoimage manually.")
+
+
+def install_host_dependency(dependency_id):
+    """Install an approved host dependency using the local package manager."""
+    if dependency_id != "browser-screenshot":
+        raise ValueError(f"Unsupported host dependency: {dependency_id}")
+    if _browser_screenshot_available(command_status(["wkhtmltoimage", "chromium", "chromium-browser", "google-chrome"])):
+        return {"dependency": dependency_id, "installed": True, "message": "Browser screenshot tooling is already available.", "commands": []}
+    commands = browser_screenshot_install_plan()
+    outputs = []
+    for command in commands:
+        if not command or command[0] is None:
+            raise RuntimeError("Unable to build an install command for this host.")
+        result = subprocess.run(command, capture_output=True, text=True, timeout=600, check=False)
+        outputs.append({"command": " ".join(command), "returncode": result.returncode, "stdout": result.stdout[-2000:], "stderr": result.stderr[-2000:]})
+        if result.returncode != 0:
+            message = result.stderr.strip() or result.stdout.strip() or "Host dependency install failed"
+            raise RuntimeError(message)
+    installed = _browser_screenshot_available(command_status(["wkhtmltoimage", "chromium", "chromium-browser", "google-chrome"]))
+    return {"dependency": dependency_id, "installed": installed, "message": "Browser screenshot tooling installed." if installed else "Install command completed but tooling was not found on PATH.", "commands": outputs}
 
 
 def _install_python_package(package, specs):
@@ -313,11 +383,14 @@ def build_capabilities() -> Dict[str, object]:
         or (system == "Linux" and (_available(commands, "nmcli", "iw") or packages["scapy"]))
     )
 
+    oui_status = oui_database_status()
+
     features = {
         "Core web UI": True,
         "Minecraft status lab": True,
         "Minecraft mob toggles": True,
         "Interface inventory": bool(commands.get("ip", {}).get("available") or commands.get("ifconfig", {}).get("available") or commands.get("ipconfig", {}).get("available") or system == "Windows"),
+        "OUI vendor lookup": bool(oui_status.get("loaded")),
         "Passive ARP scan": bool(commands.get("arp", {}).get("available") or system == "Linux"),
         "Active ping scan": bool(commands.get("ping", {}).get("available")),
         "Traceroute": bool(commands.get("traceroute", {}).get("available") or commands.get("tracepath", {}).get("available") or commands.get("tracert", {}).get("available")),
@@ -341,6 +414,7 @@ def build_capabilities() -> Dict[str, object]:
         "Aireplay deauth": "Requires the external aireplay-ng command from aircrack-ng.",
         "Reports": "Exports the current in-memory runtime state; restart-persistent storage is not required.",
         "New device alerts": "Alerts are generated for newly recorded non-control inventory devices.",
+        "OUI vendor lookup": "Uses oui/oui_db.csv when available and a built-in fallback set for common lab, router, and virtual-device prefixes.",
     }
 
     display_command_names = _display_command_names(system)
@@ -373,4 +447,5 @@ def build_capabilities() -> Dict[str, object]:
         "feature_notes": feature_notes,
         "registry": registry,
         "display_registry": registry,
+        "oui_database": oui_status,
     }

--- a/scripts/interfaceTools.py
+++ b/scripts/interfaceTools.py
@@ -17,6 +17,28 @@ BASE_DIR = os.path.dirname(os.path.dirname(__file__))
 PARENT_DIR = os.path.dirname(BASE_DIR)
 GRANDPARENT_DIR = os.path.dirname(PARENT_DIR)
 
+# Built-in safety net for common lab/router/virtual-device OUIs. The local
+# database loaded from oui/oui_db.csv (or a refreshed IEEE export) is still the
+# primary source, but keeping a tiny fallback prevents core demos/tests from
+# silently losing vendor context if that file is missing or malformed.
+FALLBACK_OUI_DB = {
+    '00:0c:29': 'VMware',
+    '00:15:5d': 'Microsoft',
+    '00:50:56': 'VMware',
+    '08:00:27': 'PCS Systemtechnik GmbH',
+    '18:69:d8': 'TP-LINK Technologies',
+    '34:ab:37': 'Google',
+    '40:16:3b': 'Cisco Systems',
+    '52:54:00': 'QEMU/KVM Virtual NIC',
+    '74:ea:3a': 'Apple',
+    '90:9a:4a': 'Ubiquiti Networks',
+    '9c:2a:70': 'MikroTik',
+    'a8:b1:3b': 'Netgear',
+    'b8:27:eb': 'Raspberry Pi Foundation',
+    'bc:92:6b': 'Amazon Technologies',
+    'e8:2a:ea': 'Ubiquiti Networks',
+}
+
 # Try locating the OUI database inside the project directory or one of the
 # parent directories. This allows keeping the file outside the repository if
 # desired.
@@ -39,14 +61,15 @@ def _normalize_oui_prefix(prefix):
 
 
 def _load_oui_db():
-    """Load the local OUI database if available.
+    """Load OUI mappings from the bundled/found database plus fallbacks.
 
     Supports the compact project format (prefix,vendor) and the IEEE CSV
-    format downloaded by scripts/update_oui_db.py.
+    format downloaded by scripts/update_oui_db.py. Malformed rows are skipped so
+    one bad line does not disable all vendor lookups.
     """
-    db = {}
+    db = dict(FALLBACK_OUI_DB)
     if OUI_DB_PATH and os.path.exists(OUI_DB_PATH):
-        with open(OUI_DB_PATH, encoding='utf-8') as f:
+        with open(OUI_DB_PATH, encoding='utf-8-sig') as f:
             header = f.readline().strip().split(',')
             f.seek(0)
             if {'Assignment', 'Organization Name'}.issubset(set(header)):
@@ -59,15 +82,26 @@ def _load_oui_db():
             else:
                 for line in f:
                     line = line.strip()
-                    if not line or line.startswith('#'):
+                    if not line or line.startswith('#') or ',' not in line:
                         continue
                     prefix, name = line.split(',', 1)
                     normalized = _normalize_oui_prefix(prefix)
-                    if normalized:
+                    if normalized and name.strip():
                         db[normalized] = name.strip()
     return db
 
 OUI_DB = _load_oui_db()
+
+
+def oui_database_status():
+    """Return metadata useful for validating local OUI lookup health."""
+    return {
+        'path': OUI_DB_PATH,
+        'path_exists': bool(OUI_DB_PATH and os.path.exists(OUI_DB_PATH)),
+        'entries': len(OUI_DB),
+        'fallback_entries': len(FALLBACK_OUI_DB),
+        'loaded': bool(OUI_DB),
+    }
 
 
 def _normalize_interface_state(status, interface_type=None):

--- a/scripts/interfaceTools.py
+++ b/scripts/interfaceTools.py
@@ -95,6 +95,13 @@ def _load_oui_db():
 OUI_DB = _load_oui_db()
 
 
+def refresh_oui_database():
+    """Reload the local OUI database after an on-demand refresh."""
+    global OUI_DB
+    OUI_DB = _load_oui_db()
+    return oui_database_status()
+
+
 def oui_database_status():
     """Return metadata useful for validating local OUI lookup health."""
     return {

--- a/scripts/interfaceTools.py
+++ b/scripts/interfaceTools.py
@@ -31,6 +31,7 @@ FALLBACK_OUI_DB = {
     '40:16:3b': 'Cisco Systems',
     '52:54:00': 'QEMU/KVM Virtual NIC',
     '74:ea:3a': 'Apple',
+    '8c:49:62': 'Roku, Inc.',
     '90:9a:4a': 'Ubiquiti Networks',
     '9c:2a:70': 'MikroTik',
     'a8:b1:3b': 'Netgear',

--- a/scripts/interfaceTools.py
+++ b/scripts/interfaceTools.py
@@ -11,6 +11,7 @@ import json
 
 AF_PACKET_FAMILY = getattr(socket, "AF_PACKET", 17)
 _WINDOWS_INTERFACE_METADATA = {}
+FULL_OUI_ENTRY_THRESHOLD = 10000
 
 # Load a small local OUI database mapping prefixes to manufacturer names
 BASE_DIR = os.path.dirname(os.path.dirname(__file__))
@@ -102,6 +103,9 @@ def oui_database_status():
         'entries': len(OUI_DB),
         'fallback_entries': len(FALLBACK_OUI_DB),
         'loaded': bool(OUI_DB),
+        'coverage': 'full' if len(OUI_DB) >= FULL_OUI_ENTRY_THRESHOLD else 'compact',
+        'needs_refresh': len(OUI_DB) < FULL_OUI_ENTRY_THRESHOLD,
+        'full_entry_threshold': FULL_OUI_ENTRY_THRESHOLD,
     }
 
 

--- a/scripts/networkScan.py
+++ b/scripts/networkScan.py
@@ -256,6 +256,77 @@ def _parse_arp_command():
     return devices
 
 
+
+def packet_passive_scan(interface, timeout=2, packet_limit=250, manufacturer_lookup=None):
+    """Capture passive packet metadata for devices visible on an interface.
+
+    The capture is metadata-only (MAC/IP/protocol) and bounded by both a short
+    timeout and packet count so callers can use it in continuous monitor loops
+    without storing payloads or growing memory unbounded.
+    """
+    interface = (interface or "").strip()
+    if not interface:
+        raise ValueError("Missing interface")
+    timeout = max(1, min(int(timeout), 10))
+    packet_limit = max(25, min(int(packet_limit), 1000))
+    manufacturer_lookup = manufacturer_lookup or (lambda mac: "Unknown")
+    try:
+        from scapy.all import ARP, Ether, IP, IPv6, sniff
+    except ImportError as exc:
+        raise RuntimeError("Live packet capture requires scapy to be installed") from exc
+
+    devices = {}
+
+    def remember(mac=None, ip=None, protocol=None):
+        mac = _normalize_mac(mac) or ""
+        ip = (ip or "").strip()
+        if not mac and not ip:
+            return
+        if mac in {"ff:ff:ff:ff:ff:ff", "00:00:00:00:00:00"}:
+            return
+        key = mac or ip
+        entry = devices.setdefault(key, {
+            "ip": ip or "Unknown",
+            "mac": mac or "Unknown",
+            "hostname": "Unknown",
+            "manufacturer": manufacturer_lookup(mac) if mac else "Unknown",
+            "source": "packet-observation",
+            "protocols": [],
+        })
+        if ip and entry.get("ip") in {"Unknown", ""}:
+            entry["ip"] = ip
+        if mac and entry.get("mac") in {"Unknown", ""}:
+            entry["mac"] = mac
+            entry["manufacturer"] = manufacturer_lookup(mac)
+        if protocol and protocol not in entry["protocols"]:
+            entry["protocols"].append(protocol)
+
+    def observe(packet):
+        try:
+            src_mac = packet[Ether].src if packet.haslayer(Ether) else None
+            if packet.haslayer(ARP):
+                arp = packet[ARP]
+                remember(arp.hwsrc, arp.psrc, "arp")
+                remember(arp.hwdst, arp.pdst, "arp")
+            elif packet.haslayer(IP):
+                remember(src_mac, packet[IP].src, "ipv4")
+            elif packet.haslayer(IPv6):
+                remember(src_mac, packet[IPv6].src, "ipv6")
+            elif src_mac:
+                remember(src_mac, None, "ethernet")
+        except Exception:
+            return
+
+    capture_filter = "arp or udp port 67 or udp port 68 or udp port 5353 or udp port 1900 or icmp6"
+    try:
+        sniff(iface=interface, store=False, prn=observe, timeout=timeout, count=packet_limit, filter=capture_filter)
+    except Exception as exc:
+        message = str(exc).lower()
+        if "filter" not in message and "libpcap" not in message and "bpf" not in message:
+            raise
+        sniff(iface=interface, store=False, prn=observe, timeout=timeout, count=packet_limit)
+    return list(devices.values())
+
 def passive_scan(interface):
     """Read the ARP cache for entries associated with the interface when available."""
     devices = _parse_proc_arp(interface)

--- a/scripts/networkScan.py
+++ b/scripts/networkScan.py
@@ -173,11 +173,27 @@ def _dedupe_devices(devices):
     return unique
 
 
+def _arp_cache_candidates(interface=None):
+    """Return ARP cache entries for an interface, falling back to host-wide cache.
+
+    UI adapter labels are not always the kernel interface names (for example a
+    friendly "WiFi" label), so an active scan should still show cached LAN
+    neighbors instead of reporting an empty result when CIDR detection fails.
+    """
+    devices = _parse_proc_arp(interface)
+    if devices:
+        return devices
+    devices = _parse_proc_arp()
+    if devices:
+        return devices
+    return _parse_arp_command()
+
+
 def active_scan(interface):
     """Perform a bounded ping sweep and return live hosts with MAC addresses."""
     cidr = _get_ipv4_cidr(interface)
     if not cidr:
-        return []
+        return sorted(_dedupe_devices(_arp_cache_candidates(interface)), key=lambda item: ipaddress.ip_address(item["ip"]))
     try:
         network = ipaddress.ip_interface(cidr).network
     except ValueError:
@@ -189,7 +205,7 @@ def active_scan(interface):
     # afterwards so ICMP-blocking LAN hosts can still show up when discovered.
     hosts = list(network.hosts())
     if len(hosts) > 1024:
-        return []
+        return sorted(_dedupe_devices(_arp_cache_candidates(interface)), key=lambda item: ipaddress.ip_address(item["ip"]))
 
     live_hosts = []
     workers = min(64, max(1, len(hosts)))
@@ -200,7 +216,7 @@ def active_scan(interface):
             if ip:
                 live_hosts.append({"ip": ip, "mac": get_mac_by_ip(ip)})
 
-    live_hosts.extend(_parse_proc_arp(interface))
+    live_hosts.extend(_arp_cache_candidates(interface))
     return sorted(_dedupe_devices(live_hosts), key=lambda item: ipaddress.ip_address(item["ip"]))
 
 

--- a/scripts/update_oui_db.py
+++ b/scripts/update_oui_db.py
@@ -4,6 +4,10 @@ import os
 import urllib.request
 
 IEEE_OUI_CSV_URL = 'https://standards-oui.ieee.org/oui/oui.csv'
+IEEE_OUI_CSV_URLS = [
+    IEEE_OUI_CSV_URL,
+    'https://standards.ieee.org/wp-content/uploads/import/documents/standards/products-programs/regauth/oui/oui.csv',
+]
 DEFAULT_OUTPUT = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'oui', 'oui_db.csv')
 
 
@@ -14,10 +18,24 @@ def _normalize_assignment(value):
     return ':'.join(cleaned[index:index + 2] for index in range(0, 6, 2))
 
 
-def download_oui_database(output_path=DEFAULT_OUTPUT, url=IEEE_OUI_CSV_URL):
+def _fetch_text(url, opener=urllib.request.urlopen):
+    request = urllib.request.Request(url, headers={'User-Agent': 'MobileRouterOUIUpdater/1.0'})
+    with opener(request, timeout=30) as response:
+        return response.read().decode('utf-8-sig')
+
+
+def download_oui_database(output_path=DEFAULT_OUTPUT, url=None, opener=urllib.request.urlopen):
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    with urllib.request.urlopen(url, timeout=30) as response:
-        text = response.read().decode('utf-8-sig')
+    errors = []
+    text = None
+    for candidate in ([url] if url else IEEE_OUI_CSV_URLS):
+        try:
+            text = _fetch_text(candidate, opener=opener)
+            break
+        except Exception as exc:
+            errors.append(f'{candidate}: {exc}')
+    if text is None:
+        raise RuntimeError('Unable to download IEEE OUI database. Tried: ' + '; '.join(errors))
 
     rows = csv.DictReader(text.splitlines())
     entries = []

--- a/scripts/wifi/utils.py
+++ b/scripts/wifi/utils.py
@@ -605,10 +605,8 @@ def get_networks_summary():
 
 
 def _mac_manufacturer(mac):
-    try:
-        from scripts.interfaceTools import lookup_manufacturer
-    except ImportError:
-        return 'Unknown'
+    from services.oui import lookup_manufacturer
+
     return lookup_manufacturer(mac)
 
 

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,1 @@
+"""Application service helpers split from Flask route wiring."""

--- a/services/alerts.py
+++ b/services/alerts.py
@@ -1,0 +1,93 @@
+"""Alert record helpers for newly discovered devices and watched clients."""
+
+import time
+import uuid
+from urllib.parse import quote
+
+
+def create_new_device_alert(device, source, interface, alert_store, lock):
+    """Record an unread alert for a newly observed inventory device."""
+    display_name = device.get('name') or device.get('hostname') or device.get('ssid') or device.get('ip') or device.get('mac') or 'Unknown device'
+    device_identifier = device.get('mac') or device.get('bssid') or device.get('ip')
+    device_url = f"/clients/{quote(str(device_identifier))}" if device_identifier else None
+    alert = {
+        'id': uuid.uuid4().hex,
+        'device_id': device.get('id'),
+        'display_name': display_name,
+        'ip': device.get('ip'),
+        'mac': device.get('mac') or device.get('bssid'),
+        'manufacturer': device.get('manufacturer') or 'Unknown',
+        'device_url': device_url,
+        'source': source,
+        'interface': interface,
+        'created_at': time.time(),
+        'read': False,
+    }
+    with lock:
+        alert_store.insert(0, alert)
+        del alert_store[200:]
+    return alert
+
+
+def create_grouped_device_alert(devices, source, interface, alert_store, lock):
+    """Record one unread alert for a batch of newly observed devices."""
+    devices = [dict(device) for device in devices or []]
+    alert = {
+        'id': uuid.uuid4().hex,
+        'alert_type': 'grouped-discovery',
+        'display_name': f"{len(devices)} new devices discovered",
+        'ip': None,
+        'mac': None,
+        'manufacturer': 'Multiple',
+        'device_url': '/inventory',
+        'source': source,
+        'interface': interface,
+        'created_at': time.time(),
+        'read': False,
+        'device_count': len(devices),
+        'devices': [
+            {
+                'id': device.get('id'),
+                'display_name': device.get('name') or device.get('hostname') or device.get('ssid') or device.get('ip') or device.get('mac') or 'Unknown device',
+                'ip': device.get('ip'),
+                'mac': device.get('mac') or device.get('bssid'),
+                'manufacturer': device.get('manufacturer') or 'Unknown',
+            }
+            for device in devices[:10]
+        ],
+    }
+    with lock:
+        alert_store.insert(0, alert)
+        del alert_store[200:]
+    return alert
+
+
+def alert_records(alert_store, lock):
+    """Return alert records with display labels."""
+    with lock:
+        records = [dict(alert) for alert in alert_store]
+    for alert in records:
+        alert['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(alert.get('created_at', 0)))
+    return records
+
+
+def unread_alert_count(alert_store, lock):
+    with lock:
+        return len([alert for alert in alert_store if not alert.get('read')])
+
+
+def mark_alert_read(alert_id, alert_store, lock):
+    with lock:
+        for alert in alert_store:
+            if alert['id'] == alert_id:
+                alert['read'] = True
+                unread_count = len([item for item in alert_store if not item.get('read')])
+                return dict(alert), unread_count
+    return None, None
+
+
+def mark_all_alerts_read(alert_store, lock):
+    with lock:
+        for alert in alert_store:
+            alert['read'] = True
+    return 0

--- a/services/device_intel.py
+++ b/services/device_intel.py
@@ -1,0 +1,134 @@
+"""Device identity, role, and service intelligence helpers."""
+
+import hashlib
+import socket
+import ssl
+from urllib.parse import urljoin
+from urllib.request import Request
+from urllib.error import HTTPError, URLError
+
+
+def is_locally_administered_mac(mac):
+    """Return True when a MAC has the local/private address bit set."""
+    if not mac:
+        return False
+    try:
+        first_octet = int(str(mac).replace('-', ':').split(':')[0], 16)
+    except (ValueError, IndexError):
+        return False
+    return bool(first_octet & 0b00000010)
+
+
+def merge_observed_names(existing, device, source, now):
+    """Merge host/name/display labels into a source-attributed observed-name history."""
+    names = {
+        (item.get('name'), item.get('source')): dict(item)
+        for item in existing.get('observed_names', [])
+        if item.get('name')
+    }
+    for field in ('display_name', 'hostname', 'name'):
+        value = str(device.get(field) or '').strip().strip('.')
+        if not value:
+            continue
+        key = (value, source)
+        previous = names.get(key, {})
+        names[key] = {
+            'name': value[:120],
+            'source': source,
+            'field': field,
+            'first_seen': previous.get('first_seen') or now,
+            'last_seen': now,
+        }
+    return sorted(names.values(), key=lambda item: item.get('last_seen') or 0, reverse=True)[:12]
+
+
+def infer_device_role(device):
+    """Infer a likely device role from vendor, names, services, ports, and metadata."""
+    text_parts = [
+        device.get('manufacturer'),
+        device.get('hostname'),
+        device.get('name'),
+        device.get('display_name'),
+        device.get('device_type'),
+        device.get('network_role'),
+    ]
+    for item in device.get('open_port_details') or []:
+        text_parts.extend([item.get('service'), item.get('description'), item.get('http_title'), item.get('http_server')])
+    for item in device.get('service_metadata_list') or []:
+        text_parts.extend(str(value) for value in item.values() if isinstance(value, (str, int)))
+    metadata = device.get('service_metadata') or {}
+    if isinstance(metadata, dict):
+        text_parts.extend(str(value) for value in metadata.values() if isinstance(value, (str, int)))
+    value = ' '.join(str(part or '') for part in text_parts).lower()
+    port_set = {int(item.get('port')) for item in device.get('open_port_details') or [] if item.get('port')}
+
+    rules = [
+        ('Gateway/router', 'high', ['gateway', 'router', 'openwrt', 'internetgatewaydevice'], {53, 67, 80, 443}),
+        ('Printer', 'high', ['printer', '_ipp', 'laserjet', 'cups'], {631, 9100, 515}),
+        ('NAS/file server', 'high', ['nas', 'synology', 'qnap', 'samba', 'smb'], {139, 445, 2049}),
+        ('Camera/NVR', 'medium', ['camera', 'nvr', 'rtsp', 'hikvision', 'dahua'], {554, 8000, 8080}),
+        ('Media/TV device', 'medium', ['airplay', 'chromecast', 'roku', 'tv', 'spotify', 'dlna'], {7000, 8008, 8009}),
+        ('Home automation/IoT', 'medium', ['home assistant', 'esphome', 'tasmota', 'iot', 'esp32'], {8123, 6053, 1883}),
+        ('Remote admin host', 'medium', ['ssh', 'rdp', 'vnc'], {22, 3389, 5900}),
+        ('Web appliance', 'medium', ['http', 'nginx', 'apache', 'lighttpd'], {80, 443, 8080, 8443}),
+    ]
+    evidence = []
+    for role, confidence, terms, ports in rules:
+        matched_terms = [term for term in terms if term in value]
+        matched_ports = sorted(port_set & ports)
+        if matched_terms or matched_ports:
+            if matched_terms:
+                evidence.append(f"Matched terms: {', '.join(matched_terms[:3])}")
+            if matched_ports:
+                evidence.append(f"Matched ports: {', '.join(str(port) for port in matched_ports[:4])}")
+            return {'role': role, 'confidence': confidence, 'evidence': evidence[:4]}
+    if device.get('is_control_traffic'):
+        return {'role': device.get('network_role') or 'Control traffic', 'confidence': 'high', 'evidence': ['Classified as control traffic']}
+    return {'role': device.get('network_role') or device.get('device_type') or 'Client', 'confidence': 'low', 'evidence': ['No strong role fingerprint yet']}
+
+
+def favicon_metadata(url, urlopen, timeout=3):
+    """Fetch and hash a site's favicon for lightweight web-app fingerprinting."""
+    try:
+        favicon_url = urljoin(url, '/favicon.ico')
+        req = Request(favicon_url, headers={'User-Agent': 'MobileRouterLab/1.0'})
+        with urlopen(req, timeout=timeout) as resp:
+            data = resp.read(131072)
+        if not data:
+            return None
+        digest = hashlib.sha256(data).hexdigest()
+        hints = {
+            # These are intentionally conservative generic hints. More known hashes
+            # can be added later from locally collected, non-sensitive samples.
+        }
+        return {
+            'url': favicon_url,
+            'sha256': digest,
+            'size': len(data),
+            'app_hint': hints.get(digest),
+        }
+    except (HTTPError, URLError, TimeoutError, OSError, ValueError):
+        return None
+
+
+def tls_certificate_metadata(host, port, timeout=3):
+    """Collect basic TLS certificate identity for HTTPS-like services."""
+    try:
+        context = ssl._create_unverified_context()
+        with socket.create_connection((host, int(port)), timeout=timeout) as raw_sock:
+            with context.wrap_socket(raw_sock, server_hostname=host) as tls_sock:
+                cert = tls_sock.getpeercert()
+                cipher = tls_sock.cipher()
+    except (OSError, ssl.SSLError, ValueError):
+        return None
+    subject = dict(part[0] for part in cert.get('subject', []) if part)
+    issuer = dict(part[0] for part in cert.get('issuer', []) if part)
+    sans = [value for key, value in cert.get('subjectAltName', []) if key.lower() == 'dns']
+    return {
+        'subject_common_name': subject.get('commonName'),
+        'issuer_common_name': issuer.get('commonName'),
+        'dns_names': sans[:12],
+        'not_before': cert.get('notBefore'),
+        'not_after': cert.get('notAfter'),
+        'cipher': cipher[0] if cipher else None,
+    }

--- a/services/diagnostics.py
+++ b/services/diagnostics.py
@@ -1,0 +1,344 @@
+"""Network diagnostics, reachability, and advanced assessment helpers."""
+
+import ipaddress
+import json
+import os
+import re
+import time
+
+
+def ping_command(host, count=4, timeout=2, os_name=os.name):
+    """Build a platform-appropriate ping command."""
+    if os_name == 'nt':
+        return ['ping', '-n', str(count), '-w', str(timeout * 1000), host]
+    return ['ping', '-c', str(count), '-W', str(timeout), host]
+
+
+def parse_ping_output(output):
+    """Return packet-loss and latency details from common ping output."""
+    loss = None
+    transmitted = received = None
+    packet_match = re.search(
+        r'(\d+)\s+packets transmitted,\s+(\d+)\s+(?:packets )?received,\s+([\d.]+)% packet loss',
+        output,
+    )
+    if packet_match:
+        transmitted = int(packet_match.group(1))
+        received = int(packet_match.group(2))
+        loss = float(packet_match.group(3))
+    windows_match = re.search(
+        r'Packets: Sent = (\d+), Received = (\d+), Lost = (\d+) \((\d+)% loss\)',
+        output,
+    )
+    if windows_match:
+        transmitted = int(windows_match.group(1))
+        received = int(windows_match.group(2))
+        loss = float(windows_match.group(4))
+    stats_match = re.search(r'(?:rtt|round-trip).*?=\s*([\d.]+)/([\d.]+)/([\d.]+)/(?:[\d.]+)', output)
+    windows_stats = re.search(r'Minimum = (\d+)ms, Maximum = (\d+)ms, Average = (\d+)ms', output)
+    latency = {}
+    if stats_match:
+        latency = {
+            'min_ms': float(stats_match.group(1)),
+            'avg_ms': float(stats_match.group(2)),
+            'max_ms': float(stats_match.group(3)),
+        }
+    elif windows_stats:
+        latency = {
+            'min_ms': float(windows_stats.group(1)),
+            'avg_ms': float(windows_stats.group(3)),
+            'max_ms': float(windows_stats.group(2)),
+        }
+    return {'transmitted': transmitted, 'received': received, 'packet_loss_percent': loss, 'latency': latency}
+
+
+def run_ping_check(host, count, timeout, parse_int, subprocess_module, ping_history):
+    """Run a bounded ping and append the result to reachability history."""
+    host = (host or '').strip()
+    if not host:
+        raise ValueError('Host is required')
+    count = max(1, min(parse_int(count, 'Count must be an integer'), 10))
+    timeout = max(1, min(parse_int(timeout, 'Timeout must be an integer'), 10))
+    started = time.time()
+    result = subprocess_module.run(
+        ping_command(host, count=count, timeout=timeout, os_name=os.name),
+        capture_output=True,
+        text=True,
+        timeout=(count * timeout) + 5,
+        check=False,
+    )
+    output = (result.stdout or result.stderr or '').strip()
+    history = {
+        'host': host,
+        'reachable': result.returncode == 0,
+        'returncode': result.returncode,
+        'duration_ms': round((time.time() - started) * 1000, 2),
+        'output': output,
+        **parse_ping_output(output),
+        'checked_at': time.time(),
+    }
+    ping_history.append(history)
+    del ping_history[:-100]
+    return history
+
+
+def run_ping_sweep(cidr, count, timeout, run_ping_check, timeout_error):
+    """Run a bounded ping sweep over small IPv4/IPv6 subnets."""
+    network = ipaddress.ip_network((cidr or '').strip(), strict=False)
+    hosts = list(network.hosts())
+    if network.version == 6 and network.prefixlen < 120:
+        raise ValueError('IPv6 sweeps are limited to /120 or smaller ranges')
+    if len(hosts) > 64:
+        raise ValueError('Subnet sweeps are limited to 64 hosts')
+    results = []
+    for host in hosts:
+        try:
+            results.append(run_ping_check(str(host), count=count, timeout=timeout))
+        except timeout_error:
+            results.append({
+                'host': str(host),
+                'reachable': False,
+                'packet_loss_percent': 100.0,
+                'latency': {},
+                'output': 'Timed out',
+                'checked_at': time.time(),
+            })
+    return {
+        'cidr': str(network),
+        'total_hosts': len(results),
+        'reachable_hosts': len([item for item in results if item.get('reachable')]),
+        'results': results,
+    }
+
+
+def parse_route_lines(output):
+    """Parse Linux route output into dictionaries."""
+    routes = []
+    for line in (output or '').splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        tokens = line.split()
+        route = {
+            'raw': line,
+            'destination': tokens[0] if tokens else None,
+            'gateway': None,
+            'interface': None,
+            'metric': None,
+            'family': 'IPv6' if ':' in tokens[0] else 'IPv4',
+        }
+        if 'via' in tokens:
+            route['gateway'] = tokens[tokens.index('via') + 1]
+        if 'dev' in tokens:
+            route['interface'] = tokens[tokens.index('dev') + 1]
+        if 'metric' in tokens:
+            route['metric'] = tokens[tokens.index('metric') + 1]
+        routes.append(route)
+    return routes
+
+
+def build_route_diagnostics(target, run_text_command, os_name=os.name):
+    """Display default gateways, routes, VPN hints, and target path context."""
+    commands = []
+    if os_name == 'nt':
+        commands.append(['route', 'print'])
+        if target:
+            commands.append(['tracert', '-d', '-h', '1', target])
+    else:
+        commands.extend([['ip', '-4', 'route', 'show'], ['ip', '-6', 'route', 'show']])
+        if target:
+            commands.append(['ip', 'route', 'get', target])
+    command_results = [run_text_command(command) for command in commands]
+    routes = []
+    for result in command_results:
+        if result['command'][:2] in (['ip', '-4'], ['ip', '-6']) or result['command'][:1] == ['ip']:
+            routes.extend(parse_route_lines(result['output']))
+    return {
+        'default_gateways': [route for route in routes if route.get('destination') == 'default'],
+        'routes': routes,
+        'vpn_hints': [
+            route for route in routes
+            if re.search(r'\b(tun|tap|wg|vpn|ppp|utun)\w*\b', route.get('interface') or '', re.I)
+        ],
+        'scan_path_context': next(
+            (result['output'] for result in command_results if result['command'][:3] == ['ip', 'route', 'get']),
+            '',
+        ),
+        'commands': command_results,
+        'checked_at': time.time(),
+    }
+
+
+def discover_vlan_context(ssid, vlan_id, notes, run_text_command, note_store, uuid_factory, os_name=os.name):
+    """Inventory VLAN-like interfaces and store optional SSID-to-VLAN notes."""
+    command_result = (
+        run_text_command(['ip', '-d', 'link', 'show'], timeout=5)
+        if os_name != 'nt'
+        else {'output': '', 'returncode': 1}
+    )
+    vlans = []
+    current = None
+    for line in command_result.get('output', '').splitlines():
+        header = re.match(r'\d+:\s+([^:@]+(?:\.\d+)?)(?:@([^:]+))?:', line.strip())
+        if header:
+            name = header.group(1)
+            parent = header.group(2)
+            current = {'interface': name, 'parent': parent, 'vlan_id': None, 'raw': line.strip()}
+            if '.' in name and name.rsplit('.', 1)[-1].isdigit():
+                current['vlan_id'] = name.rsplit('.', 1)[-1]
+                vlans.append(current)
+            continue
+        if current and 'vlan id' in line:
+            match = re.search(r'vlan id\s+(\d+)', line)
+            if match:
+                current['vlan_id'] = match.group(1)
+                if current not in vlans:
+                    vlans.append(current)
+    note_record = None
+    if ssid or vlan_id or notes:
+        note_record = {
+            'id': uuid_factory().hex,
+            'ssid': (ssid or '').strip(),
+            'vlan_id': str(vlan_id or '').strip(),
+            'notes': (notes or '').strip()[:500],
+            'created_at': time.time(),
+            'validation_context': 'Confirm client isolation, gateway ACLs, DHCP scope, DNS policy, and inter-VLAN firewall rules.',
+        }
+        note_store.insert(0, note_record)
+        del note_store[100:]
+    return {'vlans': vlans, 'notes': list(note_store), 'created_note': note_record, 'command': command_result}
+
+
+def build_egress_diagnostics(selected_interface, run_text_command, build_route_diagnostics, network_interfaces, environ, urlopen, open_file, os_name=os.name):
+    """Collect public egress, DNS, NAT, VPN/proxy, and route context."""
+    public_ip = None
+    try:
+        with urlopen('https://api.ipify.org', timeout=4) as response:
+            public_ip = response.read().decode('utf-8').strip()
+    except Exception as exc:
+        public_error = str(exc)
+    else:
+        public_error = None
+    try:
+        with open_file('/etc/resolv.conf', encoding='utf-8') as handle:
+            resolvers = [line.split()[1] for line in handle if line.startswith('nameserver') and len(line.split()) > 1]
+    except OSError:
+        resolvers = []
+    ipv6_default = run_text_command(['ip', '-6', 'route', 'show', 'default'], timeout=5) if os_name != 'nt' else {'output': ''}
+    interface_route = (
+        run_text_command(['ip', 'route', 'show', 'dev', selected_interface], timeout=5)
+        if selected_interface and os_name != 'nt'
+        else {'output': ''}
+    )
+    proxy_hints = {key: value for key, value in environ.items() if key.lower() in {'http_proxy', 'https_proxy', 'all_proxy', 'no_proxy'}}
+    route_diag = build_route_diagnostics(public_ip) if public_ip else build_route_diagnostics()
+    private_addresses = [iface.to_dict().get('ip_address') for iface in network_interfaces if getattr(iface, 'ip_address', None)]
+    private_prefixes = ('10.', '172.16.', '172.17.', '172.18.', '172.19.', '172.2', '172.30.', '172.31.', '192.168.')
+    nat_context = 'Likely NAT/private egress' if any(str(ip).startswith(private_prefixes) for ip in private_addresses) else 'No RFC1918 interface address detected'
+    return {
+        'public_ip': public_ip,
+        'public_ip_error': public_error,
+        'nat_context': nat_context,
+        'dns_resolvers': resolvers,
+        'ipv6_egress': ipv6_default.get('output'),
+        'vpn_hints': route_diag.get('vpn_hints', []),
+        'proxy_hints': proxy_hints,
+        'interface_route_context': interface_route.get('output'),
+        'per_interface': [
+            {'name': iface.name, 'type': iface.interface_type, 'ip_address': getattr(iface, 'ip_address', None)}
+            for iface in network_interfaces
+        ],
+    }
+
+
+def run_iperf3_test(mode, host, port, seconds, parse_int, shutil_module, subprocess_module):
+    """Run a bounded iperf3 client or one-shot server check."""
+    iperf3 = shutil_module.which('iperf3')
+    if not iperf3:
+        raise ValueError('iperf3 is not installed')
+    mode = (mode or 'client').strip().lower()
+    port = max(1, min(parse_int(port, 'Port must be an integer'), 65535))
+    seconds = max(1, min(parse_int(seconds, 'Seconds must be an integer'), 30))
+    if mode == 'client':
+        if not host:
+            raise ValueError('Host is required for iperf3 client tests')
+        command = [iperf3, '-c', host, '-p', str(port), '-t', str(seconds), '-J']
+    elif mode == 'server':
+        command = [iperf3, '-s', '-1', '-p', str(port), '-J']
+    else:
+        raise ValueError('Mode must be client or server')
+    result = subprocess_module.run(command, capture_output=True, text=True, timeout=seconds + 10, check=False)
+    output = (result.stdout or result.stderr or '').strip()
+    try:
+        parsed = json.loads(output) if output.startswith('{') else {}
+    except json.JSONDecodeError:
+        parsed = {}
+    summary = parsed.get('end', {}).get('sum_received') or parsed.get('end', {}).get('sum_sent') or {}
+    return {'command': command, 'returncode': result.returncode, 'summary': summary, 'json': parsed, 'output': output[-2000:]}
+
+
+def run_snmp_inventory(host, community, version, oid, shutil_module, subprocess_module, record_inventory_devices):
+    """Collect authorized SNMP identity/interface metadata using supplied credentials."""
+    if not host:
+        raise ValueError('SNMP host is required')
+    if not community:
+        raise ValueError('SNMP community or credential is required')
+    snmpwalk = shutil_module.which('snmpwalk')
+    if not snmpwalk:
+        raise ValueError('snmpwalk is not installed')
+    oid_map = {'system': '1.3.6.1.2.1.1', 'interfaces': '1.3.6.1.2.1.2.2.1.2'}
+    selected_oid = oid_map.get((oid or 'system').strip().lower(), oid_map['system'])
+    command = [snmpwalk, '-v', version or '2c', '-c', community, '-Oqv', host, selected_oid]
+    result = subprocess_module.run(command, capture_output=True, text=True, timeout=10, check=False)
+    lines = [line.strip().strip('"') for line in (result.stdout or '').splitlines() if line.strip()]
+    metadata = {
+        'host': host,
+        'version': version,
+        'oid': selected_oid,
+        'values': lines[:50],
+        'returncode': result.returncode,
+        'error': (result.stderr or '').strip(),
+    }
+    record_inventory_devices([
+        {'ip': host, 'name': lines[0] if lines else host, 'device_type': 'SNMP device', 'service_metadata': metadata}
+    ], 'snmp-discovery')
+    return metadata
+
+
+def run_ipv6_assessment(host, ports, run_text_command, shutil_module, socket_module, os_name=os.name):
+    """Run bounded IPv6 reachability, route, neighbor, DNS, and TCP checks."""
+    host = (host or '').strip()
+    ports = [int(port) for port in re.split(r'[,\s]+', ports or '') if port.strip().isdigit()][:10]
+    ping = None
+    trace = None
+    if host:
+        ping = run_text_command(['ping', '-6', '-c', '3', host], timeout=8)
+        traceroute_tool = shutil_module.which('traceroute6') or shutil_module.which('traceroute')
+        if traceroute_tool:
+            trace = run_text_command([traceroute_tool, '-6', '-n', '-m', '12', host], timeout=15)
+    neighbors = run_text_command(['ip', '-6', 'neigh', 'show'], timeout=5) if os_name != 'nt' else {'output': ''}
+    routes = run_text_command(['ip', '-6', 'route', 'show'], timeout=5) if os_name != 'nt' else {'output': ''}
+    dns_records = []
+    if host:
+        try:
+            dns_records = sorted({item[4][0] for item in socket_module.getaddrinfo(host, None, socket_module.AF_INET6)})
+        except socket_module.gaierror:
+            dns_records = []
+    port_results = []
+    for port in ports:
+        status = 'closed'
+        try:
+            with socket_module.create_connection((host, port, 0, 0), timeout=1):
+                status = 'open'
+        except OSError:
+            status = 'closed'
+        port_results.append({'port': port, 'status': status})
+    return {
+        'host': host,
+        'ping': ping,
+        'traceroute': trace,
+        'neighbors': neighbors.get('output'),
+        'router_advertisement_visibility': routes.get('output'),
+        'dns_aaaa': dns_records,
+        'ports': port_results,
+    }

--- a/services/evidence.py
+++ b/services/evidence.py
@@ -1,0 +1,101 @@
+"""Evidence vault record and export helpers."""
+
+import csv
+import io
+import os
+import time
+import uuid
+
+
+def evidence_records(evidence_store, lock):
+    """Return evidence vault records with display labels."""
+    with lock:
+        records = [dict(item) for item in evidence_store]
+    for item in records:
+        item['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('created_at', 0)))
+    return records
+
+
+def create_evidence_record(title, category, source, device, notes, content, uploaded_file, evidence_dir, evidence_store, lock, save_state, secure_filename):
+    """Store a timestamped evidence record and optional uploaded file metadata."""
+    title = (title or '').strip()
+    if not title:
+        raise ValueError('Evidence title is required')
+    category = (category or 'note').strip().lower()
+    if category not in {'note', 'scan-output', 'capture', 'screenshot', 'artifact'}:
+        raise ValueError('Unsupported evidence category')
+
+    record = {
+        'id': uuid.uuid4().hex,
+        'title': title,
+        'category': category,
+        'source': (source or '').strip(),
+        'device': (device or '').strip(),
+        'notes': (notes or '').strip(),
+        'content': (content or '').strip(),
+        'created_at': time.time(),
+        'file_name': None,
+        'file_size': None,
+        'download_url': None,
+    }
+
+    if uploaded_file and uploaded_file.filename:
+        os.makedirs(evidence_dir, exist_ok=True)
+        safe_name = secure_filename(uploaded_file.filename)
+        if not safe_name:
+            raise ValueError('Uploaded file name is not valid')
+        stored_name = f"{record['id']}-{safe_name}"
+        path = os.path.join(evidence_dir, stored_name)
+        uploaded_file.save(path)
+        record.update({
+            'file_name': safe_name,
+            'stored_name': stored_name,
+            'file_size': os.path.getsize(path),
+            'download_url': f"/evidence/{record['id']}/download",
+        })
+
+    with lock:
+        evidence_store.insert(0, record)
+        del evidence_store[500:]
+    save_state('evidence')
+    return dict(record)
+
+
+def evidence_as_csv(records):
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['Title', 'Category', 'Source', 'Device', 'File', 'Created', 'Notes', 'Content'])
+    for item in records:
+        writer.writerow([
+            item.get('title'),
+            item.get('category'),
+            item.get('source'),
+            item.get('device'),
+            item.get('file_name'),
+            item.get('created_at_label'),
+            item.get('notes'),
+            item.get('content'),
+        ])
+    return output.getvalue()
+
+
+def evidence_as_markdown(records):
+    lines = ['# Evidence Vault', '']
+    if not records:
+        lines.append('_No evidence records captured yet._')
+    for item in records:
+        lines.extend([
+            f"## {item.get('title')}",
+            f"- Category: {item.get('category')}",
+            f"- Source: {item.get('source') or 'Unknown'}",
+            f"- Device: {item.get('device') or 'N/A'}",
+            f"- Created: {item.get('created_at_label')}",
+        ])
+        if item.get('file_name'):
+            lines.append(f"- File: {item.get('file_name')} ({item.get('file_size')} bytes)")
+        if item.get('notes'):
+            lines.extend(['', item.get('notes')])
+        if item.get('content'):
+            lines.extend(['', '```', item.get('content'), '```'])
+        lines.append('')
+    return '\n'.join(lines)

--- a/services/inventory.py
+++ b/services/inventory.py
@@ -1,0 +1,296 @@
+"""Inventory persistence and import/export helpers.
+
+The Flask app owns the in-memory dictionaries and callback functions; this
+module keeps inventory merge/export logic isolated from route handlers.
+"""
+
+import time
+
+from services import device_intel
+
+
+def find_device(identifier, inventory, lock, normalize_mac):
+    """Find an inventory item by normalized MAC, IP, or inventory id."""
+    normalized = normalize_mac(identifier) if identifier else None
+    with lock:
+        if normalized:
+            for key in (f'mac:{normalized}', normalized):
+                if key in inventory:
+                    return dict(inventory[key])
+            for item in inventory.values():
+                if normalize_mac(item.get('mac') or item.get('address')) == normalized:
+                    return dict(item)
+        for item in inventory.values():
+            if item.get('ip') == identifier or item.get('id') == identifier:
+                return dict(item)
+    return None
+
+
+def merge_devices(
+    devices,
+    source,
+    interface,
+    inventory,
+    lock,
+    normalize_mac,
+    inventory_key,
+    lookup_manufacturer,
+    create_new_device_alert,
+    create_grouped_device_alert,
+):
+    """Merge discovered devices into inventory with source, interface, and OUI metadata."""
+    now = time.time()
+    changed_devices = []
+    new_devices = []
+    with lock:
+        for raw_device in devices or []:
+            device = dict(raw_device)
+            mac = normalize_mac(device.get('mac') or device.get('address') or device.get('bssid'))
+            if mac:
+                device['mac'] = mac
+            key = inventory_key(device)
+            if not key:
+                continue
+            existing = inventory.get(key, {})
+            first_seen = existing.get('first_seen', now)
+            sources = sorted(set(existing.get('sources', [])) | {source})
+            interfaces_seen = sorted(set(existing.get('interfaces', [])) | ({interface} if interface else set()))
+            manufacturer = (
+                device.get('manufacturer')
+                or (lookup_manufacturer(mac) if mac else None)
+                or existing.get('manufacturer')
+                or 'Unknown'
+            )
+            observed_names = device_intel.merge_observed_names(existing, device, source, now)
+            merged = {
+                **existing,
+                **{k: v for k, v in device.items() if v not in (None, '')},
+                'id': key,
+                'mac': mac or existing.get('mac'),
+                'manufacturer': manufacturer,
+                'first_seen': first_seen,
+                'last_seen': now,
+                'sources': sources,
+                'interfaces': interfaces_seen,
+                'observed_names': observed_names,
+                'likely_randomized_mac': device_intel.is_locally_administered_mac(mac),
+            }
+            merged['device_role_guess'] = device_intel.infer_device_role(merged)
+            is_new_device = not existing
+            inventory[key] = merged
+            if is_new_device and not merged.get('is_control_traffic'):
+                new_devices.append(dict(merged))
+            changed_devices.append(dict(merged))
+    if source == 'passive-scan' or len(new_devices) <= 1:
+        for device in new_devices:
+            create_new_device_alert(device, source, interface)
+    else:
+        create_grouped_device_alert(new_devices, source, interface)
+    return changed_devices
+
+
+def record_open_ports(
+    host,
+    port_details,
+    source,
+    inventory,
+    lock,
+    enrich_port_web_url,
+    append_client_timeline_event,
+    is_client_watched,
+    create_client_watch_alert,
+):
+    """Attach open-port/service findings to an IP device profile."""
+    host = (host or '').strip()
+    if not host:
+        return None
+    details = sorted(
+        [enrich_port_web_url(host, item) for item in (port_details or []) if item.get('port')],
+        key=lambda item: item['port'],
+    )
+    now = time.time()
+    added_ports = []
+    changed_ports = []
+    with lock:
+        key = f'ip:{host}'
+        existing_key = key if key in inventory else None
+        if existing_key is None:
+            for candidate_key, item in inventory.items():
+                if item.get('ip') == host:
+                    existing_key = candidate_key
+                    break
+        if existing_key is None:
+            existing_key = key
+            inventory[existing_key] = {
+                'id': key,
+                'ip': host,
+                'manufacturer': 'Unknown',
+                'first_seen': now,
+                'interfaces': [],
+                'sources': [],
+            }
+        device = inventory[existing_key]
+        existing_details = {
+            item.get('port'): dict(item)
+            for item in device.get('open_port_details', [])
+            if item.get('port')
+        }
+        for detail in details:
+            previous = existing_details.get(detail['port'])
+            if previous is None:
+                added_ports.append(detail)
+            elif (
+                previous.get('service') != detail.get('service')
+                or previous.get('description') != detail.get('description')
+            ):
+                changed_ports.append({'previous': previous, 'current': detail})
+            existing_details[detail['port']] = detail
+        device['open_port_details'] = [existing_details[port] for port in sorted(existing_details)]
+        device['open_ports'] = sorted(existing_details)
+        device['last_port_scan'] = now
+        device['last_seen'] = now
+        device['sources'] = sorted(set(device.get('sources', [])) | {source})
+        inventory[existing_key] = device
+        updated = dict(device)
+    if added_ports:
+        added_summary = ', '.join(
+            f"{item['port']}/tcp {item.get('service') or 'Unknown'}"
+            for item in added_ports
+        )
+        append_client_timeline_event(
+            host,
+            'New open ports',
+            f'Added {added_summary} from {source}.',
+            source,
+        )
+        if is_client_watched(host):
+            added_numbers = ', '.join(str(item['port']) for item in added_ports)
+            create_client_watch_alert(
+                host,
+                'New open port discovered',
+                f'{len(added_ports)} new port(s): {added_numbers}',
+            )
+    for change in changed_ports:
+        current = change['current']
+        append_client_timeline_event(
+            host,
+            'Service changed',
+            f"{current['port']}/tcp is now {current.get('service') or 'Unknown'} from {source}.",
+            source,
+        )
+    return updated
+
+
+def export_payload(records, exported_at=None):
+    """Build a portable inventory export including saved port/service details."""
+    devices = []
+    for device in records or []:
+        devices.append({
+            'id': device.get('id'),
+            'display_name': device.get('display_name'),
+            'ip': device.get('ip'),
+            'mac': device.get('mac'),
+            'bssid': device.get('bssid'),
+            'manufacturer': device.get('manufacturer'),
+            'hostname': device.get('hostname'),
+            'name': device.get('name'),
+            'device_type': device.get('device_type'),
+            'sources': device.get('sources', []),
+            'interfaces': device.get('interfaces', []),
+            'first_seen': device.get('first_seen'),
+            'last_seen': device.get('last_seen'),
+            'client_tags': device.get('client_tags', []),
+            'client_notes': device.get('client_notes'),
+            'expected_open_ports': device.get('expected_open_ports', []),
+            'open_ports': device.get('open_ports', []),
+            'open_port_details': device.get('open_port_details', []),
+            'last_port_scan': device.get('last_port_scan'),
+            'observed_names': device.get('observed_names', []),
+            'likely_randomized_mac': device.get('likely_randomized_mac'),
+            'device_role_guess': device.get('device_role_guess'),
+        })
+    return {'exported_at': exported_at or time.time(), 'schema': 'mobile-router-inventory-v1', 'devices': devices}
+
+
+def import_payload(
+    payload,
+    source,
+    record_inventory_devices,
+    find_inventory_device,
+    inventory_key,
+    inventory,
+    lock,
+    record_device_open_ports,
+):
+    """Import devices and saved port/service profiles from a portable JSON export."""
+    if not isinstance(payload, dict):
+        raise ValueError('Inventory import must be a JSON object')
+    devices = payload.get('devices')
+    if not isinstance(devices, list):
+        raise ValueError('Inventory import must contain a devices list')
+    imported_devices = 0
+    imported_port_profiles = 0
+    for raw in devices[:1000]:
+        if not isinstance(raw, dict):
+            continue
+        device = {
+            key: raw.get(key)
+            for key in ('ip', 'mac', 'bssid', 'hostname', 'name', 'device_type', 'manufacturer')
+            if raw.get(key)
+        }
+        device['sources'] = sorted(set(raw.get('sources') or []) | {source})
+        interfaces = raw.get('interfaces') or []
+        interface = interfaces[0] if interfaces else None
+        enriched = record_inventory_devices([device], source, interface)
+        identifier = raw.get('ip') or raw.get('mac') or raw.get('bssid')
+        if not identifier:
+            continue
+        imported_devices += len(enriched)
+        updates = {}
+        for field in (
+            'client_tags',
+            'client_notes',
+            'expected_open_ports',
+            'last_port_scan',
+            'observed_names',
+            'likely_randomized_mac',
+            'device_role_guess',
+        ):
+            if raw.get(field) not in (None, ''):
+                updates[field] = raw.get(field)
+        if updates:
+            target = find_inventory_device(identifier) or {}
+            key = target.get('id') or inventory_key({
+                **device,
+                'ip': raw.get('ip'),
+                'mac': raw.get('mac'),
+                'bssid': raw.get('bssid'),
+            })
+            with lock:
+                if key in inventory:
+                    inventory[key].update(updates)
+        port_details = raw.get('open_port_details') or []
+        if raw.get('ip') and port_details:
+            record_device_open_ports(raw.get('ip'), port_details, source=source)
+            imported_port_profiles += 1
+    return {'imported_devices': imported_devices, 'imported_port_profiles': imported_port_profiles}
+
+
+def manufacturer_summary(records):
+    """Summarize inventory by manufacturer/OUI."""
+    vendors = {}
+    unknown = 0
+    for item in records or []:
+        vendor = item.get('manufacturer') or 'Unknown'
+        vendors.setdefault(vendor, {'manufacturer': vendor, 'count': 0, 'devices': []})
+        vendors[vendor]['count'] += 1
+        vendors[vendor]['devices'].append(item)
+        if vendor == 'Unknown':
+            unknown += 1
+    top_vendors = sorted(vendors.values(), key=lambda item: (-item['count'], item['manufacturer']))
+    return {
+        'total_devices': len(records or []),
+        'known_manufacturers': len([vendor for vendor in vendors if vendor != 'Unknown']),
+        'unknown_manufacturers': unknown,
+        'top_vendors': top_vendors,
+    }

--- a/services/labs.py
+++ b/services/labs.py
@@ -1,0 +1,269 @@
+"""Helpers for safe, auditable wireless lab workflows."""
+
+import csv
+import io
+import os
+import re
+import time
+import uuid
+
+DEAUTH_FRAME_LIMIT = 5
+BROADCAST_MAC = 'ff:ff:ff:ff:ff:ff'
+EVIL_TWIN_MAX_DURATION_MINUTES = 30
+EVIL_TWIN_ACTIONS = {'plan', 'start', 'cleanup'}
+PINEAP_ACTIONS = {'recon', 'campaign', 'handshake', 'module'}
+PINEAP_MODULES = {'recon', 'evil-twin-lab', 'handshake-capture', 'portal-awareness', 'detection-report'}
+HANDSHAKE_CAPTURE_TYPES = {'wpa-handshake', 'pmkid'}
+
+
+def require_normalized_mac(value, normalize_mac):
+    """Return a normalized MAC address or raise ValueError for required lab inputs."""
+    mac = normalize_mac(value)
+    if not mac:
+        raise ValueError('Enter a valid MAC address in the form aa:bb:cc:dd:ee:ff')
+    return mac
+
+
+def validate_deauth_request(data, normalize_mac, parse_int):
+    """Validate bounded deauth lab inputs for an authorized classroom exercise."""
+    ap_mac = require_normalized_mac(data.get('ap'), normalize_mac)
+    target_mac = require_normalized_mac(data.get('target') or BROADCAST_MAC, normalize_mac)
+    if ap_mac == BROADCAST_MAC:
+        raise ValueError('AP MAC must be a specific lab access point, not broadcast')
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab network before running deauth')
+    frames = parse_int(data.get('frames'), 'Frames must be an integer')
+    if frames < 1 or frames > DEAUTH_FRAME_LIMIT:
+        raise ValueError(f'Frames must be between 1 and {DEAUTH_FRAME_LIMIT} for first-year labs')
+    return ap_mac, target_mac, frames
+
+
+def validate_evil_twin_request(data, normalize_mac, parse_int):
+    """Validate a controlled rogue-AP/captive-portal lab workflow request."""
+    action = (data.get('action') or 'plan').strip().lower()
+    if action not in EVIL_TWIN_ACTIONS:
+        raise ValueError('Choose plan, start, or cleanup for the lab workflow')
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab before preparing an evil twin lab workflow')
+    ssid = (data.get('ssid') or '').strip()
+    if not ssid or len(ssid) > 32:
+        raise ValueError('Enter the exact lab SSID, up to 32 characters')
+    bssid = require_normalized_mac(data.get('bssid'), normalize_mac)
+    channel = parse_int(data.get('channel'), 'Channel must be an integer')
+    if channel < 1 or channel > 196:
+        raise ValueError('Channel must be between 1 and 196')
+    duration = parse_int(data.get('durationMinutes') or '10', 'Duration must be an integer')
+    if duration < 1 or duration > EVIL_TWIN_MAX_DURATION_MINUTES:
+        raise ValueError(f'Duration must be between 1 and {EVIL_TWIN_MAX_DURATION_MINUTES} minutes')
+    portal_message = (data.get('portalMessage') or 'Training portal: do not enter real credentials.').strip()
+    if len(portal_message) > 200:
+        raise ValueError('Portal message must be 200 characters or fewer')
+    return {
+        'action': action,
+        'ssid': ssid,
+        'bssid': bssid,
+        'channel': channel,
+        'duration_minutes': duration,
+        'portal_message': portal_message,
+    }
+
+
+def evil_twin_guidance(run):
+    """Return safe operator, cleanup, and defensive guidance for the lab."""
+    return {
+        'operator_steps': [
+            f"Verify the isolated lab AP broadcasting '{run['ssid']}' has BSSID {run['bssid']} on channel {run['channel']}.",
+            'Use a dedicated lab radio and avoid bridging the portal to production networks.',
+            'Display only the training message; do not request, collect, or store credentials.',
+            f"Stop the workflow within {run['duration_minutes']} minutes and confirm clients reconnect to the legitimate lab AP.",
+        ],
+        'cleanup_steps': [
+            'Stop hostapd/dnsmasq or any lab AP service started outside Mobile Router.',
+            'Remove temporary DHCP/DNS/portal configuration files for this SSID.',
+            'Restore interface mode, channel, IP addressing, forwarding, and firewall rules.',
+            'Record the cleanup result in the lab log and evidence notes.',
+        ],
+        'detection_guidance': [
+            'Alert on duplicate SSIDs with a new BSSID, mismatched channel, or weaker security than baseline.',
+            'Compare beacon RSN/capability fields and vendor OUIs against the approved AP inventory.',
+            'Watch DHCP/DNS gateway changes and captive-portal redirects from unknown MAC addresses.',
+            'Train users to report unexpected portal prompts and never enter real credentials in drills.',
+        ],
+    }
+
+
+def record_evil_twin_run(selected_interface, lab, runs, lock, save_state, logger):
+    """Record a non-credential evil-twin/captive-portal lab workflow event."""
+    run = {'id': uuid.uuid4().hex, 'created_at': time.time(), 'interface': selected_interface, **lab}
+    run.update(evil_twin_guidance(run))
+    with lock:
+        runs.append(run)
+        del runs[:-25]
+    save_state('evil-twin-lab')
+    logger.info(
+        'Evil twin lab %s recorded for SSID %r BSSID %s channel %s on %s',
+        run['action'], run['ssid'], run['bssid'], run['channel'], selected_interface,
+    )
+    return run
+
+
+def _split_module_ids(value):
+    modules = []
+    for item in re.split(r'[,\s]+', value or ''):
+        item = item.strip().lower()
+        if item:
+            modules.append(item)
+    return modules
+
+
+def validate_pineap_request(data, normalize_mac, parse_int):
+    """Validate a WiFi Pineapple-style lab controller request."""
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab before running a campaign workflow')
+    action = (data.get('action') or 'recon').strip().lower()
+    if action not in PINEAP_ACTIONS:
+        raise ValueError('Choose recon, campaign, handshake, or module')
+    ssid = (data.get('ssid') or '').strip()
+    if ssid and len(ssid) > 32:
+        raise ValueError('SSID must be 32 characters or fewer')
+    bssid = require_normalized_mac(data.get('bssid'), normalize_mac) if data.get('bssid') else None
+    channel = None
+    if data.get('channel'):
+        channel = parse_int(data.get('channel'), 'Channel must be an integer')
+        if channel < 1 or channel > 196:
+            raise ValueError('Channel must be between 1 and 196')
+    modules = _split_module_ids(data.get('modules') or 'recon,detection-report')
+    unknown = [module for module in modules if module not in PINEAP_MODULES]
+    if unknown:
+        raise ValueError(f"Unknown lab module: {', '.join(unknown)}")
+    if action in {'campaign', 'handshake', 'module'} and not ssid:
+        raise ValueError('Enter an explicit lab SSID for campaign, handshake, or module workflows')
+    return {
+        'action': action,
+        'ssid': ssid,
+        'bssid': bssid,
+        'channel': channel,
+        'modules': modules,
+        'notes': (data.get('notes') or '').strip()[:500],
+    }
+
+
+def build_pineap_result(selected_interface, lab, runs, lock, save_state, logger, wifi_utils):
+    """Build an auditable, non-destructive PineAP-style lab result."""
+    recon = []
+    if lab['action'] == 'recon':
+        wifi_utils.scan_networks(selected_interface)
+        recon = wifi_utils.get_networks_summary()
+    run = {
+        'id': uuid.uuid4().hex,
+        'created_at': time.time(),
+        'interface': selected_interface,
+        **lab,
+        'recon': recon,
+        'campaign_steps': [
+            'Recon: inventory authorized lab SSIDs, BSSIDs, channels, security, and WPS exposure.',
+            'Campaign: select only approved training modules and log operator intent before execution.',
+            'Handshake: capture or upload WPA/WPA2 handshake or PMKID evidence without password cracking.',
+            'Report: export findings, cleanup actions, and detection opportunities for defenders.',
+        ],
+        'module_status': [
+            {'id': module, 'status': 'queued' if lab['action'] != 'recon' else 'available'}
+            for module in lab['modules']
+        ],
+        'safety': 'This controller records authorized lab workflow state and recon output; it does not collect credentials or run cracking jobs.',
+    }
+    with lock:
+        runs.insert(0, run)
+        del runs[100:]
+    save_state('pineap-lab')
+    logger.info('PineAP-style lab %s recorded for SSID %r on %s', run['action'], run['ssid'], selected_interface)
+    return run
+
+
+def validate_handshake_request(data, normalize_mac, parse_int):
+    """Validate handshake/PMKID evidence catalog inputs."""
+    if data.get('authorized') != 'on':
+        raise ValueError('Confirm this is an authorized isolated lab before cataloging handshake evidence')
+    ssid = (data.get('ssid') or '').strip()
+    if not ssid or len(ssid) > 32:
+        raise ValueError('Enter the exact lab SSID, up to 32 characters')
+    bssid = require_normalized_mac(data.get('bssid'), normalize_mac)
+    channel = parse_int(data.get('channel'), 'Channel must be an integer')
+    if channel < 1 or channel > 196:
+        raise ValueError('Channel must be between 1 and 196')
+    capture_type = (data.get('captureType') or 'wpa-handshake').strip().lower()
+    if capture_type not in HANDSHAKE_CAPTURE_TYPES:
+        raise ValueError('Capture type must be WPA handshake or PMKID')
+    return {
+        'ssid': ssid,
+        'bssid': bssid,
+        'channel': channel,
+        'capture_type': capture_type,
+        'client': normalize_mac(data.get('client')) if data.get('client') else '',
+        'validation_notes': (data.get('validationNotes') or '').strip()[:500],
+    }
+
+
+def validate_handshake_evidence(record, uploaded_file=None):
+    """Attach lightweight validation status for uploaded WPA/PMKID evidence."""
+    file_name = uploaded_file.filename if uploaded_file and uploaded_file.filename else ''
+    extension = os.path.splitext(file_name.lower())[1]
+    accepted = {'.cap', '.pcap', '.pcapng', '.hc22000', '.hccapx'}
+    checks = [
+        'SSID/BSSID/channel are explicitly scoped to the authorized lab target.',
+        'Evidence is cataloged for validation/export only; password cracking is out of scope.',
+    ]
+    if file_name:
+        checks.append('Uploaded capture extension is recognized.' if extension in accepted else 'Uploaded capture extension is unusual; verify manually.')
+    else:
+        checks.append('No capture uploaded yet; record is ready for later evidence attachment.')
+    status = 'needs-review' if file_name and extension not in accepted else 'cataloged'
+    return {'validation_status': status, 'validation_checks': checks}
+
+
+def record_handshake_evidence(selected_interface, lab, uploaded_file, create_evidence_record, records, lock, save_state, logger):
+    """Catalog handshake/PMKID lab evidence and mirror it into the evidence vault."""
+    validation = validate_handshake_evidence(lab, uploaded_file=uploaded_file)
+    evidence = create_evidence_record(
+        f"{lab['capture_type'].upper()} evidence for {lab['ssid']}",
+        category='capture',
+        source='WPA handshake capture lab',
+        device=lab['bssid'],
+        notes=lab['validation_notes'],
+        content='\n'.join(validation['validation_checks']),
+        uploaded_file=uploaded_file,
+    )
+    record = {
+        'id': uuid.uuid4().hex,
+        'created_at': time.time(),
+        'interface': selected_interface,
+        **lab,
+        **validation,
+        'evidence_id': evidence['id'],
+        'download_url': evidence.get('download_url'),
+        'file_name': evidence.get('file_name'),
+        'file_size': evidence.get('file_size'),
+    }
+    with lock:
+        records.insert(0, record)
+        del records[200:]
+    save_state('handshake-lab')
+    logger.info('Handshake lab evidence %s cataloged for SSID %r BSSID %s', record['capture_type'], record['ssid'], record['bssid'])
+    return record
+
+
+def export_handshake_records(records, lock):
+    with lock:
+        exported = [dict(item) for item in records]
+    for item in exported:
+        item['created_at_label'] = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(item.get('created_at', 0)))
+    return exported
+
+
+def handshake_records_csv(records):
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['SSID', 'BSSID', 'Channel', 'Type', 'Client', 'Status', 'File', 'Created'])
+    for item in records:
+        writer.writerow([item.get('ssid'), item.get('bssid'), item.get('channel'), item.get('capture_type'), item.get('client'), item.get('validation_status'), item.get('file_name'), item.get('created_at_label')])
+    return output.getvalue()

--- a/services/oui.py
+++ b/services/oui.py
@@ -1,0 +1,23 @@
+"""Canonical OUI/vendor lookup service.
+
+All app features should resolve MAC vendors through this module so cards,
+inventory records, wireless details, and capabilities use the same local IEEE
+OUI database plus the same built-in fallback map.
+"""
+
+from scripts import interfaceTools
+
+
+def lookup_manufacturer(mac):
+    """Return the vendor for a MAC address using the shared OUI backend."""
+    return interfaceTools.lookup_manufacturer(mac)
+
+
+def refresh_oui_database():
+    """Reload the shared OUI backend after the local database is updated."""
+    return interfaceTools.refresh_oui_database()
+
+
+def oui_database_status():
+    """Return status for the shared OUI backend."""
+    return interfaceTools.oui_database_status()

--- a/services/persistence.py
+++ b/services/persistence.py
@@ -1,0 +1,62 @@
+"""Small JSON persistence helpers for runtime inventory/profile state."""
+
+import json
+import os
+import tempfile
+import time
+
+DEFAULT_DATA_DIR = os.path.join(os.path.dirname(os.path.dirname(__file__)), 'data')
+STATE_SCHEMA_VERSION = 1
+
+
+def state_path():
+    return os.environ.get('MOBILE_ROUTER_STATE_PATH') or os.path.join(
+        os.environ.get('MOBILE_ROUTER_DATA_DIR', DEFAULT_DATA_DIR),
+        'runtime_state.json',
+    )
+
+
+def _json_safe(value):
+    if isinstance(value, set):
+        return sorted(value)
+    if isinstance(value, dict):
+        return {str(key): _json_safe(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_json_safe(item) for item in value]
+    return value
+
+
+def load_state(path=None):
+    path = path or state_path()
+    if not os.path.exists(path):
+        return {}
+    try:
+        with open(path, encoding='utf-8') as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    return payload
+
+
+def save_state(state, path=None):
+    path = path or state_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    payload = {
+        'schema_version': STATE_SCHEMA_VERSION,
+        'saved_at': time.time(),
+        **_json_safe(state),
+    }
+    fd, tmp_path = tempfile.mkstemp(prefix='.runtime-state-', suffix='.json', dir=os.path.dirname(path))
+    try:
+        with os.fdopen(fd, 'w', encoding='utf-8') as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+        os.replace(tmp_path, path)
+    finally:
+        if os.path.exists(tmp_path):
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+    return path

--- a/services/port_scans.py
+++ b/services/port_scans.py
@@ -1,0 +1,142 @@
+"""Background port-scan job state and execution helpers."""
+
+import time
+
+def job_snapshot(job):
+    """Return a serializable snapshot of a port-scan job."""
+    return {
+        **job,
+        'kind': 'port-scan',
+        'open_ports': list(job.get('open_ports', [])),
+        'open_port_details': list(job.get('open_port_details', [])),
+        'cancelable': job.get('status') in {'queued', 'running'},
+    }
+
+
+def all_snapshots(jobs, lock):
+    """Return all port-scan job snapshots sorted by update time."""
+    with lock:
+        snapshots = [job_snapshot(job) for job in jobs.values()]
+    return sorted(
+        snapshots,
+        key=lambda item: item.get('updated_at') or item.get('created_at') or 0,
+        reverse=True,
+    )
+
+
+def update_job(jobs, lock, job_id, **updates):
+    """Update a port-scan job and return its latest snapshot."""
+    with lock:
+        job = jobs.get(job_id)
+        if not job:
+            return None
+        job.update(updates)
+        job['updated_at'] = time.time()
+        return job_snapshot(job)
+
+
+def running_count(jobs, lock):
+    """Count queued or running port-scan jobs."""
+    with lock:
+        return len([job for job in jobs.values() if job.get('status') in {'queued', 'running'}])
+
+
+def run_job(job_id, jobs, lock, enrich_web_port_metadata, record_device_open_ports):
+    """Run a cancellable background TCP port scan and persist open-port profiles."""
+    from scripts.portScanner import PortScanError, describe_open_ports, identify_port_service, scan_ports
+
+    with lock:
+        job = jobs.get(job_id)
+        if not job:
+            return
+        host = job['host']
+        start = job['start']
+        end = job['end']
+        total = job['total_ports']
+        job['status'] = 'running'
+        job['started_at'] = time.time()
+        job['updated_at'] = job['started_at']
+
+    scanned = 0
+
+    def on_open(port):
+        service_detail = enrich_web_port_metadata(host, identify_port_service(port))
+        with lock:
+            current = jobs.get(job_id)
+            if not current:
+                return
+            if port not in current['open_ports']:
+                current['open_ports'].append(port)
+                current['open_ports'].sort()
+                current.setdefault('open_port_details', []).append(service_detail)
+                current['open_port_details'] = sorted(
+                    current['open_port_details'],
+                    key=lambda item: item['port'],
+                )
+            current['message'] = f"Open port found: {port} ({service_detail['service']})"
+            current['updated_at'] = time.time()
+        record_device_open_ports(host, [service_detail], source='port-scan-live')
+
+    def should_cancel():
+        with lock:
+            return bool(jobs.get(job_id, {}).get('cancel_requested'))
+
+    def on_progress(port):
+        nonlocal scanned
+        scanned += 1
+        with lock:
+            current = jobs.get(job_id)
+            if not current:
+                return
+            current['scanned_ports'] = scanned
+            current['current_port'] = port
+            current['progress'] = round((scanned / total) * 100, 1) if total else 100
+            current['updated_at'] = time.time()
+
+    try:
+        ports = scan_ports(
+            host,
+            start,
+            end,
+            on_open=on_open,
+            on_progress=on_progress,
+            should_cancel=should_cancel,
+            max_ports=None,
+        )
+        if should_cancel():
+            update_job(
+                jobs,
+                lock,
+                job_id,
+                status='cancelled',
+                completed_at=time.time(),
+                message='Port scan cancelled.',
+            )
+            return
+        final_details = [enrich_web_port_metadata(host, detail) for detail in describe_open_ports(ports)]
+        record_device_open_ports(host, final_details, source='port-scan')
+        update_job(
+            jobs,
+            lock,
+            job_id,
+            status='complete',
+            open_ports=ports,
+            open_port_details=final_details,
+            scanned_ports=total,
+            current_port=end,
+            progress=100,
+            completed_at=time.time(),
+            message=f'Port scan complete: {len(ports)} open port(s) found.',
+        )
+    except PortScanError as exc:
+        update_job(jobs, lock, job_id, status='failed', error=str(exc), message=str(exc), completed_at=time.time())
+    except Exception as exc:
+        update_job(
+            jobs,
+            lock,
+            job_id,
+            status='failed',
+            error=str(exc),
+            message=f'Port scan failed: {exc}',
+            completed_at=time.time(),
+        )

--- a/services/reports.py
+++ b/services/reports.py
@@ -1,0 +1,97 @@
+"""Report assembly and export format helpers."""
+
+import csv
+import io
+import time
+
+
+def build_report_data(network_interfaces, inventory_records, manufacturer_insights, all_job_snapshots, alert_records, evidence_records, build_capabilities):
+    """Collect the current application state for report exports."""
+    devices = inventory_records()
+    exported_at = time.time()
+    return {
+        'exported_at': exported_at,
+        'exported_at_label': time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(exported_at)),
+        'interfaces': [iface.to_dict() for iface in network_interfaces],
+        'devices': devices,
+        'insights': manufacturer_insights(devices),
+        'jobs': all_job_snapshots(),
+        'alerts': alert_records(),
+        'evidence': evidence_records(),
+        'capabilities': build_capabilities(),
+    }
+
+
+def report_as_csv(report):
+    output = io.StringIO()
+    writer = csv.writer(output)
+    writer.writerow(['Mobile Router Report'])
+    writer.writerow(['Exported at', report['exported_at_label']])
+    writer.writerow([])
+    writer.writerow(['Devices'])
+    writer.writerow(['Name', 'IP', 'MAC', 'Manufacturer', 'Sources', 'Interfaces', 'First seen', 'Last seen'])
+    for device in report['devices']:
+        writer.writerow([
+            device.get('display_name'),
+            device.get('ip'),
+            device.get('mac') or device.get('bssid'),
+            device.get('manufacturer'),
+            ', '.join(device.get('sources', [])),
+            ', '.join(device.get('interfaces', [])),
+            device.get('first_seen_label'),
+            device.get('last_seen_label'),
+        ])
+    writer.writerow([])
+    writer.writerow(['Interfaces'])
+    writer.writerow(['Name', 'Type', 'State', 'Manufacturer'])
+    for iface in report['interfaces']:
+        writer.writerow([iface.get('name'), iface.get('interface_type'), iface.get('state'), iface.get('manufacturer')])
+    writer.writerow([])
+    writer.writerow(['Jobs'])
+    writer.writerow(['ID', 'Kind', 'Label', 'Status', 'Progress'])
+    for job in report['jobs']:
+        writer.writerow([job.get('id'), job.get('kind'), job.get('label') or job.get('scan_type'), job.get('status'), job.get('progress')])
+    writer.writerow([])
+    writer.writerow(['Evidence'])
+    writer.writerow(['Title', 'Category', 'Source', 'Device', 'File', 'Created'])
+    for item in report['evidence']:
+        writer.writerow([item.get('title'), item.get('category'), item.get('source'), item.get('device'), item.get('file_name'), item.get('created_at_label')])
+    writer.writerow([])
+    writer.writerow(['Alerts'])
+    writer.writerow(['Device', 'IP', 'MAC', 'Manufacturer', 'Source', 'Read', 'Created'])
+    for alert in report['alerts']:
+        writer.writerow([alert.get('display_name'), alert.get('ip'), alert.get('mac'), alert.get('manufacturer'), alert.get('source'), alert.get('read'), alert.get('created_at_label')])
+    return output.getvalue()
+
+
+def report_as_markdown(report):
+    lines = [
+        '# Mobile Router Report',
+        '',
+        f"Exported at: {report['exported_at_label']}",
+        '',
+        '## Summary',
+        f"- Devices: {report['insights']['total_devices']}",
+        f"- Known manufacturers: {report['insights']['known_manufacturers']}",
+        f"- Unknown manufacturers: {report['insights']['unknown_manufacturers']}",
+        f"- Interfaces: {len(report['interfaces'])}",
+        f"- Jobs: {len(report['jobs'])}",
+        f"- Alerts: {len(report['alerts'])}",
+        f"- Evidence records: {len(report['evidence'])}",
+        '',
+        '## Devices',
+        '| Name | IP | MAC/BSSID | Manufacturer | Sources |',
+        '| --- | --- | --- | --- | --- |',
+    ]
+    for device in report['devices']:
+        lines.append(f"| {device.get('display_name', '')} | {device.get('ip') or ''} | {device.get('mac') or device.get('bssid') or ''} | {device.get('manufacturer') or ''} | {', '.join(device.get('sources', []))} |")
+    lines.extend(['', '## Interfaces', '| Name | Type | State | Manufacturer |', '| --- | --- | --- | --- |'])
+    for iface in report['interfaces']:
+        lines.append(f"| {iface.get('name', '')} | {iface.get('interface_type', '')} | {iface.get('state', '')} | {iface.get('manufacturer', '')} |")
+    lines.extend(['', '## Evidence', '| Title | Category | Source | Device | File | Created |', '| --- | --- | --- | --- | --- | --- |'])
+    for item in report['evidence']:
+        lines.append(f"| {item.get('title', '')} | {item.get('category', '')} | {item.get('source') or ''} | {item.get('device') or ''} | {item.get('file_name') or ''} | {item.get('created_at_label') or ''} |")
+    lines.extend(['', '## Alerts', '| Device | IP | MAC | Source | Read |', '| --- | --- | --- | --- | --- |'])
+    for alert in report['alerts']:
+        lines.append(f"| {alert.get('display_name', '')} | {alert.get('ip') or ''} | {alert.get('mac') or ''} | {alert.get('source') or ''} | {alert.get('read')} |")
+    return '\n'.join(lines) + '\n'

--- a/services/wireless_clients.py
+++ b/services/wireless_clients.py
@@ -82,7 +82,10 @@ def merge_network_clients(network, cache, labels, normalize_mac, inventory_recor
         if client.get('mac') or client.get('ip')
     }
     cached = {
-        client.get('mac') or client.get('ip'): {**dict(client), 'currently_visible': False}
+        client.get('mac') or client.get('ip'): {
+            **dict(client),
+            'currently_visible': bool(client.get('network_scan_scoped')) if client.get('network_scan_scoped') else False,
+        }
         for client in existing_cache
         if client.get('mac') or client.get('ip')
     }

--- a/services/wireless_clients.py
+++ b/services/wireless_clients.py
@@ -1,0 +1,165 @@
+"""Wireless-network client cache, labels, and display helpers."""
+
+import time
+
+
+HIDDEN_SSID_LABEL = '<Hidden SSID>'
+
+
+def cache_key(network, normalize_mac):
+    """Build a stable cache key for SSID/interface/BSSID scoped clients."""
+    return (
+        (network.get('interface') or '').strip(),
+        (network.get('ssid') or HIDDEN_SSID_LABEL).strip(),
+        normalize_mac(network.get('bssid')) or 'any-bssid',
+    )
+
+
+def client_label_key(interface, ssid, bssid, identity, normalize_mac):
+    """Build a stable key for a custom client label scoped to one Wi-Fi network."""
+    return (
+        (interface or '').strip(),
+        (ssid or HIDDEN_SSID_LABEL).strip(),
+        normalize_mac(bssid) or 'any-bssid',
+        (identity or '').strip(),
+    )
+
+
+def client_display_label(network, client, labels, normalize_mac):
+    """Resolve the best display label for a client on a specific Wi-Fi network."""
+    identity = client.get('mac') or client.get('ip')
+    label = labels.get(
+        client_label_key(
+            network.get('interface'),
+            network.get('ssid'),
+            network.get('bssid'),
+            identity,
+            normalize_mac,
+        )
+    )
+    if label:
+        return label
+    return (
+        client.get('display_name')
+        or client.get('hostname')
+        or client.get('name')
+        or client.get('ip')
+        or client.get('mac')
+        or 'Client'
+    )
+
+
+def sort_clients(clients):
+    """Sort network clients by role, saved service profile, known state, then label."""
+    return sorted(
+        clients,
+        key=lambda item: (
+            item.get('sort_bucket', 9),
+            0 if item.get('network_known_state') == 'New' else 1,
+            (item.get('display_name') or item.get('ip') or item.get('mac') or '').lower(),
+        ),
+    )
+
+
+def merge_network_clients(network, cache, labels, normalize_mac, inventory_records):
+    """Persist and merge wireless clients plus inventory devices for a network view."""
+    key = cache_key(network, normalize_mac)
+    now = time.time()
+    existing_cache = cache.get(key, [])
+    known_identities = {
+        client.get('mac') or client.get('ip')
+        for client in existing_cache
+        if client.get('mac') or client.get('ip')
+    }
+    cached = {
+        client.get('mac') or client.get('ip'): {**dict(client), 'currently_visible': False}
+        for client in existing_cache
+        if client.get('mac') or client.get('ip')
+    }
+    for raw_client in network.get('clients') or []:
+        client = dict(raw_client)
+        mac = normalize_mac(client.get('mac'))
+        if mac:
+            client['mac'] = mac
+        client['source'] = client.get('source') or 'wireless-client-observation'
+        identity = client.get('mac') or client.get('ip')
+        if not identity:
+            continue
+        previous = cached.get(identity, {})
+        client['network_first_seen'] = previous.get('network_first_seen') or now
+        client['network_last_seen'] = now
+        client['currently_visible'] = True
+        cached[identity] = {**previous, **client}
+
+    interface_name = network.get('interface')
+    inventory_devices = []
+    for device in inventory_records():
+        if interface_name and interface_name not in set(device.get('interfaces') or []):
+            continue
+        if device.get('is_control_traffic') or not (device.get('ip') or device.get('mac')):
+            continue
+        inventory_devices.append(device)
+        identity = device.get('mac') or device.get('ip')
+        previous = cached.get(identity, {})
+        cached[identity] = {
+            **previous,
+            'mac': device.get('mac') or previous.get('mac'),
+            'ip': device.get('ip') or previous.get('ip'),
+            'display_name': device.get('display_name'),
+            'manufacturer': device.get('manufacturer'),
+            'sources': device.get('sources', []),
+            'discovery_methods': device.get('discovery_methods') or device.get('sources', []),
+            'network_role': device.get('network_role'),
+            'network_scope': device.get('network_scope'),
+            'scan_note': device.get('scan_note'),
+            'open_port_details': device.get('open_port_details', []),
+            'client_tags': device.get('client_tags', []),
+            'client_notes': device.get('client_notes'),
+            'observed_names': device.get('observed_names', []),
+            'likely_randomized_mac': device.get('likely_randomized_mac'),
+            'device_role_guess': device.get('device_role_guess'),
+            'network_first_seen': previous.get('network_first_seen') or device.get('first_seen') or now,
+            'network_last_seen': max(
+                previous.get('network_last_seen') or 0,
+                device.get('last_seen') or now,
+            ),
+            'source': 'inventory',
+        }
+
+    for identity, client in list(cached.items()):
+        first_seen = client.get('network_first_seen') or now
+        client['network_first_seen'] = first_seen
+        client['network_last_seen'] = client.get('network_last_seen') or now
+        client['network_known_state'] = (
+            'Known' if identity in known_identities or (now - first_seen) > 86400 else 'New'
+        )
+        client['has_open_ports'] = bool(client.get('open_port_details'))
+        client['sort_bucket'] = (
+            0
+            if 'gateway' in str(client.get('network_role') or '').lower()
+            else (1 if client.get('has_open_ports') else 2)
+        )
+        client['custom_label'] = labels.get(
+            client_label_key(
+                network.get('interface'),
+                network.get('ssid'),
+                network.get('bssid'),
+                identity,
+                normalize_mac,
+            )
+        )
+        client['display_name'] = client_display_label(network, client, labels, normalize_mac)
+
+    disappeared_clients = sort_clients([
+        client
+        for client in cached.values()
+        if not client.get('currently_visible') and client.get('source') != 'inventory'
+    ])
+    clients = sort_clients([client for client in cached.values() if client not in disappeared_clients])
+    cache[key] = clients + disappeared_clients
+    network['clients'] = clients
+    network['disappeared_clients'] = disappeared_clients
+    network['interface_devices'] = inventory_devices
+    network['client_count'] = len(clients)
+    network['inventory_device_count'] = len(inventory_devices)
+    return network

--- a/services/wireless_clients.py
+++ b/services/wireless_clients.py
@@ -72,7 +72,10 @@ def merge_network_clients(network, cache, labels, normalize_mac, inventory_recor
     """Persist and merge wireless clients plus inventory devices for a network view."""
     key = cache_key(network, normalize_mac)
     now = time.time()
-    existing_cache = cache.get(key, [])
+    existing_cache = [
+        dict(client) for client in cache.get(key, [])
+        if client.get('source') != 'inventory'
+    ]
     known_identities = {
         client.get('mac') or client.get('ip')
         for client in existing_cache
@@ -107,16 +110,24 @@ def merge_network_clients(network, cache, labels, normalize_mac, inventory_recor
             continue
         if device.get('is_control_traffic') or not (device.get('ip') or device.get('mac')):
             continue
+
+        possible_identities = [value for value in (device.get('mac'), device.get('ip')) if value]
+        matched_identity = next((identity for identity in possible_identities if identity in cached), None)
+        if not matched_identity:
+            # Inventory is interface-scoped, not SSID/BSSID-scoped. Never inject a
+            # device into a Wi-Fi network page unless that exact identity was
+            # already observed or cached for this specific network key.
+            continue
+
         inventory_devices.append(device)
-        identity = device.get('mac') or device.get('ip')
-        previous = cached.get(identity, {})
+        previous = cached.get(matched_identity, {})
         resolved_manufacturer = _known_manufacturer(
             device.get('manufacturer'),
             previous.get('manufacturer'),
             lookup_manufacturer(device.get('mac')) if lookup_manufacturer and device.get('mac') else None,
             'Unknown',
         )
-        cached[identity] = {
+        cached[matched_identity] = {
             **previous,
             'mac': device.get('mac') or previous.get('mac'),
             'ip': device.get('ip') or previous.get('ip'),
@@ -138,7 +149,7 @@ def merge_network_clients(network, cache, labels, normalize_mac, inventory_recor
                 previous.get('network_last_seen') or 0,
                 device.get('last_seen') or now,
             ),
-            'source': 'inventory',
+            'source': previous.get('source') or 'wireless-client-observation',
         }
 
     for identity, client in list(cached.items()):

--- a/services/wireless_clients.py
+++ b/services/wireless_clients.py
@@ -61,7 +61,14 @@ def sort_clients(clients):
     )
 
 
-def merge_network_clients(network, cache, labels, normalize_mac, inventory_records):
+def _known_manufacturer(*values):
+    for value in values:
+        if value and value != 'Unknown' and value != 'Unknown manufacturer':
+            return value
+    return None
+
+
+def merge_network_clients(network, cache, labels, normalize_mac, inventory_records, lookup_manufacturer=None):
     """Persist and merge wireless clients plus inventory devices for a network view."""
     key = cache_key(network, normalize_mac)
     now = time.time()
@@ -82,6 +89,8 @@ def merge_network_clients(network, cache, labels, normalize_mac, inventory_recor
         if mac:
             client['mac'] = mac
         client['source'] = client.get('source') or 'wireless-client-observation'
+        looked_up_manufacturer = lookup_manufacturer(mac) if lookup_manufacturer and mac else None
+        client['manufacturer'] = _known_manufacturer(client.get('manufacturer'), looked_up_manufacturer, 'Unknown')
         identity = client.get('mac') or client.get('ip')
         if not identity:
             continue
@@ -101,12 +110,18 @@ def merge_network_clients(network, cache, labels, normalize_mac, inventory_recor
         inventory_devices.append(device)
         identity = device.get('mac') or device.get('ip')
         previous = cached.get(identity, {})
+        resolved_manufacturer = _known_manufacturer(
+            device.get('manufacturer'),
+            previous.get('manufacturer'),
+            lookup_manufacturer(device.get('mac')) if lookup_manufacturer and device.get('mac') else None,
+            'Unknown',
+        )
         cached[identity] = {
             **previous,
             'mac': device.get('mac') or previous.get('mac'),
             'ip': device.get('ip') or previous.get('ip'),
             'display_name': device.get('display_name'),
-            'manufacturer': device.get('manufacturer'),
+            'manufacturer': resolved_manufacturer,
             'sources': device.get('sources', []),
             'discovery_methods': device.get('discovery_methods') or device.get('sources', []),
             'network_role': device.get('network_role'),

--- a/setup.sh
+++ b/setup.sh
@@ -5,10 +5,10 @@ set -e
 PYTHON_BIN="python3"
 PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PYLIB_DIR="$PROJECT_DIR/pylibs"
-# Allow keeping the OUI database outside the repository
-OUI_DIR="$(dirname "$(dirname "$PROJECT_DIR")")/oui"
+# Keep setup aligned with the app and Capabilities UI by using the
+# canonical downloader target consumed by services.oui/interfaceTools.
+OUI_DIR="$PROJECT_DIR/oui"
 OUI_DB="$OUI_DIR/oui_db.csv"
-OUI_URL="https://standards-oui.ieee.org/oui/oui.csv"
 
 echo "==> Checking for $PYTHON_BIN..."
 
@@ -38,13 +38,8 @@ echo "==> Ensuring OUI database is available..."
 mkdir -p "$OUI_DIR"
 if [ ! -f "$OUI_DB" ] || find "$OUI_DB" -mtime +30 >/dev/null 2>&1; then
     echo "Downloading latest OUI database..."
-    if command -v wget >/dev/null 2>&1; then
-        wget -q -O "$OUI_DB" "$OUI_URL"
-    elif command -v curl >/dev/null 2>&1; then
-        curl -L -o "$OUI_DB" "$OUI_URL"
-    else
-        echo "Neither wget nor curl is installed. Cannot download OUI database." >&2
-        exit 1
+    if ! "$PYTHON_BIN" "$PROJECT_DIR/scripts/update_oui_db.py"; then
+        echo "Unable to refresh OUI database; continuing with bundled/fallback entries." >&2
     fi
 fi
 

--- a/static/css/interface.css
+++ b/static/css/interface.css
@@ -309,6 +309,47 @@
   width: 100%;
 }
 
+.network-device-filterbar {
+  align-items: center;
+  background: #f8fbff;
+  border: 1px solid #e6edf7;
+  border-radius: 0.75rem;
+  display: flex;
+  gap: 0.75rem;
+  justify-content: space-between;
+  padding: 0.75rem;
+}
+
+.network-device-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.network-device-notes-form {
+  border: 1px solid #e6edf7;
+  border-radius: 0.65rem;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.6rem;
+}
+
+.network-device-label-form {
+  border: 1px dashed #b8d4f3;
+  border-radius: 0.65rem;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.6rem;
+}
+
+.network-device-progress {
+  min-height: 0.7rem;
+}
+
+.network-device-card-disappeared {
+  opacity: 0.82;
+}
+
 .wireless-connect-form {
   width: 100%;
 }
@@ -586,4 +627,80 @@ body.wireless-map-open {
   font-weight: 700;
   line-height: 1;
   min-width: 2.25rem;
+}
+
+.network-scan-all-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.network-device-card-grid {
+  margin-top: 1rem;
+}
+
+.network-device-card-control {
+  opacity: 0.82;
+}
+
+.network-device-bottom {
+  grid-template-columns: minmax(14rem, 1fr) minmax(12rem, 18rem);
+}
+
+.network-device-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.45rem;
+  justify-self: end;
+  width: min(100%, 18rem);
+}
+
+.network-device-open-ports {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+.client-timeline {
+  border-left: 2px solid rgba(56, 189, 248, 0.35);
+  list-style: none;
+  margin: 1rem 0 0;
+  padding-left: 1rem;
+}
+
+.client-timeline li {
+  margin-bottom: 0.85rem;
+  position: relative;
+}
+
+.client-timeline li::before {
+  background: #38bdf8;
+  border-radius: 999px;
+  content: '';
+  height: 0.65rem;
+  left: -1.4rem;
+  position: absolute;
+  top: 0.35rem;
+  width: 0.65rem;
+}
+
+.network-detail-tabs {
+  gap: 0.25rem;
+}
+
+.network-detail-tab-content {
+  margin-top: 0.75rem;
+}
+
+@media (max-width: 768px) {
+  .network-device-bottom {
+    grid-template-columns: 1fr;
+  }
+
+  .network-device-actions {
+    justify-self: stretch;
+    width: 100%;
+  }
 }

--- a/static/css/red-team.css
+++ b/static/css/red-team.css
@@ -74,3 +74,25 @@
   border-color: #dc3545;
   box-shadow: 0 0 0 0.2rem rgba(220, 53, 69, 0.15);
 }
+
+.evil-twin-guidance {
+  background: #f8f9fa;
+  border-radius: 0.75rem;
+  color: #495057;
+  padding: 0.75rem;
+}
+
+.evil-twin-guidance ul {
+  margin-bottom: 0;
+  padding-left: 1.1rem;
+}
+
+.evil-twin-status {
+  min-height: 1.25rem;
+}
+
+.pineap-lab-card textarea,
+.handshake-lab-card textarea,
+.evil-twin-lab-card textarea {
+  resize: vertical;
+}

--- a/static/js/advanced-diagnostics.js
+++ b/static/js/advanced-diagnostics.js
@@ -1,0 +1,34 @@
+$(document).ready(function () {
+  function escapeHtml(value) { return $('<div>').text(value == null ? '' : value).html(); }
+  function show(title, result) { $('#advanced-diagnostics-results').html(`<h3>${escapeHtml(title)}</h3><pre>${escapeHtml(JSON.stringify(result, null, 2))}</pre>`); }
+  function post(url, data, title) {
+    $('#advanced-diagnostics-results').html('<p>Running...</p>');
+    $.ajax({
+      url: url,
+      method: 'POST',
+      data: data,
+      success: function (response) { show(title, response.result); },
+      error: function (xhr) { $('#advanced-diagnostics-results').html(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Request failed')}</div>`); }
+    });
+  }
+  $('#vlan-discovery-btn').on('click', function (event) {
+    event.preventDefault();
+    post('/vlan-discovery', { ssid: $('#vlan-ssid').val(), vlanId: $('#vlan-id').val(), notes: $('#vlan-notes').val() }, 'VLAN context');
+  });
+  $('#egress-diagnostics-btn').on('click', function (event) {
+    event.preventDefault();
+    post('/egress-diagnostics', { selectedInterface: $('#interface-select-AdvancedDiagnostics').val() }, 'Egress diagnostics');
+  });
+  $('#iperf-client-btn').on('click', function (event) {
+    event.preventDefault();
+    post('/iperf3-test', { mode: 'client', host: $('#iperf-host').val(), port: $('#iperf-port').val(), seconds: $('#iperf-seconds').val() }, 'iperf3 result');
+  });
+  $('#snmp-discovery-btn').on('click', function (event) {
+    event.preventDefault();
+    post('/snmp-discovery', { host: $('#snmp-host').val(), community: $('#snmp-community').val(), authorized: $('#snmp-authorized').is(':checked') ? 'on' : '' }, 'SNMP inventory');
+  });
+  $('#ipv6-assessment-btn').on('click', function (event) {
+    event.preventDefault();
+    post('/ipv6-assessment', { host: $('#ipv6-host').val(), ports: $('#ipv6-ports').val() }, 'IPv6 assessment');
+  });
+});

--- a/static/js/capabilities.js
+++ b/static/js/capabilities.js
@@ -35,6 +35,34 @@ $(document).ready(function () {
     });
   });
 
+  $('.update-oui-db-btn').on('click', function () {
+    const button = $(this);
+    const response = $('#package-install-response');
+    const confirmed = window.confirm('Download the full IEEE OUI vendor database now? This replaces the compact local OUI CSV.');
+    if (!confirmed) return;
+
+    $.ajax({
+      url: '/capabilities/update-oui-database',
+      type: 'POST',
+      data: { confirm: button.data('confirm') },
+      beforeSend: function () {
+        button.prop('disabled', true).text('Downloading full OUI DB...');
+        response.html('<div class="alert alert-info" role="alert">Downloading the full IEEE OUI database. This can take a minute.</div>');
+      },
+      success: function (resp) {
+        response.html(`<div class="alert alert-success" role="alert">${escapeHtml(resp.message || 'OUI database updated.')} Refreshing capabilities...</div>`);
+        window.setTimeout(function () { window.location.reload(); }, 1500);
+      },
+      error: function (xhr) {
+        const message = xhr.responseJSON?.message || 'Unable to update the OUI database';
+        response.html(`<div class="alert alert-danger" role="alert">${escapeHtml(message)}</div>`);
+      },
+      complete: function () {
+        button.prop('disabled', false).text('Download full OUI database');
+      }
+    });
+  });
+
   $('.install-host-dependency-btn').on('click', function () {
     const button = $(this);
     const dependency = button.data('dependency');

--- a/static/js/capabilities.js
+++ b/static/js/capabilities.js
@@ -34,4 +34,33 @@ $(document).ready(function () {
       }
     });
   });
+
+  $('.install-host-dependency-btn').on('click', function () {
+    const button = $(this);
+    const dependency = button.data('dependency');
+    const response = $('#package-install-response');
+    const confirmed = window.confirm('Install browser screenshot tooling on this host? This runs the local package manager and can take several minutes.');
+    if (!confirmed) return;
+
+    $.ajax({
+      url: '/capabilities/install-host-dependency',
+      type: 'POST',
+      data: { dependency: dependency, confirm: button.data('confirm') },
+      beforeSend: function () {
+        button.prop('disabled', true).text('Installing...');
+        response.html(`<div class="alert alert-info" role="alert">Installing ${escapeHtml(dependency)} host tooling. This can take several minutes.</div>`);
+      },
+      success: function (resp) {
+        response.html(`<div class="alert alert-success" role="alert">${escapeHtml(resp.message || 'Host dependency installed.')} Refreshing capabilities...</div>`);
+        window.setTimeout(function () { window.location.reload(); }, 1500);
+      },
+      error: function (xhr) {
+        const message = xhr.responseJSON?.message || `Unable to install ${dependency}`;
+        response.html(`<div class="alert alert-danger" role="alert">${escapeHtml(message)}</div>`);
+      },
+      complete: function () {
+        button.prop('disabled', false).text('Install for me');
+      }
+    });
+  });
 });

--- a/static/js/diagnostics.js
+++ b/static/js/diagnostics.js
@@ -1,0 +1,71 @@
+$(document).ready(function () {
+  function escapeHtml(value) {
+    return $('<div>').text(value == null ? '' : value).html();
+  }
+
+  function latencyText(result) {
+    const latency = result.latency || {};
+    if (latency.avg_ms == null) { return 'No latency stats'; }
+    return `min ${latency.min_ms} ms · avg ${latency.avg_ms} ms · max ${latency.max_ms} ms`;
+  }
+
+  function renderPingResult(result) {
+    return `<div class="alert ${result.reachable ? 'alert-success' : 'alert-warning'}">
+      <strong>${escapeHtml(result.host)}</strong> ${result.reachable ? 'reachable' : 'not reachable'}<br>
+      Loss: ${escapeHtml(result.packet_loss_percent)}% · ${escapeHtml(latencyText(result))}
+    </div>`;
+  }
+
+  $('#ping-btn').on('click', function (event) {
+    event.preventDefault();
+    $.ajax({
+      url: '/ping',
+      method: 'POST',
+      data: { host: $('#ping-host').val() },
+      success: function (response) { $('#ping-results').html(renderPingResult(response.result)); },
+      error: function (xhr) { $('#ping-results').html(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Ping failed')}</div>`); }
+    });
+  });
+
+  $('#ping-sweep-btn').on('click', function (event) {
+    event.preventDefault();
+    $.ajax({
+      url: '/ping-sweep',
+      method: 'POST',
+      data: { cidr: $('#ping-cidr').val() },
+      success: function (response) {
+        let html = `<h3>Sweep ${escapeHtml(response.sweep.cidr)}</h3><p>${response.sweep.reachable_hosts}/${response.sweep.total_hosts} hosts reachable</p>`;
+        response.sweep.results.forEach(function (result) { html += renderPingResult(result); });
+        $('#ping-results').html(html);
+      },
+      error: function (xhr) { $('#ping-results').html(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Sweep failed')}</div>`); }
+    });
+  });
+
+  $('#route-diagnostics-btn').on('click', function (event) {
+    event.preventDefault();
+    $.ajax({
+      url: '/route-diagnostics',
+      method: 'POST',
+      data: { target: $('#route-target').val() },
+      success: function (response) {
+        const data = response.diagnostics;
+        let html = `<h3>Default gateways</h3>`;
+        if (!data.default_gateways.length) {
+          html += '<p>No default gateways parsed.</p>';
+        } else {
+          html += '<ul>';
+          data.default_gateways.forEach(function (route) { html += `<li>${escapeHtml(route.gateway || 'direct')} via ${escapeHtml(route.interface || 'unknown')} metric ${escapeHtml(route.metric || 'n/a')}</li>`; });
+          html += '</ul>';
+        }
+        html += `<h3>VPN route hints</h3><p>${data.vpn_hints.length ? data.vpn_hints.map(function (route) { return escapeHtml(route.raw); }).join('<br>') : 'No VPN-like interfaces detected in parsed routes.'}</p>`;
+        html += `<h3>Scan-path context</h3><pre>${escapeHtml(data.scan_path_context || 'No target route requested.')}</pre>`;
+        html += '<h3>Routes</h3><div class="table-responsive"><table class="table theme-table"><thead><tr><th>Family</th><th>Destination</th><th>Gateway</th><th>Interface</th><th>Metric</th></tr></thead><tbody>';
+        data.routes.forEach(function (route) { html += `<tr><td>${escapeHtml(route.family)}</td><td>${escapeHtml(route.destination)}</td><td>${escapeHtml(route.gateway || 'direct')}</td><td>${escapeHtml(route.interface || '')}</td><td>${escapeHtml(route.metric || '')}</td></tr>`; });
+        html += '</tbody></table></div>';
+        $('#route-results').html(html);
+      },
+      error: function (xhr) { $('#route-results').html(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Route diagnostics failed')}</div>`); }
+    });
+  });
+});

--- a/static/js/ip_client.js
+++ b/static/js/ip_client.js
@@ -1,0 +1,237 @@
+$(document).ready(function () {
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function clientHost() {
+    return $('[data-ip-client-tools]').data('host') || '';
+  }
+
+  function output(html) {
+    $('[data-ip-client-output]').html(html);
+  }
+
+  function renderPing(result) {
+    const reachable = result.reachable ? 'reachable' : 'unreachable';
+    const loss = result.packet_loss_percent !== null && result.packet_loss_percent !== undefined ? `${result.packet_loss_percent}% loss` : 'loss unknown';
+    const avg = result.avg_latency_ms !== null && result.avg_latency_ms !== undefined ? `${result.avg_latency_ms} ms avg` : 'latency unknown';
+    return `<div class="alert alert-${result.reachable ? 'success' : 'warning'}"><strong>Ping ${escapeHtml(reachable)}</strong>: ${escapeHtml(loss)} · ${escapeHtml(avg)}</div>`;
+  }
+
+  function renderRoute(diagnostics) {
+    const gateways = (diagnostics.default_gateways || []).map((item) => `${item.gateway || 'unknown'} via ${item.interface || 'unknown'}`).join(', ') || 'No default gateway detected';
+    const vpnHints = (diagnostics.vpn_hints || []).map((item) => item.interface).join(', ') || 'No VPN route hints';
+    const scanPath = diagnostics.scan_path_context || 'No scan-path context returned';
+    return `<div class="alert alert-info"><strong>Route diagnostics</strong><br>Gateways: ${escapeHtml(gateways)}<br>VPN hints: ${escapeHtml(vpnHints)}<br><small>${escapeHtml(scanPath)}</small></div>`;
+  }
+
+  function renderTraceroute(hops) {
+    if (!hops || !hops.length) return '<div class="alert alert-warning">Traceroute returned no hops.</div>';
+    return `<div class="alert alert-info"><strong>Traceroute hops</strong><ol class="mb-0">${hops.map((hop) => `<li>${escapeHtml(typeof hop === 'string' ? hop : JSON.stringify(hop))}</li>`).join('')}</ol></div>`;
+  }
+
+  function renderHttpInspect(results) {
+    if (!results || !results.length) return '<div class="alert alert-warning">No web services were inspected.</div>';
+    return `<div class="alert alert-info"><strong>HTTP service inspection</strong></div><div class="port-service-grid">${results.map((item) => `
+      <div class="port-service-card">
+        <strong>${escapeHtml(item.port)}/tcp</strong>
+        <span>${escapeHtml(item.title || item.status || 'No title/status')}</span>
+        <small>${escapeHtml(item.server || item.error || item.url)}</small>
+      </div>`).join('')}</div>`;
+  }
+
+  function renderFingerprints(results) {
+    if (!results || !results.length) return '<div class="alert alert-warning">No saved services are available to fingerprint.</div>';
+    return `<div class="alert alert-info"><strong>Service fingerprints</strong></div><div class="port-service-grid">${results.map((item) => {
+      const web = item.http ? ` · ${item.http.title || item.http.server || item.http.status || item.http.error || 'HTTP checked'}` : '';
+      const note = (item.banner || (item.notes || []).join('; ') || 'No additional fingerprint data');
+      return `<div class="port-service-card">
+        <strong>${escapeHtml(item.port)}/tcp ${escapeHtml(item.service)}</strong>
+        <span>Confidence: ${escapeHtml(item.confidence)}${escapeHtml(web)}</span>
+        <small>${escapeHtml(note)}</small>
+      </div>`;
+    }).join('')}</div>`;
+  }
+
+  function renderIntelligence(info) {
+    const names = (info.names || []).join(', ') || 'No learned names yet';
+    const dnsForward = ((info.dns || {}).forward || []).map((item) => `${item.name}: ${(item.addresses || []).join(', ') || 'no current answers'}`).join('; ') || 'No forward DNS checks';
+    const services = info.services || {};
+    const stability = info.stability || {};
+    const recommendations = (info.recommendations || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('') || '<li>No recommendations returned.</li>';
+    return `<div class="alert alert-info"><strong>Device intelligence snapshot</strong></div>
+      <div class="theme-grid">
+        <div class="port-service-card"><strong>Names</strong><span>${escapeHtml(names)}</span><small>DHCP: ${escapeHtml((info.dhcp || {}).hostname || 'none')} · PTR: ${escapeHtml((info.dns || {}).reverse || 'none')}</small></div>
+        <div class="port-service-card"><strong>OS hint</strong><span>${escapeHtml((info.os_hint || {}).hint || 'Unknown')}</span><small>${escapeHtml(((info.os_hint || {}).evidence || []).join('; ') || 'No TTL evidence yet')}</small></div>
+        <div class="port-service-card"><strong>Services</strong><span>${escapeHtml(services.open_port_count || 0)} saved · ${escapeHtml(services.web_port_count || 0)} web · ${escapeHtml(services.sensitive_port_count || 0)} sensitive</span><small>${escapeHtml((services.fingerprints || []).length)} fingerprint probe result(s)</small></div>
+        <div class="port-service-card"><strong>Stability</strong><span>${escapeHtml((stability.sources || []).join(', ') || 'No sources')}</span><small>Interfaces: ${escapeHtml((stability.interfaces || []).join(', ') || 'none')} · DNS: ${escapeHtml(dnsForward)}</small></div>
+      </div>
+      <h3 class="theme-subsection-title mt-3">Recommended next checks</h3>
+      <ul>${recommendations}</ul>`;
+  }
+
+  $('[data-ip-client-ping]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Pinging client...</p>');
+    $.ajax({
+      url: '/ping',
+      method: 'POST',
+      data: { host: host, count: 4, timeout: 2 },
+      success: function (resp) { output(renderPing(resp.result || {})); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Ping failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-route]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Checking route context...</p>');
+    $.ajax({
+      url: '/route-diagnostics',
+      method: 'POST',
+      data: { target: host },
+      success: function (resp) { output(renderRoute(resp.diagnostics || {})); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Route diagnostics failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-traceroute]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Running traceroute...</p>');
+    $.ajax({
+      url: '/traceroute',
+      method: 'POST',
+      data: { host: host },
+      success: function (resp) { output(renderTraceroute(resp.hops || [])); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Traceroute failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-evidence-form]').on('submit', function (event) {
+    event.preventDefault();
+    const host = clientHost();
+    const notes = $('[data-ip-client-evidence-notes]').val();
+    output('<p class="text-muted">Saving evidence note...</p>');
+    $.ajax({
+      url: '/evidence',
+      method: 'POST',
+      headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      data: {
+        title: `IP client note for ${host}`,
+        category: 'note',
+        source: 'client-detail',
+        device: host,
+        notes: notes,
+        content: notes
+      },
+      success: function (resp) {
+        $('[data-ip-client-evidence-notes]').val('');
+        output(`<div class="alert alert-success">Evidence note saved for ${escapeHtml(resp.evidence?.device || host)}.</div>`);
+      },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Evidence note failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-watch]').on('click', function () {
+    const button = $(this);
+    const host = clientHost();
+    const nextWatch = button.attr('data-watched') !== 'true';
+    output('<p class="text-muted">Updating client watch...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/watch`,
+      method: 'POST',
+      data: { watch: nextWatch ? 'on' : '' },
+      success: function (resp) {
+        button.attr('data-watched', resp.watched ? 'true' : 'false');
+        button.toggleClass('btn-warning', resp.watched).toggleClass('btn-outline-warning', !resp.watched);
+        button.text(resp.watched ? 'Watching client' : 'Watch this device');
+        output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client watch updated.')}</div>`);
+      },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Client watch update failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-http-inspect]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Inspecting saved web-service candidates...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/http-inspect`,
+      method: 'POST',
+      success: function (resp) { output(renderHttpInspect(resp.results || [])); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'HTTP inspection failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-fingerprint]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Fingerprinting saved service candidates...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/fingerprint`,
+      method: 'POST',
+      success: function (resp) { output(renderFingerprints(resp.fingerprints || [])); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Service fingerprint failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-intelligence]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Gathering device intelligence from saved profile data and safe service probes...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/intelligence`,
+      method: 'POST',
+      data: { activeProbe: 'on' },
+      success: function (resp) { output(renderIntelligence(resp.intelligence || {})); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Device intelligence failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-baseline]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Saving current device baseline...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/baseline`,
+      method: 'POST',
+      success: function (resp) { output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client baseline saved.')}</div>`); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Baseline save failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-metadata-form]').on('submit', function (event) {
+    event.preventDefault();
+    const host = clientHost();
+    output('<p class="text-muted">Saving client profile metadata...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/metadata`,
+      method: 'POST',
+      data: {
+        tags: $('[data-ip-client-tags]').val(),
+        owner: $('[data-ip-client-owner]').val(),
+        location: $('[data-ip-client-location]').val(),
+        expectedPorts: $('[data-ip-client-expected-ports]').val(),
+        notes: $('[data-ip-client-notes]').val()
+      },
+      success: function (resp) { output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client metadata saved.')}</div>`); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Client metadata save failed')}</div>`); }
+    });
+  });
+
+  $('[data-ip-client-scheduled-form]').on('submit', function (event) {
+    event.preventDefault();
+    const host = clientHost();
+    output('<p class="text-muted">Saving scheduled check plan...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/scheduled-check`,
+      method: 'POST',
+      data: {
+        intervalMinutes: $('[data-ip-client-check-interval]').val(),
+        checks: $('[data-ip-client-checks]').val()
+      },
+      success: function (resp) { output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Scheduled check saved.')}</div>`); },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Scheduled check save failed')}</div>`); }
+    });
+  });
+});

--- a/static/js/ip_client.js
+++ b/static/js/ip_client.js
@@ -234,4 +234,19 @@ $(document).ready(function () {
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Scheduled check save failed')}</div>`); }
     });
   });
+
+  $('[data-ip-client-run-scheduled]').on('click', function () {
+    const host = clientHost();
+    output('<p class="text-muted">Running saved scheduled checks now...</p>');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/scheduled-check/run`,
+      method: 'POST',
+      success: function (resp) {
+        const resultKeys = Object.keys((resp.plan || {}).last_result || {}).join(', ') || 'no checks';
+        output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Scheduled checks ran.')} Results: ${escapeHtml(resultKeys)}.</div>`);
+      },
+      error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Scheduled check run failed')}</div>`); }
+    });
+  });
+
 });

--- a/static/js/jobs.js
+++ b/static/js/jobs.js
@@ -36,7 +36,11 @@ $(document).ready(function () {
       const openPorts = job.open_ports && job.open_ports.length
         ? `<div class="port-service-grid mt-2">${job.open_ports.map((port) => {
             const info = details[port] || { service: 'Unknown', description: 'No common service mapping found' };
-            return `<div class="port-service-card"><div class="port-service-number">${escapeHtml(port)}</div><div><strong>${escapeHtml(info.service)}</strong><p>${escapeHtml(info.description)}</p></div></div>`;
+            const portLabel = `${escapeHtml(port)}/tcp`;
+            const portHtml = info.web_url ? `<a href="${escapeHtml(info.web_url)}" target="_blank" rel="noopener noreferrer">${portLabel}</a>` : portLabel;
+            const serviceUrl = `/clients/${encodeURIComponent(job.host)}/services/${encodeURIComponent(port)}`;
+            const preview = info.web_url ? `<div class="web-service-hover-preview">${info.http_thumbnail_url ? `<img src="${escapeHtml(info.http_thumbnail_url)}" alt="Preview of ${escapeHtml(info.web_url)}">` : ''}<strong>${escapeHtml(info.http_title || info.web_url)}</strong><span>Status: ${escapeHtml(info.http_status || 'not captured')}${info.http_server ? ` · ${escapeHtml(info.http_server)}` : ''}</span><small>Click the port circle to open the page; click the card body for service details.</small></div>` : '';
+            return `<div class="port-service-card" data-web-service-preview><div class="port-service-number">${portHtml}</div><a class="port-service-card-link" href="${serviceUrl}"><strong>${escapeHtml(info.service)}</strong><p>${escapeHtml(info.description)}</p>${info.http_title ? `<small>HTTP title: ${escapeHtml(info.http_title)}</small>` : ''}</a>${preview}</div>`;
           }).join('')}</div>`
         : '';
       const cancel = job.cancelable

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -78,12 +78,18 @@ $(document).ready(function () {
       </div>`;
   }
 
+  function updateNetworkScanAllHosts(items) {
+    const hostList = hostDevices(items).map((item) => item.ip).join(',');
+    $('[data-port-scan-all]').attr('data-hosts', hostList);
+  }
+
   function detailsHasPorts(item) {
     return Array.isArray(item.open_port_details) && item.open_port_details.length ? 'true' : 'false';
   }
 
-  function renderDeviceCards(items, mode) {
-    let html = renderScanAllToolbar(items);
+  function renderDeviceCards(items, mode, includeToolbar) {
+    const showToolbar = includeToolbar !== false;
+    let html = showToolbar ? renderScanAllToolbar(items) : '';
     html += '<div class="wireless-network-grid network-device-card-grid">';
     items.forEach(function (item) {
       const ip = item.ip || '';
@@ -231,10 +237,40 @@ $(document).ready(function () {
     $('#scan-results').html(`<div class="alert alert-${klass}" role="status">${escapeHtml(message)}</div>`);
   }
 
+  function networkDeviceListParams() {
+    const form = $('[data-network-device-list-scan]');
+    return {
+      interface: form.attr('data-interface') || $('#interface-select-Scan').val() || $('[data-passive-monitor-toggle]').attr('data-interface') || '',
+      ssid: form.attr('data-ssid') || '',
+      bssid: form.attr('data-bssid') || ''
+    };
+  }
+
+  function renderNetworkDeviceListItems(items) {
+    const list = $('[data-network-device-list]');
+    if (!list.length) return;
+    const cards = renderDeviceCards(items || [], 'wireless-network', false);
+    const inner = $(cards).filter('.network-device-card-grid').html() || '';
+    list.html(inner);
+    $('[data-network-device-empty]').toggleClass('d-none', !!(items || []).length);
+    updateNetworkScanAllHosts(items || []);
+  }
+
   function refreshNetworkDeviceList(message) {
-    showNetworkDeviceListStatus(message || 'Scan complete. Refreshing device list...', 'success');
-    window.location.hash = 'network-devices-pane';
-    window.setTimeout(function () { window.location.reload(); }, 900);
+    const params = networkDeviceListParams();
+    showNetworkDeviceListStatus(message || 'Updating device list...', 'success');
+    $.ajax({
+      url: '/wireless/network/clients.json',
+      method: 'GET',
+      data: params,
+      success: function (resp) {
+        renderNetworkDeviceListItems(resp.clients || []);
+        showNetworkDeviceListStatus(message || `Device list updated with ${(resp.clients || []).length} device(s).`, 'success');
+      },
+      error: function (xhr) {
+        showNetworkDeviceListStatus(xhr.responseJSON?.message || 'Device list refresh failed. The saved inventory was updated, but this tab could not redraw.', 'warning');
+      }
+    });
   }
 
   function activateNetworkDeviceTabFromHash() {
@@ -288,9 +324,7 @@ $(document).ready(function () {
           const count = status.last_count == null ? 'no' : status.last_count;
           setPassiveMonitorStatus(`Passive capture running every ${status.interval || 10}s; last update saw ${count} device(s).`, status.error ? 'warning' : 'success');
           if (status.last_update && passiveMonitorLastUpdate && status.last_update !== passiveMonitorLastUpdate) {
-            window.location.hash = 'network-devices-pane';
-            window.location.reload();
-            return;
+            refreshNetworkDeviceList(`Passive capture added ${count} observed device(s).`);
           }
           passiveMonitorLastUpdate = status.last_update || passiveMonitorLastUpdate;
         } else {
@@ -357,7 +391,7 @@ $(document).ready(function () {
       success: function (resp) {
         const result = resp.result;
         if (isNetworkDeviceListMode()) {
-          refreshNetworkDeviceList(`Comprehensive scan saved ${result.summary.total_devices} device(s). Refreshing the device list...`);
+          refreshNetworkDeviceList(`Comprehensive scan saved ${result.summary.total_devices} device(s). Updating the device list...`);
           return;
         }
         let html = '<h3>Comprehensive Device Scan Results</h3>';
@@ -387,7 +421,7 @@ $(document).ready(function () {
       data: { selectedInterface: iface },
       success: function (resp) {
         if (isNetworkDeviceListMode()) {
-          refreshNetworkDeviceList(`Active scan saved ${resp.hosts.length} host(s). Refreshing the device list...`);
+          refreshNetworkDeviceList(`Active scan saved ${resp.hosts.length} host(s). Updating the device list...`);
           return;
         }
         let html = '<h3>Active Scan Results</h3>';
@@ -413,7 +447,7 @@ $(document).ready(function () {
       data: { selectedInterface: iface },
       success: function (resp) {
         if (isNetworkDeviceListMode()) {
-          refreshNetworkDeviceList(`Passive scan saved ${resp.devices.length} device(s). Refreshing the device list...`);
+          refreshNetworkDeviceList(`Passive scan saved ${resp.devices.length} device(s). Updating the device list...`);
           return;
         }
         let html = '<h3>Passive Scan Results</h3>';

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -15,6 +15,10 @@ $(document).ready(function () {
     return 'badge bg-light text-dark';
   }
 
+  function hostDevices(items) {
+    return (items || []).filter((item) => item.ip && !item.is_control_traffic);
+  }
+
   function renderSummary(items) {
     const hosts = items.filter((item) => !item.is_control_traffic).length;
     const control = items.length - hosts;
@@ -23,32 +27,356 @@ $(document).ready(function () {
     return `<div class="alert alert-info" role="status">${hosts} host-like entries, ${control} broadcast/multicast control entries, ${internal} internal entries, ${external} public entries.</div>`;
   }
 
-  function renderRows(items, mode) {
-    let html = '<div class="table-responsive"><table class="table theme-table"><thead><tr><th>IP</th><th>MAC</th><th>Manufacturer</th><th>Role</th><th>Scope</th><th>Notes</th><th>Actions</th></tr></thead><tbody>';
-    items.forEach(function (item) {
-      const ip = escapeHtml(item.ip || '—');
-      const mac = escapeHtml(item.mac || '—');
-      const manufacturer = escapeHtml(item.manufacturer || 'Unknown');
-      const role = escapeHtml(item.network_role || 'Host');
-      const scope = escapeHtml(item.network_scope || 'Unknown');
-      const note = escapeHtml(item.scan_note || '');
-      let ipCell = ip;
-      let macCell = mac;
-      const portScanAction = item.ip && !item.is_control_traffic
-        ? `<a class="btn btn-outline-primary btn-sm" href="/port-scan?host=${encodeURIComponent(item.ip)}">Check ports</a>`
-        : '—';
-      if (mode === 'active') {
-        const display = item.ip || 'Unknown IP';
-        const linkTarget = item.mac || item.ip || '';
-        ipCell = `<a href="/clients/${encodeURIComponent(linkTarget)}">${escapeHtml(display)}</a>`;
-      } else if (item.mac) {
-        macCell = `<a href="/clients/${encodeURIComponent(item.mac)}">${mac}</a>`;
+  function renderPortBadges(item) {
+    const details = Array.isArray(item.open_port_details) ? item.open_port_details : [];
+    if (!details.length) return '<p class="text-muted mb-0 small">No saved open ports yet.</p>';
+    return `<div class="network-device-open-ports">${details.slice(0, 6).map((port) => {
+      const title = port.http_title ? ` · ${escapeHtml(port.http_title)}` : '';
+      const label = `${escapeHtml(port.port)} ${escapeHtml(port.service || 'Unknown')}${title}`;
+      const tooltip = escapeHtml(port.http_title || port.http_status || port.description || '');
+      return port.web_url ? `<a class="badge badge-info" href="${escapeHtml(port.web_url)}" target="_blank" rel="noopener noreferrer" title="${tooltip}" data-web-service-preview>${label}</a>` : `<span class="badge badge-info">${label}</span>`;
+    }).join('')}</div>`;
+  }
+
+  function renderTagBadges(tags) {
+    if (!Array.isArray(tags) || !tags.length) return '';
+    return tags.map((tag) => `<span class="badge badge-light border">${escapeHtml(tag)}</span>`).join('');
+  }
+
+  function refreshDeviceCard(host, card) {
+    if (!host || !card.length) return;
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/summary`,
+      method: 'GET',
+      success: function (resp) {
+        const device = resp.device || {};
+        const ports = card.find('[data-network-device-ports]');
+        ports.html(renderPortBadges(device));
+        const tags = card.find('[data-network-device-tags]');
+        tags.html(renderTagBadges(device.client_tags || []));
+        const notes = card.find('[data-network-device-notes]');
+        if (device.client_notes) notes.removeClass('d-none').text(device.client_notes);
+        else notes.addClass('d-none').text('');
+        card.attr('data-has-open-ports', (device.open_port_details || []).length ? 'true' : 'false');
+        if (device.display_name) card.find('[data-network-device-title]').text(device.display_name);
       }
-      html += `<tr class="${item.is_control_traffic ? 'table-secondary' : ''}"><td>${ipCell}</td><td>${macCell}</td><td>${manufacturer}</td><td><span class="${badgeClass(item)}">${role}</span></td><td>${scope}</td><td>${note}</td><td>${portScanAction}</td></tr>`;
     });
-    html += '</tbody></table></div><p><a href="/inventory">View full device inventory</a></p>';
+  }
+
+  function renderScanAllToolbar(items) {
+    const hosts = hostDevices(items);
+    if (!hosts.length) return '';
+    const hostList = hosts.map((item) => item.ip).join(',');
+    return `
+      <div class="network-scan-all-toolbar alert alert-secondary" role="region" aria-label="Port scan all discovered devices">
+        <div><strong>Port scan discovered IP devices</strong><p class="mb-0 small">Start background scans for all ${hosts.length} host-like IP device${hosts.length === 1 ? '' : 's'} in this result set.</p></div>
+        <div class="theme-actions mb-0">
+          <button class="btn btn-outline-primary btn-sm" data-port-scan-all data-hosts="${escapeHtml(hostList)}" data-start="1" data-end="1024" data-label="common port scan">Scan all common ports</button>
+          <button class="btn btn-outline-danger btn-sm" data-port-scan-all data-hosts="${escapeHtml(hostList)}" data-start="1" data-end="65535" data-label="all-port scan">Scan all ports</button>
+        </div>
+        <div class="network-scan-all-status small text-muted" data-port-scan-all-status></div>
+      </div>`;
+  }
+
+  function detailsHasPorts(item) {
+    return Array.isArray(item.open_port_details) && item.open_port_details.length ? 'true' : 'false';
+  }
+
+  function renderDeviceCards(items, mode) {
+    let html = renderScanAllToolbar(items);
+    html += '<div class="wireless-network-grid network-device-card-grid">';
+    items.forEach(function (item) {
+      const ip = item.ip || '';
+      const mac = item.mac || '';
+      const display = item.hostname || item.name || ip || mac || 'Unknown device';
+      const manufacturer = item.manufacturer || 'Unknown manufacturer';
+      const roleGuess = item.device_role_guess || {};
+      const role = roleGuess.role || item.network_role || 'Host';
+      const scope = item.network_scope || 'Unknown';
+      const methods = (item.discovery_methods || []).join(', ') || mode;
+      const note = item.scan_note || '';
+      const clientTarget = mac || ip;
+      const detailUrl = clientTarget ? `/clients/${encodeURIComponent(clientTarget)}` : '';
+      const deviceActions = ip && !item.is_control_traffic
+        ? `<div class="network-device-actions">
+            <a class="btn btn-outline-info btn-sm" href="/clients/${encodeURIComponent(ip)}">Device profile</a>
+            <a class="btn btn-outline-primary btn-sm" href="/port-scan?host=${encodeURIComponent(ip)}">Port scan</a>
+            <button class="btn btn-outline-secondary btn-sm" data-port-scan-quick data-host="${escapeHtml(ip)}" data-start="1" data-end="1024" data-label="common port scan">Common ports</button>
+            <button class="btn btn-outline-danger btn-sm" data-port-scan-quick data-host="${escapeHtml(ip)}" data-start="1" data-end="65535" data-label="all-port scan">All ports</button>
+            <div class="network-device-scan-status small text-muted" data-port-scan-quick-status></div>
+            <div class="progress network-device-progress" data-port-scan-quick-progress><div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</div></div>
+            <form class="network-device-notes-form" data-network-device-notes-form data-host="${escapeHtml(ip)}">
+              <input class="form-control form-control-sm" name="tags" placeholder="Tags, comma separated" value="${escapeHtml((item.client_tags || []).join(', '))}">
+              <textarea class="form-control form-control-sm" name="notes" rows="2" placeholder="Device notes">${escapeHtml(item.client_notes || '')}</textarea>
+              <button class="btn btn-outline-success btn-sm" type="submit">Save notes/tags</button>
+              <div class="network-device-notes-status small text-muted" data-network-device-notes-status></div>
+            </form>
+          </div>`
+        : '<span class="badge badge-secondary">No IP port scan</span>';
+      html += `
+        <article class="wireless-network-card network-device-card ${item.is_control_traffic ? 'network-device-card-control' : ''}" data-network-device-card data-host="${escapeHtml(ip)}" data-role="${escapeHtml(role)}" data-known-state="${escapeHtml(item.network_known_state || 'Known')}" data-has-open-ports="${detailsHasPorts(item)}" data-unknown="${!ip || manufacturer === 'Unknown manufacturer'}">
+          <div class="wireless-network-main">
+            <div class="wireless-network-identity">
+              <h3 class="wireless-network-ssid mb-1">${detailUrl ? `<a href="${escapeHtml(detailUrl)}">${escapeHtml(display)}</a>` : escapeHtml(display)}</h3>
+              <p class="wireless-network-meta mb-0"><i class="fa-solid fa-network-wired"></i> ${escapeHtml(ip || 'Unknown IP')}</p>
+              <p class="wireless-network-meta mb-0"><i class="fa-solid fa-fingerprint"></i> ${escapeHtml(mac || 'Unknown MAC')}</p>
+              <p class="wireless-network-meta mb-0"><i class="fa-solid fa-industry"></i> ${escapeHtml(manufacturer)}</p>
+            </div>
+            <div class="wireless-network-badges">
+              <span class="badge ${item.network_known_state === 'New' ? 'badge-warning' : 'badge-success'}">${escapeHtml(item.network_known_state || 'Known')}</span>
+              <span class="${badgeClass(item)}">${escapeHtml(role)}</span>
+              ${item.likely_randomized_mac ? '<span class="badge badge-warning">Randomized MAC likely</span>' : ''}
+              <span class="badge badge-light border">${escapeHtml(scope)}</span>
+              <span class="badge badge-info">${escapeHtml(methods)}</span>
+            </div>
+          </div>
+          <div class="wireless-network-bottom network-device-bottom">
+            <div><div data-network-device-ports>${renderPortBadges(item)}</div><div class="network-device-tags mt-2" data-network-device-tags>${renderTagBadges(item.client_tags || [])}</div>${item.client_notes ? `<p class="text-muted small mb-0 mt-2" data-network-device-notes>${escapeHtml(item.client_notes)}</p>` : `<p class="text-muted small mb-0 mt-2 d-none" data-network-device-notes></p>`}${Array.isArray(item.observed_names) && item.observed_names.length ? `<p class="text-muted small mb-0 mt-2">Names: ${escapeHtml(item.observed_names.slice(0, 3).map((entry) => entry.name).join(', '))}</p>` : ''}${note ? `<p class="text-muted small mb-0 mt-2">${escapeHtml(note)}</p>` : ''}</div>
+            ${deviceActions}
+          </div>
+        </article>`;
+    });
+    html += '</div><p class="mt-3"><a href="/inventory">View full device inventory</a></p>';
     return html;
   }
+
+  function startPortScanAll(button) {
+    const hosts = String(button.attr('data-hosts') || '').split(',').filter(Boolean);
+    const start = button.attr('data-start');
+    const end = button.attr('data-end');
+    const label = button.attr('data-label');
+    const status = button.closest('.network-scan-all-toolbar').find('[data-port-scan-all-status]');
+    if (!hosts.length) {
+      status.text('No host-like IP devices to scan.');
+      return;
+    }
+    button.closest('.network-scan-all-toolbar').find('[data-port-scan-all]').prop('disabled', true);
+    status.text(`Starting ${label} jobs for ${hosts.length} host(s)...`);
+    let started = 0;
+    let failed = 0;
+    hosts.forEach(function (host) {
+      $.ajax({
+        url: '/port-scan-jobs',
+        method: 'POST',
+        data: { host: host, start: start, end: end, label: label },
+        complete: function (xhr) {
+          if (xhr.status >= 200 && xhr.status < 300) started += 1;
+          else failed += 1;
+          status.text(`Started ${started} ${label} job(s); ${failed} failed. Results are saved to device profiles as ports are found.`);
+          if (started + failed === hosts.length) {
+            button.closest('.network-scan-all-toolbar').find('[data-port-scan-all]').prop('disabled', false);
+          }
+        }
+      });
+    });
+  }
+
+  function startQuickPortScan(button) {
+    const host = button.attr('data-host');
+    const start = button.attr('data-start');
+    const end = button.attr('data-end');
+    const label = button.attr('data-label') || 'port scan';
+    const actions = button.closest('.network-device-actions');
+    const status = actions.find('[data-port-scan-quick-status]');
+    actions.find('[data-port-scan-quick]').prop('disabled', true);
+    status.text(`Starting ${label} for ${host}...`);
+    $.ajax({
+      url: '/port-scan-jobs',
+      method: 'POST',
+      data: { host: host, start: start, end: end, label: label },
+      complete: function (xhr) {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          const job = xhr.responseJSON?.job || {};
+          status.text(`Started ${label}. Scanning...`);
+          pollQuickPortScan(job.id, actions.closest('[data-network-device-card]'), status);
+        } else {
+          status.text(xhr.responseJSON?.message || `${label} failed to start.`);
+        }
+        actions.find('[data-port-scan-quick]').prop('disabled', false);
+      }
+    });
+  }
+
+  function pollQuickPortScan(jobId, card, status) {
+    if (!jobId) return;
+    $.ajax({
+      url: `/port-scan-jobs/${encodeURIComponent(jobId)}`,
+      method: 'GET',
+      success: function (resp) {
+        const job = resp.job || {};
+        const progress = job.progress == null ? 0 : job.progress;
+        status.text(`${job.label || 'Port scan'} ${job.status}: ${progress}% (${job.open_ports?.length || 0} open)`);
+        card.find('[data-port-scan-quick-progress] .progress-bar').css('width', `${progress}%`).attr('aria-valuenow', progress).text(`${progress}%`);
+        const host = card.attr('data-host') || job.host;
+        refreshDeviceCard(host, card);
+        if (['queued', 'running'].includes(job.status)) {
+          setTimeout(function () { pollQuickPortScan(jobId, card, status); }, 1500);
+        } else {
+          status.text(`${job.message || 'Port scan finished.'}`);
+          refreshDeviceCard(host, card);
+        }
+      },
+      error: function () {
+        status.text('Unable to refresh scan progress.');
+      }
+    });
+  }
+
+  function isNetworkDeviceListMode() {
+    return $('[data-network-device-list-scan]').length > 0;
+  }
+
+  function showNetworkDeviceListStatus(message, level) {
+    const klass = level || 'info';
+    $('#scan-results').html(`<div class="alert alert-${klass}" role="status">${escapeHtml(message)}</div>`);
+  }
+
+  function refreshNetworkDeviceList(message) {
+    showNetworkDeviceListStatus(message || 'Scan complete. Refreshing device list...', 'success');
+    window.location.hash = 'network-devices-pane';
+    window.setTimeout(function () { window.location.reload(); }, 900);
+  }
+
+  function activateNetworkDeviceTabFromHash() {
+    if (!isNetworkDeviceListMode()) return;
+    if (window.location.hash === '#network-device-scan' || window.location.hash === '#network-devices-pane') {
+      $('#network-devices-tab').tab('show');
+    }
+  }
+
+  function applyNetworkDeviceFilter(filter) {
+    $('[data-network-device-card]').each(function () {
+      const card = $(this);
+      const role = String(card.attr('data-role') || '').toLowerCase();
+      const show = filter === 'all'
+        || (filter === 'gateway' && role.includes('gateway'))
+        || (filter === 'open-ports' && card.attr('data-has-open-ports') === 'true')
+        || (filter === 'new' && card.attr('data-known-state') === 'New')
+        || (filter === 'unknown' && card.attr('data-unknown') === 'true');
+      card.toggle(show);
+    });
+  }
+
+
+  let passiveMonitorLastUpdate = null;
+  let passiveMonitorPollTimer = null;
+
+  function passiveMonitorControls() {
+    return $('[data-passive-monitor-toggle]');
+  }
+
+  function setPassiveMonitorStatus(message, level) {
+    const status = $('[data-passive-monitor-status]');
+    status.removeClass('text-muted text-success text-danger text-warning');
+    status.addClass(level ? `text-${level}` : 'text-muted');
+    status.text(message);
+  }
+
+  function pollPassiveMonitorStatus() {
+    const toggle = passiveMonitorControls();
+    if (!toggle.length) return;
+    const iface = toggle.attr('data-interface');
+    $.ajax({
+      url: '/passive-monitor/status',
+      method: 'GET',
+      data: { selectedInterface: iface },
+      success: function (resp) {
+        const status = resp.status || {};
+        toggle.prop('checked', !!status.enabled);
+        if (status.interval) $('[data-passive-monitor-interval]').val(status.interval);
+        if (status.enabled) {
+          const count = status.last_count == null ? 'no' : status.last_count;
+          setPassiveMonitorStatus(`Passive capture running every ${status.interval || 10}s; last update saw ${count} device(s).`, status.error ? 'warning' : 'success');
+          if (status.last_update && passiveMonitorLastUpdate && status.last_update !== passiveMonitorLastUpdate) {
+            window.location.hash = 'network-devices-pane';
+            window.location.reload();
+            return;
+          }
+          passiveMonitorLastUpdate = status.last_update || passiveMonitorLastUpdate;
+        } else {
+          setPassiveMonitorStatus('Passive monitor is off.', 'muted');
+        }
+      },
+      complete: function () {
+        window.clearTimeout(passiveMonitorPollTimer);
+        passiveMonitorPollTimer = window.setTimeout(pollPassiveMonitorStatus, 5000);
+      }
+    });
+  }
+
+  function togglePassiveMonitor(toggle) {
+    const enabled = toggle.is(':checked');
+    const iface = toggle.attr('data-interface');
+    const interval = $('[data-passive-monitor-interval]').val() || 10;
+    setPassiveMonitorStatus(enabled ? 'Starting continuous passive capture...' : 'Stopping continuous passive capture...', 'muted');
+    $.ajax({
+      url: '/passive-monitor/toggle',
+      method: 'POST',
+      data: { selectedInterface: iface, enabled: enabled ? 'on' : '', interval: interval },
+      success: function (resp) {
+        const status = resp.status || {};
+        passiveMonitorLastUpdate = status.last_update || null;
+        setPassiveMonitorStatus(resp.message || 'Passive monitor updated.', enabled ? 'success' : 'muted');
+        pollPassiveMonitorStatus();
+      },
+      error: function (xhr) {
+        toggle.prop('checked', !enabled);
+        setPassiveMonitorStatus(xhr.responseJSON?.message || 'Unable to update passive monitor.', 'danger');
+      }
+    });
+  }
+
+  activateNetworkDeviceTabFromHash();
+
+  pollPassiveMonitorStatus();
+
+  $(document).on('change', '[data-passive-monitor-toggle]', function () {
+    togglePassiveMonitor($(this));
+  });
+
+  $(document).on('click', 'a[href="#network-device-scan"]', function () {
+    if (isNetworkDeviceListMode()) {
+      $('#network-devices-tab').tab('show');
+    }
+  });
+
+  $('#comprehensive-scan-btn').on('click', function (e) {
+    e.preventDefault();
+    const iface = $('#interface-select-Scan').val();
+    if (isNetworkDeviceListMode()) showNetworkDeviceListStatus('Comprehensive scan running. Devices will be saved into this tab...', 'info');
+    else $('#scan-results').html('<p>Comprehensive scan running...</p>');
+    $.ajax({
+      url: '/comprehensive-scan',
+      method: 'POST',
+      data: {
+        selectedInterface: iface,
+        includePassive: $('#include-passive').is(':checked') ? 'on' : '',
+        includeServices: $('#include-services').is(':checked') ? 'on' : '',
+        sweepCidr: $('#sweep-cidr').val()
+      },
+      success: function (resp) {
+        const result = resp.result;
+        if (isNetworkDeviceListMode()) {
+          refreshNetworkDeviceList(`Comprehensive scan saved ${result.summary.total_devices} device(s). Refreshing the device list...`);
+          return;
+        }
+        let html = '<h3>Comprehensive Device Scan Results</h3>';
+        html += `<div class="alert alert-info" role="status">${result.summary.total_devices} total devices, ${result.summary.host_like} host-like devices, ${result.summary.with_services} with service metadata. Methods: ${escapeHtml(result.methods.join(', '))}</div>`;
+        if (result.errors.length) {
+          html += `<div class="alert alert-warning">Some methods reported errors: ${escapeHtml(result.errors.join('; '))}</div>`;
+        }
+        if (result.devices.length === 0) {
+          html += '<p>No devices found</p>';
+        } else {
+          html += renderDeviceCards(result.devices, 'comprehensive');
+        }
+        $('#scan-results').html(html);
+      },
+      error: function (xhr) {
+        showNetworkDeviceListStatus(xhr.responseJSON?.message || 'Comprehensive scan failed', 'danger');
+      }
+    });
+  });
 
   $('#active-scan-btn').on('click', function (e) {
     e.preventDefault();
@@ -58,16 +386,20 @@ $(document).ready(function () {
       method: 'POST',
       data: { selectedInterface: iface },
       success: function (resp) {
+        if (isNetworkDeviceListMode()) {
+          refreshNetworkDeviceList(`Active scan saved ${resp.hosts.length} host(s). Refreshing the device list...`);
+          return;
+        }
         let html = '<h3>Active Scan Results</h3>';
         if (resp.hosts.length === 0) {
           html += '<p>No hosts found</p>';
         } else {
-          html += renderSummary(resp.hosts) + renderRows(resp.hosts, 'active');
+          html += renderSummary(resp.hosts) + renderDeviceCards(resp.hosts, 'active');
         }
         $('#scan-results').html(html);
       },
       error: function () {
-        $('#scan-results').html('<p>Scan failed</p>');
+        showNetworkDeviceListStatus('Scan failed', 'danger');
       }
     });
   });
@@ -80,16 +412,84 @@ $(document).ready(function () {
       method: 'POST',
       data: { selectedInterface: iface },
       success: function (resp) {
+        if (isNetworkDeviceListMode()) {
+          refreshNetworkDeviceList(`Passive scan saved ${resp.devices.length} device(s). Refreshing the device list...`);
+          return;
+        }
         let html = '<h3>Passive Scan Results</h3>';
         if (resp.devices.length === 0) {
           html += '<p>No devices found</p>';
         } else {
-          html += renderSummary(resp.devices) + renderRows(resp.devices, 'passive');
+          html += renderSummary(resp.devices) + renderDeviceCards(resp.devices, 'passive');
         }
         $('#scan-results').html(html);
       },
       error: function () {
-        $('#scan-results').html('<p>Scan failed</p>');
+        showNetworkDeviceListStatus('Scan failed', 'danger');
+      }
+    });
+  });
+
+  $(document).on('click', '[data-port-scan-all]', function (e) {
+    e.preventDefault();
+    startPortScanAll($(this));
+  });
+
+  $(document).on('click', '[data-port-scan-quick]', function (e) {
+    e.preventDefault();
+    startQuickPortScan($(this));
+  });
+
+  $(document).on('click', '[data-network-device-filter]', function (e) {
+    e.preventDefault();
+    $('[data-network-device-filter]').removeClass('active');
+    $(this).addClass('active');
+    applyNetworkDeviceFilter($(this).attr('data-network-device-filter'));
+  });
+
+  $(document).on('submit', '[data-network-device-label-form]', function (e) {
+    e.preventDefault();
+    const form = $(this);
+    const status = form.find('[data-network-device-label-status]');
+    const card = form.closest('[data-network-device-card]');
+    status.text('Saving SSID label...');
+    $.ajax({
+      url: '/wireless/network/label',
+      method: 'POST',
+      data: {
+        interface: form.attr('data-interface'),
+        ssid: form.attr('data-ssid'),
+        bssid: form.attr('data-bssid'),
+        identity: form.attr('data-identity'),
+        label: form.find('[name="label"]').val()
+      },
+      success: function (resp) {
+        status.text(resp.message || 'SSID label saved.');
+        const label = form.find('[name="label"]').val();
+        if (label) card.find('[data-network-device-title]').text(label);
+      },
+      error: function (xhr) {
+        status.text(xhr.responseJSON?.message || 'Failed to save SSID label.');
+      }
+    });
+  });
+
+  $(document).on('submit', '[data-network-device-notes-form]', function (e) {
+    e.preventDefault();
+    const form = $(this);
+    const host = form.attr('data-host');
+    const status = form.find('[data-network-device-notes-status]');
+    status.text('Saving notes/tags...');
+    $.ajax({
+      url: `/clients/${encodeURIComponent(host)}/metadata`,
+      method: 'POST',
+      data: form.serialize(),
+      success: function () {
+        status.text('Saved notes/tags.');
+        refreshDeviceCard(host, form.closest('[data-network-device-card]'));
+      },
+      error: function (xhr) {
+        status.text(xhr.responseJSON?.message || 'Failed to save notes/tags.');
       }
     });
   });

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -272,6 +272,11 @@ $(document).ready(function () {
     };
   }
 
+  function updateNetworkDeviceTabCount(items) {
+    const count = Array.isArray(items) ? items.length : 0;
+    $('[data-network-device-count]').text(count);
+  }
+
   function renderNetworkDeviceListItems(items) {
     const list = $('[data-network-device-list]');
     if (!list.length) return;
@@ -279,6 +284,7 @@ $(document).ready(function () {
     const inner = $(cards).filter('.network-device-card-grid').html() || '';
     list.html(inner);
     $('[data-network-device-empty]').toggleClass('d-none', !!(items || []).length);
+    updateNetworkDeviceTabCount(items || []);
     updateNetworkScanAllHosts(items || []);
   }
 

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -237,12 +237,38 @@ $(document).ready(function () {
     $('#scan-results').html(`<div class="alert alert-${klass}" role="status">${escapeHtml(message)}</div>`);
   }
 
+  function setScanButtonBusy(button, busy, label) {
+    const original = button.attr('data-original-text') || button.text();
+    if (!button.attr('data-original-text')) button.attr('data-original-text', original);
+    button.prop('disabled', busy);
+    button.toggleClass('scan-button-busy', busy);
+    if (busy) {
+      button.html(`<span class="spinner-border spinner-border-sm mr-1" role="status" aria-hidden="true"></span>${escapeHtml(label || original)}`);
+    } else {
+      button.text(original);
+    }
+  }
+
+  function setScanControlsBusy(activeButton, busy, label) {
+    $('#comprehensive-scan-btn, #active-scan-btn, #passive-scan-btn').prop('disabled', busy);
+    if (activeButton && activeButton.length) setScanButtonBusy(activeButton, busy, label);
+  }
+
   function networkDeviceListParams() {
     const form = $('[data-network-device-list-scan]');
     return {
       interface: form.attr('data-interface') || $('#interface-select-Scan').val() || $('[data-passive-monitor-toggle]').attr('data-interface') || '',
       ssid: form.attr('data-ssid') || '',
       bssid: form.attr('data-bssid') || ''
+    };
+  }
+
+  function networkDeviceScanPostData(extra) {
+    const params = networkDeviceListParams();
+    return {
+      ...(extra || {}),
+      ssid: params.ssid,
+      bssid: params.bssid
     };
   }
 
@@ -328,7 +354,7 @@ $(document).ready(function () {
     $.ajax({
       url: '/passive-analytics.json',
       method: 'GET',
-      data: { selectedInterface: iface },
+      data: networkDeviceScanPostData({ selectedInterface: iface }),
       success: function (resp) { renderPassiveAnalytics(resp.analytics || {}); }
     });
   }
@@ -354,7 +380,7 @@ $(document).ready(function () {
     $.ajax({
       url: '/passive-monitor/status',
       method: 'GET',
-      data: { selectedInterface: iface },
+      data: networkDeviceScanPostData({ selectedInterface: iface }),
       success: function (resp) {
         const status = resp.status || {};
         toggle.prop('checked', !!status.enabled);
@@ -418,22 +444,25 @@ $(document).ready(function () {
 
   $('#comprehensive-scan-btn').on('click', function (e) {
     e.preventDefault();
+    const button = $(this);
     const iface = $('#interface-select-Scan').val();
-    if (isNetworkDeviceListMode()) showNetworkDeviceListStatus('Comprehensive scan running. Devices will be saved into this tab...', 'info');
+    setScanControlsBusy(button, true, 'Scanning...');
+    if (isNetworkDeviceListMode()) showNetworkDeviceListStatus('Comprehensive scan running. Devices will appear here as soon as this scan reports them...', 'info');
     else $('#scan-results').html('<p>Comprehensive scan running...</p>');
     $.ajax({
       url: '/comprehensive-scan',
       method: 'POST',
-      data: {
+      data: networkDeviceScanPostData({
         selectedInterface: iface,
         includePassive: $('#include-passive').is(':checked') ? 'on' : '',
         includeServices: $('#include-services').is(':checked') ? 'on' : '',
         sweepCidr: $('#sweep-cidr').val()
-      },
+      }),
       success: function (resp) {
         const result = resp.result;
         if (isNetworkDeviceListMode()) {
-          refreshNetworkDeviceList(`Comprehensive scan saved ${result.summary.total_devices} device(s). Updating the device list...`);
+          renderNetworkDeviceListItems(result.network_clients || result.devices || []);
+          refreshNetworkDeviceList(`Comprehensive scan saved ${result.summary.total_devices} device(s). Device list updated.`);
           return;
         }
         let html = '<h3>Comprehensive Device Scan Results</h3>';
@@ -450,20 +479,24 @@ $(document).ready(function () {
       },
       error: function (xhr) {
         showNetworkDeviceListStatus(xhr.responseJSON?.message || 'Comprehensive scan failed', 'danger');
-      }
+      },
+      complete: function () { setScanControlsBusy(button, false); }
     });
   });
 
   $('#active-scan-btn').on('click', function (e) {
     e.preventDefault();
+    const button = $(this);
     const iface = $('#interface-select-Scan').val();
+    setScanControlsBusy(button, true, 'Scanning...');
     $.ajax({
       url: '/active-scan',
       method: 'POST',
-      data: { selectedInterface: iface },
+      data: networkDeviceScanPostData({ selectedInterface: iface }),
       success: function (resp) {
         if (isNetworkDeviceListMode()) {
-          refreshNetworkDeviceList(`Active scan saved ${resp.hosts.length} host(s). Updating the device list...`);
+          renderNetworkDeviceListItems(resp.network_clients || resp.hosts || []);
+          refreshNetworkDeviceList(`Active scan saved ${resp.hosts.length} host(s). Device list updated.`);
           return;
         }
         let html = '<h3>Active Scan Results</h3>';
@@ -476,20 +509,24 @@ $(document).ready(function () {
       },
       error: function () {
         showNetworkDeviceListStatus('Scan failed', 'danger');
-      }
+      },
+      complete: function () { setScanControlsBusy(button, false); }
     });
   });
 
   $('#passive-scan-btn').on('click', function (e) {
     e.preventDefault();
+    const button = $(this);
     const iface = $('#interface-select-Scan').val();
+    setScanControlsBusy(button, true, 'Listening...');
     $.ajax({
       url: '/passive-scan',
       method: 'POST',
-      data: { selectedInterface: iface },
+      data: networkDeviceScanPostData({ selectedInterface: iface }),
       success: function (resp) {
         if (isNetworkDeviceListMode()) {
-          refreshNetworkDeviceList(`Passive scan saved ${resp.devices.length} device(s). Updating the device list...`);
+          renderNetworkDeviceListItems(resp.network_clients || resp.devices || []);
+          refreshNetworkDeviceList(`Passive scan saved ${resp.devices.length} device(s). Device list updated.`);
           renderPassiveAnalytics(resp.analytics || {});
           return;
         }
@@ -503,7 +540,8 @@ $(document).ready(function () {
       },
       error: function () {
         showNetworkDeviceListStatus('Scan failed', 'danger');
-      }
+      },
+      complete: function () { setScanControlsBusy(button, false); }
     });
   });
 

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -391,9 +391,13 @@ $(document).ready(function () {
         const status = resp.status || {};
         toggle.prop('checked', !!status.enabled);
         if (status.interval) $('[data-passive-monitor-interval]').val(status.interval);
+        $('[data-passive-monitor-mode]').prop('checked', status.mode === 'packet');
         if (status.enabled) {
           const count = status.last_count == null ? 'no' : status.last_count;
-          setPassiveMonitorStatus(`Passive capture running every ${status.interval || 10}s; last update saw ${count} device(s).`, status.error ? 'warning' : 'success');
+          const modeLabel = status.mode === 'packet'
+            ? `Live packet capture running in ${status.interval || 2}s windows; last window saw ${count} device(s).`
+            : `Passive cache capture running every ${status.interval || 10}s; last update saw ${count} device(s).`;
+          setPassiveMonitorStatus(modeLabel, status.error ? 'warning' : 'success');
           if (status.last_update && passiveMonitorLastUpdate && status.last_update !== passiveMonitorLastUpdate) {
             refreshNetworkDeviceList(`Passive capture added ${count} observed device(s).`);
             refreshPassiveAnalytics();
@@ -414,11 +418,12 @@ $(document).ready(function () {
     const enabled = toggle.is(':checked');
     const iface = toggle.attr('data-interface');
     const interval = $('[data-passive-monitor-interval]').val() || 10;
+    const mode = $('[data-passive-monitor-mode]').is(':checked') ? 'packet' : 'cache';
     setPassiveMonitorStatus(enabled ? 'Starting continuous passive capture...' : 'Stopping continuous passive capture...', 'muted');
     $.ajax({
       url: '/passive-monitor/toggle',
       method: 'POST',
-      data: { selectedInterface: iface, enabled: enabled ? 'on' : '', interval: interval },
+      data: { selectedInterface: iface, enabled: enabled ? 'on' : '', interval: interval, mode: mode },
       success: function (resp) {
         const status = resp.status || {};
         passiveMonitorLastUpdate = status.last_update || null;
@@ -440,6 +445,11 @@ $(document).ready(function () {
 
   $(document).on('change', '[data-passive-monitor-toggle]', function () {
     togglePassiveMonitor($(this));
+  });
+
+  $(document).on('change', '[data-passive-monitor-mode]', function () {
+    const toggle = passiveMonitorControls();
+    if (toggle.is(':checked')) togglePassiveMonitor(toggle);
   });
 
   $(document).on('click', 'a[href="#network-device-scan"]', function () {

--- a/static/js/network_scan.js
+++ b/static/js/network_scan.js
@@ -294,6 +294,45 @@ $(document).ready(function () {
   }
 
 
+  function renderPassiveAnalytics(analytics) {
+    const panel = $('[data-passive-analytics-panel]');
+    if (!panel.length) return;
+    const summary = analytics || {};
+    const samples = summary.total_samples || 0;
+    const known = summary.known_device_count || 0;
+    const active = summary.active_device_count || 0;
+    const quiet = summary.recently_disappeared_count || 0;
+    $('[data-passive-analytics-summary]').html(`Samples: <strong>${escapeHtml(samples)}</strong> · Active in latest sample: <strong>${escapeHtml(active)}</strong> · Known passively: <strong>${escapeHtml(known)}</strong> · Recently quiet: <strong>${escapeHtml(quiet)}</strong>`);
+    const quietDevices = summary.recently_disappeared || [];
+    const activeDevices = summary.active_devices || [];
+    const cards = [
+      ...activeDevices.slice(0, 6).map((item) => ({...item, state: 'Observed in latest passive sample'})),
+      ...quietDevices.slice(0, 6).map((item) => ({...item, state: 'Recently disappeared / quiet'}))
+    ];
+    if (!cards.length) {
+      $('[data-passive-analytics-devices]').html('<p class="text-muted mb-0">No passive device churn yet.</p>');
+      return;
+    }
+    $('[data-passive-analytics-devices]').html(cards.map((item) => `
+      <div class="port-service-card">
+        <strong>${escapeHtml(item.hostname || item.ip || item.mac || item.identity)}</strong>
+        <span>${escapeHtml(item.state)}</span>
+        <small>${escapeHtml(item.mac || 'MAC unknown')} · ${escapeHtml(item.manufacturer || 'Unknown')} · seen ${escapeHtml(item.seen_count || 0)} time(s)</small>
+      </div>`).join(''));
+  }
+
+  function refreshPassiveAnalytics() {
+    const panel = $('[data-passive-analytics-panel]');
+    if (!panel.length) return;
+    const iface = panel.attr('data-interface') || $('[data-passive-monitor-toggle]').attr('data-interface') || $('#interface-select-Scan').val() || '';
+    $.ajax({
+      url: '/passive-analytics.json',
+      method: 'GET',
+      data: { selectedInterface: iface },
+      success: function (resp) { renderPassiveAnalytics(resp.analytics || {}); }
+    });
+  }
+
   let passiveMonitorLastUpdate = null;
   let passiveMonitorPollTimer = null;
 
@@ -325,6 +364,7 @@ $(document).ready(function () {
           setPassiveMonitorStatus(`Passive capture running every ${status.interval || 10}s; last update saw ${count} device(s).`, status.error ? 'warning' : 'success');
           if (status.last_update && passiveMonitorLastUpdate && status.last_update !== passiveMonitorLastUpdate) {
             refreshNetworkDeviceList(`Passive capture added ${count} observed device(s).`);
+            refreshPassiveAnalytics();
           }
           passiveMonitorLastUpdate = status.last_update || passiveMonitorLastUpdate;
         } else {
@@ -351,6 +391,7 @@ $(document).ready(function () {
         const status = resp.status || {};
         passiveMonitorLastUpdate = status.last_update || null;
         setPassiveMonitorStatus(resp.message || 'Passive monitor updated.', enabled ? 'success' : 'muted');
+        refreshPassiveAnalytics();
         pollPassiveMonitorStatus();
       },
       error: function (xhr) {
@@ -363,6 +404,7 @@ $(document).ready(function () {
   activateNetworkDeviceTabFromHash();
 
   pollPassiveMonitorStatus();
+  refreshPassiveAnalytics();
 
   $(document).on('change', '[data-passive-monitor-toggle]', function () {
     togglePassiveMonitor($(this));
@@ -448,6 +490,7 @@ $(document).ready(function () {
       success: function (resp) {
         if (isNetworkDeviceListMode()) {
           refreshNetworkDeviceList(`Passive scan saved ${resp.devices.length} device(s). Updating the device list...`);
+          renderPassiveAnalytics(resp.analytics || {});
           return;
         }
         let html = '<h3>Passive Scan Results</h3>';
@@ -462,6 +505,11 @@ $(document).ready(function () {
         showNetworkDeviceListStatus('Scan failed', 'danger');
       }
     });
+  });
+
+  $(document).on('click', '[data-passive-analytics-refresh]', function (e) {
+    e.preventDefault();
+    refreshPassiveAnalytics();
   });
 
   $(document).on('click', '[data-port-scan-all]', function (e) {

--- a/static/js/port_scan_live.js
+++ b/static/js/port_scan_live.js
@@ -29,9 +29,13 @@ $(document).ready(function () {
     ports.forEach(function (port) {
       const info = details[port] || { service: 'Unknown', description: 'No common service mapping found' };
       const isNew = !previousPorts.has(port);
-      html += `<div class="port-service-card ${isNew ? 'port-service-card-new' : ''}">`;
-      html += `<div class="port-service-number">${escapeHtml(port)}</div>`;
-      html += `<div><strong>${escapeHtml(info.service)}</strong><p>${escapeHtml(info.description)}</p></div>`;
+      const portLabel = `${escapeHtml(port)}/tcp`;
+      const portHtml = info.web_url ? `<a href="${escapeHtml(info.web_url)}" target="_blank" rel="noopener noreferrer">${portLabel}</a>` : portLabel;
+      const serviceUrl = `/clients/${encodeURIComponent(job.host)}/services/${encodeURIComponent(port)}`;
+      const preview = info.web_url ? `<div class="web-service-hover-preview">${info.http_thumbnail_url ? `<img src="${escapeHtml(info.http_thumbnail_url)}" alt="Preview of ${escapeHtml(info.web_url)}">` : ''}<strong>${escapeHtml(info.http_title || info.web_url)}</strong><span>Status: ${escapeHtml(info.http_status || 'not captured')}${info.http_server ? ` · ${escapeHtml(info.http_server)}` : ''}</span><small>Click the port circle to open the page; click the card body for service details.</small></div>` : '';
+      html += `<div class="port-service-card ${isNew ? 'port-service-card-new' : ''}" data-web-service-preview>`;
+      html += `<div class="port-service-number">${portHtml}</div>`;
+      html += `<a class="port-service-card-link" href="${serviceUrl}"><strong>${escapeHtml(info.service)}</strong><p>${escapeHtml(info.description)}</p>${info.http_title ? `<small>HTTP title: ${escapeHtml(info.http_title)}</small>` : ''}</a>${preview}`;
       html += '</div>';
     });
     html += '</div>';

--- a/static/js/red-team-scripts.js
+++ b/static/js/red-team-scripts.js
@@ -243,6 +243,180 @@ $(document).ready(function () {
         });
     });
 
+    $("#EvilTwin-Submit").on("click", function(event) {
+        event.preventDefault();
+
+        var $ssidInput = $("#EvilTwin-SSID");
+        var $bssidInput = $("#EvilTwin-BSSID");
+        var $channelInput = $("#EvilTwin-Channel");
+        var $authorizedInput = $("#EvilTwin-Authorized");
+        var $status = $("#EvilTwin-Status");
+        var ssid = $ssidInput.val();
+        var bssid = $bssidInput.val();
+        var channel = $channelInput.val();
+        var authorized = $authorizedInput.is(":checked");
+
+        if (!ssid || !bssid || !channel || !authorized) {
+            if (!ssid) { $ssidInput.addClass("input-error"); }
+            if (!bssid) { $bssidInput.addClass("input-error"); }
+            if (!channel) { $channelInput.addClass("input-error"); }
+            if (!authorized) { $authorizedInput.addClass("input-error"); }
+            $status.removeClass("text-success").addClass("text-danger").text("Complete SSID, BSSID, channel, and authorization confirmation.");
+            return;
+        }
+
+        var $submitButton = $("#EvilTwin-Submit");
+        var originalButtonClass = $submitButton.attr('class');
+        var originalButtonStyle = $submitButton.attr('style');
+        var originalButtonText = $submitButton.text();
+
+        $.ajax({
+            url: "/evil-twin-lab",
+            type: "POST",
+            data: {
+                action: $("#EvilTwin-Action").val(),
+                ssid: ssid,
+                bssid: bssid,
+                channel: channel,
+                durationMinutes: $("#EvilTwin-Duration").val(),
+                portalMessage: $("#EvilTwin-Portal-Message").val(),
+                authorized: authorized ? "on" : "",
+                selectedInterface: $("#interface-select-EvilTwin").val()
+            },
+            beforeSend: function() {
+                $submitButton.prop("disabled", true);
+                $submitButton.attr('class', 'spinner-border text-primary');
+                $submitButton.text('');
+                $ssidInput.removeClass("input-error");
+                $bssidInput.removeClass("input-error");
+                $channelInput.removeClass("input-error");
+                $authorizedInput.removeClass("input-error");
+                $status.removeClass("text-danger text-success").text('');
+            },
+            success: function(response) {
+                var guidance = response.run && response.run.detection_guidance ? response.run.detection_guidance[0] : '';
+                $status.removeClass("text-danger").addClass("text-success").text((response.message || "Lab workflow recorded.") + " " + guidance);
+            },
+            error: function(error) {
+                var message = error.responseJSON && error.responseJSON.message ? error.responseJSON.message : "Failed to prepare lab workflow.";
+                $status.removeClass("text-success").addClass("text-danger").text(message);
+            },
+            complete: function() {
+                $submitButton.attr('class', originalButtonClass);
+                $submitButton.attr('style', originalButtonStyle);
+                $submitButton.text(originalButtonText);
+                $submitButton.prop("disabled", false);
+            }
+        });
+    });
+
+    $("#Pineap-Submit").on("click", function(event) {
+        event.preventDefault();
+        var $status = $("#Pineap-Status");
+        var authorized = $("#Pineap-Authorized").is(":checked");
+        if (!authorized) {
+            $("#Pineap-Authorized").addClass("input-error");
+            $status.removeClass("text-success").addClass("text-danger").text("Confirm the isolated authorized lab scope before running a campaign workflow.");
+            return;
+        }
+        var $submitButton = $("#Pineap-Submit");
+        var originalButtonClass = $submitButton.attr('class');
+        var originalButtonStyle = $submitButton.attr('style');
+        var originalButtonText = $submitButton.text();
+        $.ajax({
+            url: "/pineap-lab",
+            type: "POST",
+            data: {
+                action: $("#Pineap-Action").val(),
+                ssid: $("#Pineap-SSID").val(),
+                bssid: $("#Pineap-BSSID").val(),
+                channel: $("#Pineap-Channel").val(),
+                modules: $("#Pineap-Modules").val(),
+                notes: $("#Pineap-Notes").val(),
+                authorized: authorized ? "on" : "",
+                selectedInterface: $("#interface-select-Pineap").val()
+            },
+            beforeSend: function() {
+                $submitButton.prop("disabled", true);
+                $submitButton.attr('class', 'spinner-border text-primary');
+                $submitButton.text('');
+                $("#Pineap-Authorized").removeClass("input-error");
+                $status.removeClass("text-danger text-success").text('');
+            },
+            success: function(response) {
+                var count = response.run && response.run.recon ? response.run.recon.length : 0;
+                $status.removeClass("text-danger").addClass("text-success").text((response.message || "Campaign workflow recorded.") + " Recon networks: " + count + ".");
+            },
+            error: function(error) {
+                var message = error.responseJSON && error.responseJSON.message ? error.responseJSON.message : "Failed to run campaign workflow.";
+                $status.removeClass("text-success").addClass("text-danger").text(message);
+            },
+            complete: function() {
+                $submitButton.attr('class', originalButtonClass);
+                $submitButton.attr('style', originalButtonStyle);
+                $submitButton.text(originalButtonText);
+                $submitButton.prop("disabled", false);
+            }
+        });
+    });
+
+    $("#Handshake-Submit").on("click", function(event) {
+        event.preventDefault();
+        var $status = $("#Handshake-Status");
+        var required = [$("#Handshake-SSID"), $("#Handshake-BSSID"), $("#Handshake-Channel")];
+        var missing = false;
+        required.forEach(function($input) {
+            if (!$input.val()) {
+                $input.addClass("input-error");
+                missing = true;
+            }
+        });
+        if (!$("#Handshake-Authorized").is(":checked")) {
+            $("#Handshake-Authorized").addClass("input-error");
+            missing = true;
+        }
+        if (missing) {
+            $status.removeClass("text-success").addClass("text-danger").text("Complete SSID, BSSID, channel, and authorization confirmation.");
+            return;
+        }
+        var $submitButton = $("#Handshake-Submit");
+        var originalButtonClass = $submitButton.attr('class');
+        var originalButtonStyle = $submitButton.attr('style');
+        var originalButtonText = $submitButton.text();
+        var formData = new FormData($(".handshake-lab-card form")[0]);
+        formData.set("authorized", "on");
+        formData.set("selectedInterface", $("#interface-select-Handshake").val());
+        $.ajax({
+            url: "/handshake-lab",
+            type: "POST",
+            data: formData,
+            processData: false,
+            contentType: false,
+            beforeSend: function() {
+                $submitButton.prop("disabled", true);
+                $submitButton.attr('class', 'spinner-border text-primary');
+                $submitButton.text('');
+                required.forEach(function($input) { $input.removeClass("input-error"); });
+                $("#Handshake-Authorized").removeClass("input-error");
+                $status.removeClass("text-danger text-success").text('');
+            },
+            success: function(response) {
+                var status = response.record && response.record.validation_status ? response.record.validation_status : "cataloged";
+                $status.removeClass("text-danger").addClass("text-success").text((response.message || "Evidence cataloged.") + " Status: " + status + ".");
+            },
+            error: function(error) {
+                var message = error.responseJSON && error.responseJSON.message ? error.responseJSON.message : "Failed to catalog evidence.";
+                $status.removeClass("text-success").addClass("text-danger").text(message);
+            },
+            complete: function() {
+                $submitButton.attr('class', originalButtonClass);
+                $submitButton.attr('style', originalButtonStyle);
+                $submitButton.text(originalButtonText);
+                $submitButton.prop("disabled", false);
+            }
+        });
+    });
+
     $("#Aireplay-Deauth-Submit").on("click", function(event) {
         event.preventDefault();
 

--- a/static/js/service-discovery.js
+++ b/static/js/service-discovery.js
@@ -1,0 +1,78 @@
+$(document).ready(function () {
+  function escapeHtml(value) {
+    return $('<div>').text(value == null ? '' : value).html();
+  }
+
+  function serviceTable(items, columns) {
+    if (!items || !items.length) {
+      return '<p>No records discovered.</p>';
+    }
+    let html = '<div class="table-responsive"><table class="table theme-table"><thead><tr>';
+    columns.forEach(function (column) { html += `<th>${escapeHtml(column.label)}</th>`; });
+    html += '</tr></thead><tbody>';
+    items.forEach(function (item) {
+      html += '<tr>';
+      columns.forEach(function (column) { html += `<td>${escapeHtml(item[column.key] || '')}</td>`; });
+      html += '</tr>';
+    });
+    html += '</tbody></table></div>';
+    return html;
+  }
+
+  function runDiscovery(button, url, render) {
+    button.prop('disabled', true);
+    $('#service-discovery-results').html('<p>Discovery running...</p>');
+    $.ajax({
+      url: url,
+      method: 'POST',
+      data: { selectedInterface: $('#interface-select-ServiceDiscovery').val() },
+      success: function (response) { $('#service-discovery-results').html(render(response.result)); },
+      error: function (xhr) { $('#service-discovery-results').html(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Discovery failed')}</div>`); },
+      complete: function () { button.prop('disabled', false); }
+    });
+  }
+
+  $('#mdns-discovery-btn').on('click', function (event) {
+    event.preventDefault();
+    runDiscovery($(this), '/mdns-discovery', function (result) {
+      return `<h3>mDNS/Bonjour</h3><p>${escapeHtml(result.message)}</p>` + serviceTable(result.services, [
+        { key: 'name', label: 'Name' },
+        { key: 'service_type', label: 'Service' },
+        { key: 'hostname', label: 'Hostname' },
+        { key: 'ip', label: 'IP' },
+        { key: 'port', label: 'Port' },
+        { key: 'role', label: 'Role' },
+        { key: 'txt', label: 'TXT' }
+      ]);
+    });
+  });
+
+  $('#upnp-discovery-btn').on('click', function (event) {
+    event.preventDefault();
+    runDiscovery($(this), '/upnp-discovery', function (result) {
+      return `<h3>UPnP/SSDP</h3><p>${escapeHtml(result.message)}</p>` + serviceTable(result.devices, [
+        { key: 'friendly_name', label: 'Friendly name' },
+        { key: 'ip', label: 'IP' },
+        { key: 'manufacturer', label: 'Manufacturer' },
+        { key: 'model', label: 'Model' },
+        { key: 'service_type', label: 'Service type' },
+        { key: 'control_url', label: 'Control URL' },
+        { key: 'role', label: 'Role' }
+      ]);
+    });
+  });
+
+  $('#neighbor-discovery-btn').on('click', function (event) {
+    event.preventDefault();
+    runDiscovery($(this), '/neighbor-discovery', function (result) {
+      return `<h3>LLDP/CDP neighbors</h3><p>${escapeHtml(result.message)}</p>` + serviceTable(result.neighbors, [
+        { key: 'name', label: 'Neighbor' },
+        { key: 'port_id', label: 'Port' },
+        { key: 'management_address', label: 'Management address' },
+        { key: 'vlans', label: 'VLANs' },
+        { key: 'role', label: 'Role' },
+        { key: 'description', label: 'Description' }
+      ]);
+    });
+  });
+});

--- a/static/js/wireless-adapters.js
+++ b/static/js/wireless-adapters.js
@@ -364,6 +364,7 @@ $(document).ready(function () {
             </div>
             ${hasWps && network.wps_note ? `<p class="wireless-network-notes text-warning mb-2"><i class="fa-solid fa-triangle-exclamation"></i> ${escapeHtml(network.wps_note)}</p>` : ''}
             <div class="wireless-network-actions">
+              <a class="btn btn-outline-success btn-sm" href="${escapeHtml(detailUrl)}#network-device-scan" title="Open this SSID detail page with the interface device scan panel">Device scan</a>
               <form class="wireless-connect-form" data-interface="${escapeHtml(interfaceName)}" data-ssid="${escapeHtml(ssid)}">
                 <div class="input-group input-group-sm">
                   <input type="password" class="form-control" name="password" placeholder="${isOpen ? 'Open network: no password needed' : 'Password'}" aria-label="Password for ${escapeHtml(ssid)}">

--- a/static/style.css
+++ b/static/style.css
@@ -376,6 +376,7 @@ html[data-theme="dark"] .roadmap-completed-note {
 }
 
 .port-service-card {
+  position: relative;
   display: flex;
   align-items: center;
   gap: 0.75rem;
@@ -401,6 +402,57 @@ html[data-theme="dark"] .roadmap-completed-note {
   justify-content: center;
   font-weight: 700;
   font-size: 1.1rem;
+}
+
+.port-service-number a {
+  color: #fff;
+  text-decoration: none;
+}
+
+.port-service-card-link {
+  color: inherit;
+  display: grid;
+  flex: 1;
+  min-width: 0;
+  text-decoration: none;
+}
+
+.port-service-card-link:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+.web-service-hover-preview {
+  background: var(--card-bg, #fff);
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  border-radius: 0.75rem;
+  box-shadow: 0 0.75rem 2rem rgba(0, 0, 0, 0.18);
+  display: grid;
+  gap: 0.35rem;
+  left: 0.75rem;
+  max-width: 22rem;
+  opacity: 0;
+  padding: 0.75rem;
+  pointer-events: none;
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  transform: translateY(-0.35rem);
+  transition: opacity 0.2s ease 0.7s, transform 0.2s ease 0.7s;
+  visibility: hidden;
+  z-index: 20;
+}
+
+[data-web-service-preview]:hover .web-service-hover-preview,
+.port-service-card:hover .web-service-hover-preview {
+  opacity: 1;
+  transform: translateY(0);
+  visibility: visible;
+}
+
+.web-service-hover-preview img,
+.web-service-preview-image {
+  border-radius: 0.5rem;
+  max-width: 100%;
 }
 
 .port-service-card p {

--- a/templates/_primary-nav-links.html
+++ b/templates/_primary-nav-links.html
@@ -14,11 +14,13 @@
 {% endfor %}
 
 <div class="nav-item dropdown nav-compact-group">
-  <a href="#" class="nav-link {% if title in ['Network Scan', 'Port Scan', 'Traceroute', 'Red Team', 'Minecraft Attack'] %}active{% endif %}" data-toggle="dropdown">Tools</a>
+  <a href="#" class="nav-link {% if title in ['Service Discovery', 'Port Scan', 'Traceroute', 'Diagnostics', 'Advanced Diagnostics', 'Red Team', 'Minecraft Attack'] %}active{% endif %}" data-toggle="dropdown">Tools</a>
   <div class="dropdown-menu">
-    <a href="/network-scan" class="dropdown-item {% if title == 'Network Scan' %}active{% endif %}">Network Scan</a>
+    <a href="/service-discovery" class="dropdown-item {% if title == 'Service Discovery' %}active{% endif %}">Service Discovery</a>
     <a href="/port-scan" class="dropdown-item {% if title == 'Port Scan' %}active{% endif %}">Port Scan</a>
     <a href="/traceroute" class="dropdown-item {% if title == 'Traceroute' %}active{% endif %}">Traceroute</a>
+    <a href="/diagnostics" class="dropdown-item {% if title == 'Diagnostics' %}active{% endif %}">Diagnostics</a>
+    <a href="/advanced-diagnostics" class="dropdown-item {% if title == 'Advanced Diagnostics' %}active{% endif %}">Advanced Diagnostics</a>
     <div class="dropdown-divider"></div>
     <a href="/red-team" class="dropdown-item {% if title == 'Red Team' %}active{% endif %}">Red Team</a>
     <a href="/minecraft-attack" class="dropdown-item {% if title == 'Minecraft Attack' %}active{% endif %}">Minecraft Attack</a>

--- a/templates/advanced_diagnostics.html
+++ b/templates/advanced_diagnostics.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+
+{% block title %}Advanced Diagnostics{% endblock %}
+
+{% block content %}
+<section class="page-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">Advanced network tools</p>
+    <h1 class="page-title">Advanced Diagnostics</h1>
+    <p class="page-subtitle">Track VLAN segmentation, egress behavior, iperf3 baselines, SNMP inventory, and IPv6 assessment context.</p>
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <form id="advanced-diagnostics-form" class="theme-form">
+      <div>
+        <label class="theme-label" for="interface-select-AdvancedDiagnostics">Interface</label>
+        {% set selectId = 'AdvancedDiagnostics' %}
+        {% include '_adapters-list.html' %}
+      </div>
+      <input class="form-control" id="vlan-ssid" placeholder="SSID for VLAN note">
+      <input class="form-control" id="vlan-id" placeholder="VLAN ID">
+      <textarea class="form-control" id="vlan-notes" placeholder="Segmentation validation notes"></textarea>
+      <div class="theme-actions">
+        <button id="vlan-discovery-btn" class="btn btn-primary">VLAN Context</button>
+        <button id="egress-diagnostics-btn" class="btn btn-secondary">Egress Diagnostics</button>
+      </div>
+    </form>
+    <hr>
+    <form id="performance-form" class="theme-form">
+      <input class="form-control" id="iperf-host" placeholder="iperf3 server host">
+      <input class="form-control" id="iperf-port" placeholder="5201">
+      <input class="form-control" id="iperf-seconds" placeholder="5">
+      <button id="iperf-client-btn" class="btn btn-outline-primary">Run iperf3 Client</button>
+    </form>
+    <hr>
+    <form id="snmp-form" class="theme-form">
+      <input class="form-control" id="snmp-host" placeholder="SNMP host">
+      <input class="form-control" id="snmp-community" placeholder="Community / credential">
+      <label class="form-check deauth-lab-confirm"><input type="checkbox" id="snmp-authorized" class="form-check-input"> <span>Authorized SNMP inventory check</span></label>
+      <button id="snmp-discovery-btn" class="btn btn-outline-primary">Collect SNMP Metadata</button>
+    </form>
+    <hr>
+    <form id="ipv6-form" class="theme-form">
+      <input class="form-control" id="ipv6-host" placeholder="IPv6 host or hostname">
+      <input class="form-control" id="ipv6-ports" placeholder="Optional ports, e.g. 22,443">
+      <button id="ipv6-assessment-btn" class="btn btn-outline-primary">Run IPv6 Assessment</button>
+    </form>
+    <div id="advanced-diagnostics-results" class="theme-results"></div>
+  </div>
+</section>
+<script src="/static/js/advanced-diagnostics.js"></script>
+{% endblock %}

--- a/templates/attacks/_evilTwinLab.html
+++ b/templates/attacks/_evilTwinLab.html
@@ -1,0 +1,32 @@
+<div class="card m-3 evil-twin-lab-card" style="width: 18rem;">
+  <h5 class="card-title">Evil Twin &amp; Captive Portal Lab</h5>
+  <p class="card-text">Prepare controlled rogue-AP and captive-portal drills for an isolated, authorized lab without collecting credentials.</p>
+  <form class="form-inline" method="post" action="/evil-twin-lab">
+      <select class="form-control mb-2" id="EvilTwin-Action" name="action" aria-label="Lab action">
+        <option value="plan">Plan only</option>
+        <option value="start">Start checklist</option>
+        <option value="cleanup">Cleanup checklist</option>
+      </select>
+      <input type="text" class="form-control mb-2" id="EvilTwin-SSID" placeholder="Exact lab SSID" maxlength="32" name="ssid">
+      <input type="text" class="form-control mb-2" id="EvilTwin-BSSID" placeholder="Legitimate lab AP BSSID" name="bssid">
+      <input type="number" class="form-control mb-2" id="EvilTwin-Channel" placeholder="Channel" min="1" max="196" name="channel">
+      <input type="number" class="form-control mb-2" id="EvilTwin-Duration" placeholder="Duration minutes (1-30)" min="1" max="30" name="durationMinutes">
+      <textarea class="form-control mb-2" id="EvilTwin-Portal-Message" maxlength="200" name="portalMessage" rows="3">Training portal: do not enter real credentials.</textarea>
+      <label class="form-check deauth-lab-confirm">
+        <input class="form-check-input" type="checkbox" id="EvilTwin-Authorized" name="authorized">
+        <span class="form-check-label">I confirm this is an authorized isolated class lab and no credentials will be collected.</span>
+      </label>
+      {% set selectId = 'EvilTwin' %}
+      {% include '_adapters-list.html' %}
+      <button id="EvilTwin-Submit" class="btn btn-primary mb-2">Prepare Lab Workflow</button>
+      <div id="EvilTwin-Status" class="evil-twin-status small" aria-live="polite"></div>
+  </form>
+  <div class="evil-twin-guidance mt-3">
+    <strong>Detection guidance:</strong>
+    <ul>
+      <li>Flag duplicate SSIDs with new BSSIDs or channels.</li>
+      <li>Compare RSN/security and OUI details to approved AP inventory.</li>
+      <li>Watch DHCP, DNS, and portal redirects from unknown gateways.</li>
+    </ul>
+  </div>
+</div>

--- a/templates/attacks/_handshakeLab.html
+++ b/templates/attacks/_handshakeLab.html
@@ -1,0 +1,25 @@
+<div class="card m-3 handshake-lab-card" style="width: 18rem;">
+  <h5 class="card-title">WPA Handshake Capture Lab</h5>
+  <p class="card-text">Catalog WPA/WPA2 handshake or PMKID evidence from authorized lab networks for validation and export.</p>
+  <form class="form-inline" method="post" action="/handshake-lab" enctype="multipart/form-data">
+      <input type="text" class="form-control mb-2" id="Handshake-SSID" placeholder="Exact lab SSID" maxlength="32" name="ssid">
+      <input type="text" class="form-control mb-2" id="Handshake-BSSID" placeholder="Lab AP BSSID" name="bssid">
+      <input type="number" class="form-control mb-2" id="Handshake-Channel" placeholder="Channel" min="1" max="196" name="channel">
+      <input type="text" class="form-control mb-2" id="Handshake-Client" placeholder="Optional client MAC" name="client">
+      <select class="form-control mb-2" id="Handshake-Capture-Type" name="captureType" aria-label="Capture type">
+        <option value="wpa-handshake">WPA/WPA2 handshake</option>
+        <option value="pmkid">PMKID</option>
+      </select>
+      <input type="file" class="form-control mb-2" id="Handshake-Capture" name="capture" accept=".cap,.pcap,.pcapng,.hc22000,.hccapx">
+      <textarea class="form-control mb-2" id="Handshake-Validation-Notes" name="validationNotes" rows="3" placeholder="Validation notes, packet counts, or capture source"></textarea>
+      <label class="form-check deauth-lab-confirm">
+        <input class="form-check-input" type="checkbox" id="Handshake-Authorized" name="authorized">
+        <span class="form-check-label">I confirm this evidence is from an authorized isolated lab and will not be used for cracking here.</span>
+      </label>
+      {% set selectId = 'Handshake' %}
+      {% include '_adapters-list.html' %}
+      <button id="Handshake-Submit" class="btn btn-primary mb-2">Catalog Evidence</button>
+      <div id="Handshake-Status" class="evil-twin-status small" aria-live="polite"></div>
+      <a class="small" href="/handshake-lab.json">Export handshake catalog JSON</a>
+  </form>
+</div>

--- a/templates/attacks/_pineapLab.html
+++ b/templates/attacks/_pineapLab.html
@@ -1,0 +1,25 @@
+<div class="card m-3 pineap-lab-card" style="width: 18rem;">
+  <h5 class="card-title">PineAP-Style Lab Console</h5>
+  <p class="card-text">Run authorized recon, campaign, handshake, and module workflows with scoped logging and no credential collection.</p>
+  <form class="form-inline" method="post" action="/pineap-lab">
+      <select class="form-control mb-2" id="Pineap-Action" name="action" aria-label="PineAP-style action">
+        <option value="recon">Recon scan</option>
+        <option value="campaign">Campaign plan</option>
+        <option value="handshake">Handshake workflow</option>
+        <option value="module">Module queue</option>
+      </select>
+      <input type="text" class="form-control mb-2" id="Pineap-SSID" placeholder="Lab SSID for campaign/module" maxlength="32" name="ssid">
+      <input type="text" class="form-control mb-2" id="Pineap-BSSID" placeholder="Optional lab BSSID" name="bssid">
+      <input type="number" class="form-control mb-2" id="Pineap-Channel" placeholder="Optional channel" min="1" max="196" name="channel">
+      <input type="text" class="form-control mb-2" id="Pineap-Modules" name="modules" value="recon,detection-report" aria-label="Modules">
+      <textarea class="form-control mb-2" id="Pineap-Notes" name="notes" rows="3" placeholder="Campaign objective and scope notes"></textarea>
+      <label class="form-check deauth-lab-confirm">
+        <input class="form-check-input" type="checkbox" id="Pineap-Authorized" name="authorized">
+        <span class="form-check-label">I confirm this campaign is limited to an authorized isolated lab.</span>
+      </label>
+      {% set selectId = 'Pineap' %}
+      {% include '_adapters-list.html' %}
+      <button id="Pineap-Submit" class="btn btn-primary mb-2">Run Lab Workflow</button>
+      <div id="Pineap-Status" class="evil-twin-status small" aria-live="polite"></div>
+  </form>
+</div>

--- a/templates/capabilities.html
+++ b/templates/capabilities.html
@@ -61,10 +61,12 @@
         <tbody>
           <tr><th>Status</th><td>{% if capabilities.oui_database.loaded %}<span class="badge badge-success">Loaded</span>{% else %}<span class="badge badge-warning">Unavailable</span>{% endif %}</td></tr>
           <tr><th>Entries</th><td>{{ capabilities.oui_database.entries }}</td></tr>
+          <tr><th>Coverage</th><td>{% if capabilities.oui_database.coverage == 'full' %}<span class="badge badge-success">Full IEEE-sized database</span>{% else %}<span class="badge badge-warning">Compact fallback database</span>{% endif %}</td></tr>
           <tr><th>Fallback entries</th><td>{{ capabilities.oui_database.fallback_entries }}</td></tr>
           <tr><th>Database path</th><td><code>{{ capabilities.oui_database.path or 'Built-in fallback only' }}</code></td></tr>
         </tbody>
       </table>
+      {% if capabilities.oui_database.needs_refresh %}<div class="alert alert-warning py-2">The bundled OUI file is compact; unknown vendors may simply be missing from the local file. Refresh the full IEEE list with <code>python scripts/update_oui_db.py</code> on a network that can reach IEEE.</div>{% endif %}
       <p class="text-muted small mb-0">Refresh the local database with <code>python scripts/update_oui_db.py</code> when internet access is available.</p>
     </div>
   </article>

--- a/templates/capabilities.html
+++ b/templates/capabilities.html
@@ -67,7 +67,10 @@
         </tbody>
       </table>
       {% if capabilities.oui_database.needs_refresh %}<div class="alert alert-warning py-2">The bundled OUI file is compact; unknown vendors may simply be missing from the local file. Refresh the full IEEE list with <code>python scripts/update_oui_db.py</code> on a network that can reach IEEE.</div>{% endif %}
-      <p class="text-muted small mb-0">Refresh the local database with <code>python scripts/update_oui_db.py</code> when internet access is available.</p>
+      <div class="theme-actions">
+        <button class="btn btn-outline-primary update-oui-db-btn" data-confirm="download">Download full OUI database</button>
+      </div>
+      <p class="text-muted small mb-0">Refresh the local database with <code>python scripts/update_oui_db.py</code> or the button above when internet access is available.</p>
     </div>
   </article>
 </section>

--- a/templates/capabilities.html
+++ b/templates/capabilities.html
@@ -53,6 +53,21 @@
       </table>
     </div>
   </article>
+
+  <article class="theme-card card">
+    <div class="card-body">
+      <h2 class="theme-section-title">OUI Vendor Lookup</h2>
+      <table class="table table-sm theme-table">
+        <tbody>
+          <tr><th>Status</th><td>{% if capabilities.oui_database.loaded %}<span class="badge badge-success">Loaded</span>{% else %}<span class="badge badge-warning">Unavailable</span>{% endif %}</td></tr>
+          <tr><th>Entries</th><td>{{ capabilities.oui_database.entries }}</td></tr>
+          <tr><th>Fallback entries</th><td>{{ capabilities.oui_database.fallback_entries }}</td></tr>
+          <tr><th>Database path</th><td><code>{{ capabilities.oui_database.path or 'Built-in fallback only' }}</code></td></tr>
+        </tbody>
+      </table>
+      <p class="text-muted small mb-0">Refresh the local database with <code>python scripts/update_oui_db.py</code> when internet access is available.</p>
+    </div>
+  </article>
 </section>
 
 
@@ -171,7 +186,20 @@
               <div class="text-muted small">{{ dependency.details }}</div>
             </td>
             <td>{% if dependency.available %}<span class="badge badge-success">Available</span>{% else %}<span class="badge badge-warning">Unavailable</span>{% endif %}</td>
-            <td><code>{{ dependency.install_hint }}</code></td>
+            <td>
+              <code>{{ dependency.install_hint }}</code>
+              {% if dependency.install_action %}
+                <div class="mt-2">
+                  <button
+                    type="button"
+                    class="btn btn-sm btn-outline-primary install-host-dependency-btn"
+                    data-dependency="{{ dependency.id }}"
+                    data-confirm="install">
+                    Install for me
+                  </button>
+                </div>
+              {% endif %}
+            </td>
           </tr>
         {% endfor %}
       </tbody>

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,4 +1,5 @@
 {% include '_header.html' %}
+<link rel="stylesheet" href="/static/css/interface.css">
 <body class="d-flex flex-column min-vh-100">
   <main class="page-shell">
     <section class="page-hero">
@@ -9,7 +10,7 @@
           {% if is_bluetooth %}
             Bluetooth identity and device details discovered from scan results. The MAC address remains the unique device ID.
           {% else %}
-            Device identity and manufacturer details discovered from scan results.
+            Device identity and manufacturer details discovered from scan results{% if display_name_source %}; display name learned from {{ display_name_source }}{% endif %}.
           {% endif %}
         </p>
       </div>
@@ -33,6 +34,19 @@
             <dt>Manufacturer</dt>
             <dd>{{ manufacturer }}</dd>
           </div>
+          {% if not is_bluetooth %}
+            <div>
+              <dt>Likely Role</dt>
+              <dd>
+                {{ (inventory_device.device_role_guess or {}).role or 'Client' }}
+                <span class="badge badge-light border">{{ (inventory_device.device_role_guess or {}).confidence or 'low' }} confidence</span>
+              </dd>
+            </div>
+            <div>
+              <dt>MAC Privacy</dt>
+              <dd>{{ 'Likely randomized/private MAC' if inventory_device.likely_randomized_mac else 'Hardware/OUI MAC not flagged as randomized' }}</dd>
+            </div>
+          {% endif %}
           {% for field in bluetooth_fields %}
             <div>
               <dt>{{ field.label }}</dt>
@@ -40,6 +54,14 @@
             </div>
           {% endfor %}
         </dl>
+        {% if not is_bluetooth and inventory_device.observed_names %}
+          <h3 class="theme-subsection-title mt-3">Names observed</h3>
+          <div class="network-device-tags">
+            {% for item in inventory_device.observed_names %}
+              <span class="badge badge-light border">{{ item.name }} · {{ item.source }}</span>
+            {% endfor %}
+          </div>
+        {% endif %}
       </div>
     </section>
 
@@ -88,6 +110,172 @@
         </div>
       </section>
     {% elif ip %}
+      <section class="theme-card card">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start flex-wrap">
+            <div>
+              <h2 class="theme-section-title">Client Health</h2>
+              <p class="text-muted">A lightweight profile score built from identity confidence, saved services, and exposure hints.</p>
+            </div>
+            <span class="badge badge-{{ health_summary.badge }} p-2">{{ health_summary.level }} · {{ health_summary.score }}/100</span>
+          </div>
+          <div class="theme-actions">
+            <button type="button" class="btn btn-{{ 'warning' if watched_client else 'outline-warning' }}" data-ip-client-watch data-watched="{{ 'true' if watched_client else 'false' }}">
+              {{ 'Watching client' if watched_client else 'Watch this device' }}
+            </button>
+            <button type="button" class="btn btn-outline-info" data-ip-client-http-inspect>Inspect web services</button>
+            <button type="button" class="btn btn-outline-success" data-ip-client-fingerprint>Fingerprint services</button>
+            <button type="button" class="btn btn-outline-dark" data-ip-client-intelligence>Gather device intelligence</button>
+            <button type="button" class="btn btn-outline-primary" data-ip-client-baseline>Save baseline</button>
+            <a class="btn btn-outline-secondary" href="/clients/{{ ip|urlencode }}/export.json">Export JSON</a>
+            <a class="btn btn-outline-secondary" href="/clients/{{ ip|urlencode }}/export.md">Export Markdown</a>
+          </div>
+          <ul class="mt-3 mb-0">
+            {% for flag in health_summary.flags %}
+              <li>{{ flag }}</li>
+            {% endfor %}
+          </ul>
+          <div class="mt-3">
+            <strong>Baseline drift:</strong> {{ baseline_diff.status }}
+            {% if baseline_diff.unexpected_ports %}<span class="badge badge-danger">Unexpected {{ baseline_diff.unexpected_ports|join(', ') }}</span>{% endif %}
+            {% if baseline_diff.missing_ports %}<span class="badge badge-warning">Missing {{ baseline_diff.missing_ports|join(', ') }}</span>{% endif %}
+          </div>
+        </div>
+      </section>
+
+      <section class="theme-card card">
+        <div class="card-body">
+          <h2 class="theme-section-title">Client Profile Metadata</h2>
+          <form class="theme-form" data-ip-client-metadata-form>
+            <div class="form-row">
+              <div class="col">
+                <label for="client-tags">Tags</label>
+                <input id="client-tags" class="form-control" data-ip-client-tags value="{{ (inventory_device.client_tags or [])|join(', ') if inventory_device else '' }}" placeholder="trusted, printer, guest">
+              </div>
+              <div class="col">
+                <label for="client-owner">Owner</label>
+                <input id="client-owner" class="form-control" data-ip-client-owner value="{{ inventory_device.client_owner if inventory_device else '' }}" placeholder="Team or person">
+              </div>
+            </div>
+            <div class="form-row mt-2">
+              <div class="col">
+                <label for="client-location">Location</label>
+                <input id="client-location" class="form-control" data-ip-client-location value="{{ inventory_device.client_location if inventory_device else '' }}" placeholder="Office, lab bench, garage">
+              </div>
+              <div class="col">
+                <label for="client-expected-ports">Expected open ports</label>
+                <input id="client-expected-ports" class="form-control" data-ip-client-expected-ports value="{{ (inventory_device.expected_open_ports or [])|join(', ') if inventory_device else '' }}" placeholder="22, 80, 443">
+              </div>
+            </div>
+            <label class="mt-2" for="client-notes">Profile notes</label>
+            <textarea id="client-notes" class="form-control" data-ip-client-notes rows="2" placeholder="Expected purpose, owner context, or remediation notes.">{{ inventory_device.client_notes if inventory_device else '' }}</textarea>
+            <div class="theme-actions">
+              <button type="submit" class="btn btn-primary">Save client metadata</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="theme-card card">
+        <div class="card-body">
+          <h2 class="theme-section-title">Client Relationship Map</h2>
+          <p class="text-muted">Context links between this client, interfaces, discovery sources, saved services, and evidence records.</p>
+          <div class="theme-grid">
+            {% for node in relationship_map.nodes %}
+              <div class="port-service-card">
+                <strong>{{ node.label }}</strong>
+                <small>{{ node.type }}</small>
+              </div>
+            {% endfor %}
+          </div>
+          <ul class="mt-3 mb-0">
+            {% for link in relationship_map.links %}
+              <li>{{ link.source }} → {{ link.target }} <span class="text-muted">({{ link.label }})</span></li>
+            {% else %}
+              <li class="text-muted">No related interfaces, services, or evidence are attached yet.</li>
+            {% endfor %}
+          </ul>
+        </div>
+      </section>
+
+      <section class="theme-card card">
+        <div class="card-body">
+          <h2 class="theme-section-title">Scheduled Client Checks</h2>
+          <p class="text-muted">Save a recurring check plan for this client. The plan is recorded now so a background scheduler can run it next.</p>
+          {% if scheduled_check %}
+            <div class="alert alert-info">Scheduled every {{ scheduled_check.interval_minutes }} minute(s): {{ scheduled_check.checks|join(', ') }}</div>
+          {% endif %}
+          <form class="theme-form" data-ip-client-scheduled-form>
+            <label for="client-check-interval">Interval minutes</label>
+            <input id="client-check-interval" class="form-control" type="number" min="5" max="10080" value="{{ scheduled_check.interval_minutes if scheduled_check else 60 }}" data-ip-client-check-interval>
+            <label class="mt-2" for="client-checks">Checks</label>
+            <input id="client-checks" class="form-control" value="{{ scheduled_check.checks|join(', ') if scheduled_check else 'ping, common-ports, baseline-drift' }}" data-ip-client-checks placeholder="ping, common-ports, http-inspect, service-fingerprint, baseline-drift">
+            <div class="theme-actions">
+              <button type="submit" class="btn btn-primary">Save scheduled checks</button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section class="theme-card card" data-ip-client-tools data-host="{{ ip }}">
+        <div class="card-body">
+          <h2 class="theme-section-title">IP Client Actions</h2>
+          <p class="text-muted">Run quick reachability and path checks, jump to deeper diagnostics, or save investigation notes for this client profile.</p>
+          <div class="theme-actions">
+            <button type="button" class="btn btn-outline-success" data-ip-client-ping>Ping client</button>
+            <button type="button" class="btn btn-outline-info" data-ip-client-route>Route diagnostics</button>
+            <button type="button" class="btn btn-outline-secondary" data-ip-client-traceroute>Traceroute</button>
+            <a class="btn btn-outline-primary" href="/diagnostics">Open diagnostics</a>
+          </div>
+          <form class="theme-form mt-3" data-ip-client-evidence-form>
+            <label for="ip-client-evidence">Evidence / investigation note</label>
+            <textarea id="ip-client-evidence" class="form-control" data-ip-client-evidence-notes rows="3" placeholder="Example: Gateway responded to ping; SSH and HTTPS open during authorized baseline." required></textarea>
+            <div class="theme-actions">
+              <button type="submit" class="btn btn-primary">Save evidence note</button>
+              <a class="btn btn-link" href="/evidence">Open Evidence Vault</a>
+            </div>
+          </form>
+          <div class="theme-results mt-3" data-ip-client-output><p class="text-muted mb-0">No IP client action has run yet.</p></div>
+        </div>
+      </section>
+
+      {% if open_port_details %}
+        <section class="theme-card card">
+          <div class="card-body">
+            <h2 class="theme-section-title">Saved Service Profile</h2>
+            <p class="text-muted">Open ports found on previous scans are saved to this device profile{% if last_port_scan_label %}; last scan {{ last_port_scan_label }}{% endif %}.</p>
+            <div class="port-service-grid">
+              {% for port in open_port_details %}
+                <div class="port-service-card" data-web-service-preview>
+                  <strong class="port-service-number">
+                    {% if port.web_url %}
+                      <a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>
+                    {% else %}
+                      {{ port.port }}/tcp
+                    {% endif %}
+                  </strong>
+                  <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}">
+                    <span>{{ port.service }}</span>
+                    <small>{{ port.description }}</small>
+                    {% if port.http_title %}<small>HTTP title: {{ port.http_title }}</small>{% endif %}
+                    {% if port.http_favicon %}<small>Favicon SHA-256: {{ port.http_favicon.sha256[:12] }}…</small>{% endif %}
+                    {% if port.tls_certificate %}<small>TLS CN: {{ port.tls_certificate.subject_common_name or 'Unknown' }}{% if port.tls_certificate.issuer_common_name %} · Issuer: {{ port.tls_certificate.issuer_common_name }}{% endif %}</small>{% endif %}
+                  </a>
+                  {% if port.web_url %}
+                    <div class="web-service-hover-preview">
+                      {% if port.http_thumbnail_url %}<img src="{{ port.http_thumbnail_url }}" alt="Preview of {{ port.web_url }}">{% endif %}
+                      <strong>{{ port.http_title or port.web_url }}</strong>
+                      <span>Status: {{ port.http_status or 'not captured' }}{% if port.http_server %} · {{ port.http_server }}{% endif %}</span>
+                      <small>Long-hover preview. Click the port circle to open the web page; click the card body for saved service details.</small>
+                    </div>
+                  {% endif %}
+                </div>
+              {% endfor %}
+            </div>
+          </div>
+        </section>
+      {% endif %}
+
       <section class="theme-card card port-scan-panel" data-host="{{ ip }}">
         <div class="card-body">
           <h2 class="theme-section-title">Device Port Scan</h2>
@@ -125,12 +313,34 @@
           </div>
         </div>
       </section>
+
+      <section class="theme-card card">
+        <div class="card-body">
+          <h2 class="theme-section-title">Client Timeline</h2>
+          {% if reachability_history %}
+            <div class="alert alert-info">
+              Recent reachability: {{ reachability_history|length }} ping check(s), latest {{ 'reachable' if reachability_history[-1].reachable else 'unreachable' }} with {{ reachability_history[-1].packet_loss_percent }}% loss.
+            </div>
+          {% endif %}
+          <ol class="client-timeline">
+            {% for event in client_timeline %}
+              <li>
+                <strong>{{ event.time_label }}</strong> — {{ event.type }}
+                <p class="mb-0">{{ event.message }}{% if event.source %} <span class="text-muted">({{ event.source }})</span>{% endif %}</p>
+              </li>
+            {% else %}
+              <li class="text-muted">No client timeline events have been recorded yet.</li>
+            {% endfor %}
+          </ol>
+        </div>
+      </section>
     {% endif %}
   </main>
 {% if is_bluetooth %}
 <script src="/static/js/bluetooth-scan.js"></script>
 {% else %}
 <script src="/static/js/port_scan_live.js"></script>
+<script src="/static/js/ip_client.js"></script>
 {% endif %}
 </body>
 {% include '_footer.html' %}

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -201,7 +201,7 @@
       <section class="theme-card card">
         <div class="card-body">
           <h2 class="theme-section-title">Scheduled Client Checks</h2>
-          <p class="text-muted">Save a recurring check plan for this client. The plan is recorded now so a background scheduler can run it next.</p>
+          <p class="text-muted">Save a recurring check plan for this client. The plan is recorded, persisted, and can be run on demand; due-check APIs can also execute saved plans without rerunning massive scans.</p>
           {% if scheduled_check %}
             <div class="alert alert-info">Scheduled every {{ scheduled_check.interval_minutes }} minute(s): {{ scheduled_check.checks|join(', ') }}</div>
           {% endif %}
@@ -212,6 +212,7 @@
             <input id="client-checks" class="form-control" value="{{ scheduled_check.checks|join(', ') if scheduled_check else 'ping, common-ports, baseline-drift' }}" data-ip-client-checks placeholder="ping, common-ports, http-inspect, service-fingerprint, baseline-drift">
             <div class="theme-actions">
               <button type="submit" class="btn btn-primary">Save scheduled checks</button>
+              <button type="button" class="btn btn-outline-success" data-ip-client-run-scheduled>Run saved checks now</button>
             </div>
           </form>
         </div>

--- a/templates/diagnostics.html
+++ b/templates/diagnostics.html
@@ -1,0 +1,57 @@
+{% extends 'base.html' %}
+
+{% block title %}Diagnostics{% endblock %}
+
+{% block content %}
+<section class="page-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">Reachability</p>
+    <h1 class="page-title">Ping &amp; Route Diagnostics</h1>
+    <p class="page-subtitle">Test single hosts, run bounded subnet sweeps, and inspect gateways, routes, VPN hints, and scan-path context.</p>
+  </div>
+</section>
+
+<section class="theme-grid">
+  <article class="theme-card card">
+    <div class="card-body">
+      <h2 class="theme-section-title">Ping and reachability</h2>
+      <form id="ping-form" class="theme-form">
+        <div class="form-group mb-0">
+          <label for="ping-host">Host or IP</label>
+          <input type="text" class="form-control" id="ping-host" placeholder="8.8.8.8 or example.com">
+        </div>
+        <div class="theme-actions">
+          <button id="ping-btn" class="btn btn-primary">Ping Host</button>
+        </div>
+      </form>
+      <form id="ping-sweep-form" class="theme-form mt-3">
+        <div class="form-group mb-0">
+          <label for="ping-cidr">Subnet sweep CIDR</label>
+          <input type="text" class="form-control" id="ping-cidr" placeholder="192.168.1.0/30">
+        </div>
+        <div class="theme-actions">
+          <button id="ping-sweep-btn" class="btn btn-outline-primary">Run Sweep</button>
+        </div>
+      </form>
+      <div id="ping-results" class="theme-results"></div>
+    </div>
+  </article>
+
+  <article class="theme-card card">
+    <div class="card-body">
+      <h2 class="theme-section-title">Route table and gateways</h2>
+      <form id="route-diagnostics-form" class="theme-form">
+        <div class="form-group mb-0">
+          <label for="route-target">Optional target for scan-path context</label>
+          <input type="text" class="form-control" id="route-target" placeholder="1.1.1.1">
+        </div>
+        <div class="theme-actions">
+          <button id="route-diagnostics-btn" class="btn btn-secondary">Inspect Routes</button>
+        </div>
+      </form>
+      <div id="route-results" class="theme-results"></div>
+    </div>
+  </article>
+</section>
+<script src="/static/js/diagnostics.js"></script>
+{% endblock %}

--- a/templates/interface_detail.html
+++ b/templates/interface_detail.html
@@ -71,7 +71,7 @@
               <li><span class="badge badge-success">Phone pairing</span> Pair phones and request authorised contacts, call history, messages, controls, media, or tethering from this page</li>
               <li><span class="badge badge-info">Host tools</span> Actions require BlueZ bluetoothctl or busctl support</li>
             {% else %}
-              <li><span class="badge badge-primary">Available</span> Active/passive network scans from the Scan page</li>
+              <li><span class="badge badge-primary">Available</span> Active, passive, and comprehensive network scans from this interface page</li>
               <li><span class="badge badge-info">Available</span> Port scan and traceroute workflows</li>
             {% endif %}
             {% if not interface.addresses %}
@@ -207,6 +207,32 @@
           </div>
         </article>
       {% endif %}
+
+      {% if interface.interface_type != 'Bluetooth' and interface.interface_type != 'Loopback' %}
+        <article class="card shadow-sm interface-network-scan-card">
+          <div class="card-body">
+            <h2 class="interface-section-title">Network Device Scan</h2>
+            <p class="text-muted">Scan this interface for local devices using active ARP, passive observations, ARP/neighbor cache data, optional ping sweeps, and service discovery metadata.</p>
+            <form id="scan-form" class="theme-form interface-scan-form">
+              <select id="interface-select-Scan" class="d-none" aria-hidden="true">
+                <option value="{{ interface.name }}" selected>{{ interface.name }}</option>
+              </select>
+              <div class="theme-actions">
+                <button id="comprehensive-scan-btn" class="btn btn-success">Comprehensive Device Scan</button>
+                <button id="active-scan-btn" class="btn btn-primary">Active Scan</button>
+                <button id="passive-scan-btn" class="btn btn-secondary">Passive Scan</button>
+              </div>
+              <div class="form-group mb-0">
+                <label for="sweep-cidr">Optional ping sweep CIDR</label>
+                <input id="sweep-cidr" class="form-control" placeholder="192.168.1.0/28 (optional, max 64 hosts)">
+              </div>
+              <label class="form-check deauth-lab-confirm"><input type="checkbox" id="include-passive" class="form-check-input" checked> <span>Include passive observations</span></label>
+              <label class="form-check deauth-lab-confirm"><input type="checkbox" id="include-services" class="form-check-input" checked> <span>Include mDNS, UPnP/SSDP, and LLDP/CDP service discovery</span></label>
+            </form>
+            <div id="scan-results" class="theme-results"></div>
+          </div>
+        </article>
+      {% endif %}
     </section>
 
     <div id="wlans-{{ interface.name }}" class="wlans" data-interface="{{ interface.name }}"></div>
@@ -219,6 +245,9 @@
     <script src="/static/js/wireless-adapters.js"></script>
   {% elif interface.interface_type == 'Bluetooth' %}
     <script src="/static/js/bluetooth-scan.js"></script>
+  {% endif %}
+  {% if interface.interface_type != 'Bluetooth' and interface.interface_type != 'Loopback' %}
+    <script src="/static/js/network_scan.js"></script>
   {% endif %}
 
   {% include '_footer.html' %}

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -7,7 +7,31 @@
   <div class="page-hero-copy">
     <p class="page-kicker">Network visibility</p>
     <h1 class="page-title">Device Inventory</h1>
-    <p class="page-subtitle">Review discovered IPs, MAC addresses, manufacturers, interfaces, sources, and first/last seen timestamps in one place.</p>
+    <p class="page-subtitle">Review discovered IPs, MAC addresses, manufacturers, interfaces, sources, saved ports, and first/last seen timestamps in one place.</p>
+  </div>
+  <div class="theme-actions">
+    <a class="btn btn-outline-primary" href="/inventory/export.json">Export devices + ports</a>
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Inventory import/export</h2>
+    <p class="text-muted">Export saves device records and saved port/service profiles so you can restore them later and avoid re-running large port scans.</p>
+    {% if import_result %}
+      {% if import_result.status == 'success' %}
+        <div class="alert alert-success" role="alert">Imported {{ import_result.imported_devices }} device record(s) and {{ import_result.imported_port_profiles }} saved port profile(s).</div>
+      {% else %}
+        <div class="alert alert-danger" role="alert">{{ import_result.message }}</div>
+      {% endif %}
+    {% endif %}
+    <form class="theme-form" action="/inventory/import" method="post" enctype="multipart/form-data">
+      <div class="form-group">
+        <label for="inventoryFile">Import exported inventory JSON</label>
+        <input id="inventoryFile" class="form-control-file" type="file" name="inventoryFile" accept="application/json,.json" required>
+      </div>
+      <button class="btn btn-primary" type="submit">Import devices + ports</button>
+    </form>
   </div>
 </section>
 
@@ -95,8 +119,33 @@
                 <td>{{ device.first_seen_label }}</td>
                 <td>{{ device.last_seen_label }}</td>
                 <td>
+                  {% if device.open_port_details %}
+                    <div class="small text-muted mb-2">
+                      Open:
+                      {% for port in device.open_port_details %}
+                        {% if loop.index <= 4 %}
+                          <span class="badge badge-info">{{ port.port }} {{ port.service }}</span>
+                        {% endif %}
+                      {% endfor %}
+                    </div>
+                  {% endif %}
+                  {% if device.client_health %}
+                    <div class="small text-muted mb-2">
+                      <span class="badge badge-{{ device.client_health.badge }}">{{ device.client_health.level }} {{ device.client_health.score }}/100</span>
+                      {% if device.client_baseline and device.client_baseline.status == 'Drift detected' %}
+                        <span class="badge badge-danger">Drift</span>
+                      {% endif %}
+                      {% if device.is_watched_client %}
+                        <span class="badge badge-warning">Watched</span>
+                      {% endif %}
+                      {% for tag in device.client_tags or [] %}
+                        {% if loop.index <= 3 %}<span class="badge badge-light border">{{ tag }}</span>{% endif %}
+                      {% endfor %}
+                    </div>
+                  {% endif %}
                   {% if device.ip and not device.is_control_traffic %}
-                    <a class="btn btn-outline-primary btn-sm" href="/port-scan?host={{ device.ip|urlencode }}">Check ports</a>
+                    <a class="btn btn-outline-primary btn-sm" href="/clients/{{ device.ip|urlencode }}">Device scan</a>
+                    <a class="btn btn-outline-secondary btn-sm" href="/port-scan?host={{ device.ip|urlencode }}">Tools scan</a>
                   {% else %}
                     —
                   {% endif %}

--- a/templates/network_scan.html
+++ b/templates/network_scan.html
@@ -3,6 +3,7 @@
 {% block title %}Network Scan{% endblock %}
 
 {% block content %}
+<link rel="stylesheet" href="/static/css/interface.css">
 <section class="page-hero">
   <div class="page-hero-copy">
     <p class="page-kicker">Discovery</p>
@@ -20,12 +21,19 @@
         {% include '_adapters-list.html' %}
       </div>
       <div class="theme-actions">
+        <button id="comprehensive-scan-btn" class="btn btn-success">Comprehensive Device Scan</button>
         <button id="active-scan-btn" class="btn btn-primary">Active Scan</button>
         <button id="passive-scan-btn" class="btn btn-secondary">Passive Scan</button>
       </div>
+      <div class="form-group mb-0">
+        <label for="sweep-cidr">Optional ping sweep CIDR</label>
+        <input id="sweep-cidr" class="form-control" placeholder="192.168.1.0/28 (optional, max 64 hosts)">
+      </div>
+      <label class="form-check deauth-lab-confirm"><input type="checkbox" id="include-passive" class="form-check-input" checked> <span>Include passive observations</span></label>
+      <label class="form-check deauth-lab-confirm"><input type="checkbox" id="include-services" class="form-check-input" checked> <span>Include mDNS, UPnP/SSDP, and LLDP/CDP service discovery</span></label>
     </form>
     <div class="alert alert-secondary mt-3" role="note">
-      <strong>How to read passive results:</strong> private LAN hosts are likely devices on your network, gateway/router rows are infrastructure, and broadcast or multicast rows are local control traffic rather than individual clients.
+      <strong>Comprehensive scans:</strong> combine active ARP discovery, passive observations, local ARP/neighbor tables, optional ping sweeps, and service discovery metadata to build device inventory like Bluetooth scans do for nearby devices.
     </div>
     <div id="scan-results" class="theme-results"></div>
   </div>

--- a/templates/red-team.html
+++ b/templates/red-team.html
@@ -15,6 +15,9 @@
       {% include 'attacks/_broadcastAttack.html' %}
       {% include 'attacks/_beaconAdvertise.html' %}
       {% include 'attacks/_deauth.html' %}
+      {% include 'attacks/_pineapLab.html' %}
+      {% include 'attacks/_handshakeLab.html' %}
+      {% include 'attacks/_evilTwinLab.html' %}
       {% include 'attacks/_aireplayDeauth.html' %}
     </section>
   </main>

--- a/templates/service_detail.html
+++ b/templates/service_detail.html
@@ -1,0 +1,36 @@
+{% include '_header.html' %}
+
+<body class="d-flex flex-column min-vh-100">
+  <main class="theme-page container py-4">
+    <section class="theme-card card">
+      <div class="card-body">
+        <p class="interface-kicker mb-1">Saved Service</p>
+        <h1 class="page-title">{{ host }}:{{ port }}</h1>
+        {% if service %}
+          <div class="theme-actions">
+            {% if service.web_url %}<a class="btn btn-primary" href="{{ service.web_url }}" target="_blank" rel="noopener noreferrer">Open web service</a>{% endif %}
+            <a class="btn btn-outline-secondary" href="/clients/{{ host|urlencode }}">Back to device</a>
+          </div>
+          <dl class="interface-definition-list mt-3">
+            <div><dt>Service</dt><dd>{{ service.service or 'Unknown' }}</dd></div>
+            <div><dt>Description</dt><dd>{{ service.description or 'No service description saved.' }}</dd></div>
+            <div><dt>HTTP Status</dt><dd>{{ service.http_status or 'Not captured' }}</dd></div>
+            <div><dt>HTTP Title</dt><dd>{{ service.http_title or 'Not captured' }}</dd></div>
+            <div><dt>Server Header</dt><dd>{{ service.http_server or 'Not captured' }}</dd></div>
+            <div><dt>URL</dt><dd>{% if service.web_url %}<a href="{{ service.web_url }}" target="_blank" rel="noopener noreferrer">{{ service.web_url }}</a>{% else %}No web URL saved{% endif %}</dd></div>
+          </dl>
+          {% if service.http_thumbnail_url %}
+            <img class="web-service-preview-image mt-3" src="{{ service.http_thumbnail_url }}" alt="Preview of {{ service.web_url }}">
+          {% else %}
+            <p class="text-muted mt-3">No screenshot preview is available yet. A preview is captured automatically when browser screenshot tooling is installed on the host.</p>
+          {% endif %}
+        {% else %}
+          <div class="alert alert-warning">No saved service profile exists for this port yet.</div>
+          <a class="btn btn-outline-secondary" href="/clients/{{ host|urlencode }}">Back to device</a>
+        {% endif %}
+      </div>
+    </section>
+  </main>
+  {% include '_footer.html' %}
+</body>
+</html>

--- a/templates/service_discovery.html
+++ b/templates/service_discovery.html
@@ -1,0 +1,35 @@
+{% extends 'base.html' %}
+
+{% block title %}Service Discovery{% endblock %}
+
+{% block content %}
+<section class="page-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">Local discovery</p>
+    <h1 class="page-title">Service Discovery</h1>
+    <p class="page-subtitle">Discover mDNS/Bonjour services, UPnP/SSDP devices, and LLDP/CDP neighbors visible on authorized local networks.</p>
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <form id="service-discovery-form" class="theme-form">
+      <div>
+        <label class="theme-label" for="interface-select-ServiceDiscovery">Interface</label>
+        {% set selectId = 'ServiceDiscovery' %}
+        {% include '_adapters-list.html' %}
+      </div>
+      <div class="theme-actions">
+        <button id="mdns-discovery-btn" class="btn btn-primary">Discover mDNS/Bonjour</button>
+        <button id="upnp-discovery-btn" class="btn btn-secondary">Discover UPnP/SSDP</button>
+        <button id="neighbor-discovery-btn" class="btn btn-outline-primary">Discover LLDP/CDP</button>
+      </div>
+    </form>
+    <div class="alert alert-secondary mt-3" role="note">
+      Service metadata discovered here is merged into the device inventory when an address is available.
+    </div>
+    <div id="service-discovery-results" class="theme-results"></div>
+  </div>
+</section>
+<script src="/static/js/service-discovery.js"></script>
+{% endblock %}

--- a/templates/wireless_network_detail.html
+++ b/templates/wireless_network_detail.html
@@ -25,7 +25,10 @@
           <label class="btn btn-outline-success mb-0" title="Continuously poll passive ARP/neighbor observations without refreshing this page. The app does not send probe packets for this mode.">
             <input class="mr-1" type="checkbox" data-passive-monitor-toggle data-interface="{{ network.interface }}"> Continuous passive capture
           </label>
-          <label class="small mb-0 text-muted">Every <input class="form-control form-control-sm d-inline-block" style="width: 4.5rem;" data-passive-monitor-interval value="10" inputmode="numeric"> sec</label>
+          <label class="small mb-0 text-muted">Every/window <input class="form-control form-control-sm d-inline-block" style="width: 4.5rem;" data-passive-monitor-interval value="10" inputmode="numeric"> sec</label>
+          <label class="small mb-0 text-muted" title="Continuously sniff packet metadata with bounded windows. Requires packet-capture permissions and stores only MAC/IP/protocol metadata, not payloads.">
+            <input class="mr-1" type="checkbox" data-passive-monitor-mode value="packet"> Live packet capture
+          </label>
           <span class="small text-muted" data-passive-monitor-status>Passive monitor is off.</span>
         {% endif %}
         <a class="btn btn-outline-secondary" href="{{ back_url }}">Back to adapter</a>

--- a/templates/wireless_network_detail.html
+++ b/templates/wireless_network_detail.html
@@ -21,6 +21,7 @@
         </div>
       </div>
       <div class="interface-actions">
+        {% if network.interface %}<a class="btn btn-primary" href="#network-device-scan">Device scan</a>{% endif %}
         <a class="btn btn-outline-secondary" href="{{ back_url }}">Back to adapter</a>
       </div>
     </section>
@@ -31,7 +32,15 @@
       </div>
     {% endif %}
 
-    <section class="interface-detail-grid network-detail-grid">
+    <ul class="nav nav-tabs mt-3 network-detail-tabs" role="tablist">
+      <li class="nav-item"><a class="nav-link active" id="network-overview-tab" data-toggle="tab" href="#network-overview-pane" role="tab" aria-controls="network-overview-pane" aria-selected="true">Overview</a></li>
+      <li class="nav-item"><a class="nav-link" id="network-devices-tab" data-toggle="tab" href="#network-devices-pane" role="tab" aria-controls="network-devices-pane" aria-selected="false">Devices <span class="badge badge-light border">{{ network.client_count }}</span></a></li>
+      <li class="nav-item"><a class="nav-link" id="network-ap-tab" data-toggle="tab" href="#network-ap-pane" role="tab" aria-controls="network-ap-pane" aria-selected="false">AP Details <span class="badge badge-light border">{{ network.access_points | length }}</span></a></li>
+    </ul>
+
+    <div class="tab-content network-detail-tab-content">
+      <section class="tab-pane fade show active" id="network-overview-pane" role="tabpanel" aria-labelledby="network-overview-tab">
+    <section class="interface-detail-grid network-detail-grid mt-3">
       <article class="card shadow-sm interface-summary-card">
         {% set gateway = network.gateway | default({}) %}
         <div class="card-body">
@@ -60,31 +69,197 @@
         </article>
       {% endif %}
 
-      <article class="card shadow-sm interface-address-card">
-        <div class="card-body">
-          <h2 class="interface-section-title">Discovered Devices</h2>
-          {% if network.clients %}
-            <div class="address-card-grid">
-              {% for client in network.clients %}
-                <section class="address-card">
-                  <div class="address-card-header"><span class="address-family">Client</span></div>
-                  <dl class="interface-definition-list compact">
-                    <div><dt>MAC</dt><dd>{{ client.mac }}</dd></div>
-                    <div><dt>Manufacturer</dt><dd>{{ client.manufacturer or 'Unknown' }}</dd></div>
-                    <div><dt>Signal</dt><dd>{{ client.signal_label }}</dd></div>
-                    <div><dt>Seen On</dt><dd>{{ client.bssid or 'Unknown AP' }}</dd></div>
-                  </dl>
-                </section>
-              {% endfor %}
-            </div>
-          {% else %}
-            <p class="text-muted mb-0">No client devices have been discovered for this SSID yet. Packet/monitor scans can populate this section when client traffic is observed.</p>
-          {% endif %}
-        </div>
-      </article>
     </section>
 
 
+      </section>
+
+      <section class="tab-pane fade" id="network-devices-pane" role="tabpanel" aria-labelledby="network-devices-tab">
+        {% if network.interface %}
+          <section id="network-device-scan" class="card shadow-sm interface-network-scan-card mt-3">
+            <div class="card-body">
+              <h2 class="interface-section-title">Network Device Scan</h2>
+              <p class="text-muted">Run device scans from this tab. Results are saved into inventory and this device list refreshes instead of rendering a separate scan result list.</p>
+              <form id="scan-form" class="theme-form interface-scan-form" data-network-device-list-scan>
+                <select id="interface-select-Scan" class="d-none" aria-hidden="true">
+                  <option value="{{ network.interface }}" selected>{{ network.interface }}</option>
+                </select>
+                <div class="theme-actions">
+                  <button id="comprehensive-scan-btn" class="btn btn-success">Comprehensive Device Scan</button>
+                  <button id="active-scan-btn" class="btn btn-primary">Active Scan</button>
+                  <button id="passive-scan-btn" class="btn btn-secondary">Passive Scan</button>
+                </div>
+                <div class="form-group mb-0">
+                  <label for="sweep-cidr">Optional ping sweep CIDR</label>
+                  <input id="sweep-cidr" class="form-control" placeholder="192.168.1.0/28 (optional, max 64 hosts)">
+                </div>
+                <label class="form-check deauth-lab-confirm"><input type="checkbox" id="include-passive" class="form-check-input" checked> <span>Include passive observations</span></label>
+                <label class="form-check deauth-lab-confirm"><input type="checkbox" id="include-services" class="form-check-input" checked> <span>Include mDNS, UPnP/SSDP, and LLDP/CDP service discovery</span></label>
+              </form>
+              <div id="scan-results" class="theme-results" data-network-device-list-status></div>
+            </div>
+          </section>
+        {% endif %}
+        <article class="card shadow-sm interface-address-card mt-3">
+          <div class="card-body">
+            <h2 class="interface-section-title">Devices Found On This Network Interface</h2>
+            <p class="text-muted">This list is persisted from wireless client observations and inventory records tied to {{ network.interface or 'this interface' }}, so devices remain visible after page reloads.</p>
+            <div class="network-scan-all-toolbar alert alert-secondary" role="region" aria-label="Continuous passive device capture">
+              <div>
+                <strong>Continuous passive capture</strong>
+                <p class="mb-0 small">Polls local ARP/neighbor observations in the background. The app does not send probe packets for this mode, but normal host traffic can still exist.</p>
+              </div>
+              <div class="theme-actions mb-0">
+                <label class="form-check form-switch mb-0">
+                  <input class="form-check-input" type="checkbox" data-passive-monitor-toggle data-interface="{{ network.interface }}">
+                  <span class="form-check-label">Keep passive capture running</span>
+                </label>
+                <label class="small mb-0">Every <input class="form-control form-control-sm d-inline-block" style="width: 5rem;" data-passive-monitor-interval value="10" inputmode="numeric"> sec</label>
+              </div>
+              <div class="network-scan-all-status small text-muted" data-passive-monitor-status>Passive monitor is off.</div>
+            </div>
+            <div class="network-scan-all-toolbar alert alert-secondary" role="region" aria-label="Port scan all network devices">
+              <div><strong>Port scan all listed IP devices</strong><p class="mb-0 small">These buttons start background scans for every IP device currently listed in this tab.</p></div>
+              <div class="theme-actions mb-0">
+                <button class="btn btn-outline-primary btn-sm" data-port-scan-all data-hosts="{{ network.clients | selectattr('ip') | map(attribute='ip') | join(',') }}" data-start="1" data-end="1024" data-label="common port scan">Scan all common ports</button>
+                <button class="btn btn-outline-danger btn-sm" data-port-scan-all data-hosts="{{ network.clients | selectattr('ip') | map(attribute='ip') | join(',') }}" data-start="1" data-end="65535" data-label="all-port scan">Scan all ports</button>
+              </div>
+              <div class="network-scan-all-status small text-muted" data-port-scan-all-status></div>
+            </div>
+            {% if network.clients %}
+              <div class="network-device-filterbar mb-3" role="region" aria-label="Network device filters">
+                <div>
+                  <strong>Sort order:</strong>
+                  <span class="text-muted small">Gateways first, then devices with saved open ports, then unknown clients.</span>
+                </div>
+                <div class="theme-actions mb-0">
+                  <button class="btn btn-outline-secondary btn-sm active" data-network-device-filter="all">All</button>
+                  <button class="btn btn-outline-secondary btn-sm" data-network-device-filter="gateway">Gateways</button>
+                  <button class="btn btn-outline-secondary btn-sm" data-network-device-filter="open-ports">Open ports</button>
+                  <button class="btn btn-outline-secondary btn-sm" data-network-device-filter="new">New</button>
+                  <button class="btn btn-outline-secondary btn-sm" data-network-device-filter="unknown">Unknown</button>
+                </div>
+                <a class="btn btn-outline-primary btn-sm" href="/wireless/network/clients.csv?interface={{ network.interface|urlencode }}&ssid={{ network.ssid|urlencode }}&bssid={{ (network.bssid or '')|urlencode }}">Export device list</a>
+              </div>
+              <div class="wireless-network-grid network-device-card-grid">
+                {% for client in network.clients %}
+                  <article class="wireless-network-card network-device-card" data-network-device-card data-host="{{ client.ip or '' }}" data-role="{{ client.network_role or '' }}" data-known-state="{{ client.network_known_state or 'Known' }}" data-has-open-ports="{{ 'true' if client.open_port_details else 'false' }}" data-unknown="{{ 'true' if not client.ip or client.manufacturer == 'Unknown' else 'false' }}">
+                    <div class="wireless-network-main">
+                      <div class="wireless-network-identity">
+                        <h3 class="wireless-network-ssid mb-1">
+                          {% if client.ip %}
+                            <a href="/clients/{{ client.ip|urlencode }}" data-network-device-title>{{ client.display_name or client.ip }}</a>
+                          {% elif client.mac %}
+                            <a href="/clients/{{ client.mac|urlencode }}" data-network-device-title>{{ client.display_name or client.mac }}</a>
+                          {% else %}
+                            <span data-network-device-title>{{ client.display_name or 'Client' }}</span>
+                          {% endif %}
+                        </h3>
+                        <p class="wireless-network-meta mb-0"><i class="fa-solid fa-network-wired"></i> {{ client.ip or 'Unknown IP' }}</p>
+                        <p class="wireless-network-meta mb-0"><i class="fa-solid fa-fingerprint"></i> {{ client.mac or 'Unknown MAC' }}</p>
+                        <p class="wireless-network-meta mb-0"><i class="fa-solid fa-industry"></i> {{ client.manufacturer or 'Unknown manufacturer' }}</p>
+                      </div>
+                      <div class="wireless-network-badges">
+                        <span class="badge {{ 'badge-success' if client.network_known_state == 'Known' else 'badge-warning' }}">{{ client.network_known_state or 'Known' }}</span>
+                        <span class="badge badge-info">{{ (client.device_role_guess or {}).role or client.network_role or 'Client' }}</span>
+                        {% if client.likely_randomized_mac %}<span class="badge badge-warning">Randomized MAC likely</span>{% endif %}
+                        <span class="badge badge-light border">{{ client.network_scope or 'Wi-Fi interface' }}</span>
+                        <span class="badge badge-primary">{{ (client.discovery_methods or client.sources or [client.source or 'wireless-observation'])|join(', ') }}</span>
+                      </div>
+                    </div>
+                    <div class="wireless-network-bottom network-device-bottom">
+                      <div>
+                        <div data-network-device-ports>
+                          {% if client.open_port_details %}
+                            <div class="network-device-open-ports">
+                            {% for port in client.open_port_details %}
+                              {% if loop.index <= 6 %}
+                                {% if port.web_url %}
+                                  <a class="badge badge-info" href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer" title="{{ port.http_title or port.http_status or port.description }}">{{ port.port }} {{ port.service }}{% if port.http_title %} · {{ port.http_title }}{% endif %}</a>
+                                {% else %}
+                                  <span class="badge badge-info">{{ port.port }} {{ port.service }}</span>
+                                {% endif %}
+                              {% endif %}
+                            {% endfor %}
+                            </div>
+                          {% else %}
+                            <p class="text-muted mb-0 small">No saved open ports yet.</p>
+                          {% endif %}
+                        </div>
+                        {% if client.client_tags %}
+                          <div class="network-device-tags mt-2" data-network-device-tags>
+                            {% for tag in client.client_tags %}<span class="badge badge-light border">{{ tag }}</span>{% endfor %}
+                          </div>
+                        {% else %}
+                          <div class="network-device-tags mt-2" data-network-device-tags></div>
+                        {% endif %}
+                        {% if client.client_notes %}<p class="text-muted small mb-0 mt-2" data-network-device-notes>{{ client.client_notes }}</p>{% else %}<p class="text-muted small mb-0 mt-2 d-none" data-network-device-notes></p>{% endif %}
+                        {% if client.observed_names %}<p class="text-muted small mb-0 mt-2">Names: {{ client.observed_names[:3] | map(attribute='name') | join(', ') }}</p>{% endif %}
+                        <p class="text-muted small mb-0 mt-2">{{ client.scan_note or client.signal_label or client.bssid or client.source or 'Persisted network client' }}</p>
+                      </div>
+                      {% if client.ip %}
+                        <div class="network-device-actions">
+                          <a class="btn btn-outline-info btn-sm" href="/clients/{{ client.ip|urlencode }}">Device profile</a>
+                          <a class="btn btn-outline-primary btn-sm" href="/port-scan?host={{ client.ip|urlencode }}">Port scan</a>
+                          <button class="btn btn-outline-secondary btn-sm" data-port-scan-quick data-host="{{ client.ip }}" data-start="1" data-end="1024" data-label="common port scan">Common ports</button>
+                          <button class="btn btn-outline-danger btn-sm" data-port-scan-quick data-host="{{ client.ip }}" data-start="1" data-end="65535" data-label="all-port scan">All ports</button>
+                          <div class="network-device-scan-status small text-muted" data-port-scan-quick-status></div>
+                          <div class="progress network-device-progress" data-port-scan-quick-progress>
+                            <div class="progress-bar" role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</div>
+                          </div>
+                          <form class="network-device-label-form" data-network-device-label-form data-interface="{{ network.interface }}" data-ssid="{{ network.ssid }}" data-bssid="{{ network.bssid or '' }}" data-identity="{{ client.mac or client.ip }}">
+                            <input class="form-control form-control-sm" name="label" placeholder="SSID label, e.g. Living room TV" value="{{ client.custom_label or '' }}">
+                            <button class="btn btn-outline-info btn-sm" type="submit">Save SSID label</button>
+                            <div class="network-device-label-status small text-muted" data-network-device-label-status></div>
+                          </form>
+                          <form class="network-device-notes-form" data-network-device-notes-form data-host="{{ client.ip }}">
+                            <input class="form-control form-control-sm" name="tags" placeholder="Tags, comma separated" value="{{ (client.client_tags or [])|join(', ') }}">
+                            <textarea class="form-control form-control-sm" name="notes" rows="2" placeholder="Device notes">{{ client.client_notes or '' }}</textarea>
+                            <button class="btn btn-outline-success btn-sm" type="submit">Save notes/tags</button>
+                            <div class="network-device-notes-status small text-muted" data-network-device-notes-status></div>
+                          </form>
+                        </div>
+                      {% else %}
+                        <span class="badge badge-secondary">No IP port scan</span>
+                      {% endif %}
+                    </div>
+                  </article>
+                {% endfor %}
+              </div>
+            {% else %}
+              <p class="text-muted mb-0">No client devices have been discovered for this SSID/interface yet. Wireless packet observations or device scans can populate this section.</p>
+            {% endif %}
+          </div>
+        </article>
+        {% if network.disappeared_clients %}
+          <article class="card shadow-sm interface-address-card mt-3">
+            <div class="card-body">
+              <h2 class="interface-section-title">Recently Disappeared Devices</h2>
+              <p class="text-muted">These clients were previously seen on this SSID/interface but were not visible in the latest network detail observation.</p>
+              <div class="wireless-network-grid network-device-card-grid">
+                {% for client in network.disappeared_clients %}
+                  <article class="wireless-network-card network-device-card network-device-card-disappeared">
+                    <div class="wireless-network-main">
+                      <div>
+                        <h3 class="wireless-network-ssid mb-1">{{ client.display_name or client.ip or client.mac }}</h3>
+                        <p class="wireless-network-meta mb-0"><i class="fa-solid fa-network-wired"></i> {{ client.ip or 'Unknown IP' }}</p>
+                        <p class="wireless-network-meta mb-0"><i class="fa-solid fa-fingerprint"></i> {{ client.mac or 'Unknown MAC' }}</p>
+                      </div>
+                      <div class="wireless-network-badges">
+                        <span class="badge badge-secondary">Recently disappeared</span>
+                        <span class="badge badge-light border">{{ client.network_known_state or 'Known' }}</span>
+                      </div>
+                    </div>
+                    <p class="text-muted small mb-0">Last seen on this network: {{ client.network_last_seen or 'unknown' }}</p>
+                  </article>
+                {% endfor %}
+              </div>
+            </div>
+          </article>
+        {% endif %}
+      </section>
+
+      <section class="tab-pane fade" id="network-ap-pane" role="tabpanel" aria-labelledby="network-ap-tab">
     <section class="card shadow-sm interface-extra-card mt-3">
       <div class="card-body">
         <h2 class="interface-section-title">AP Identity Hints</h2>
@@ -159,7 +334,13 @@
         {% endif %}
       </div>
     </section>
+      </section>
+    </div>
   </main>
+
+  {% if network.interface %}
+    <script src="/static/js/network_scan.js"></script>
+  {% endif %}
 
   {% include '_footer.html' %}
 </body>

--- a/templates/wireless_network_detail.html
+++ b/templates/wireless_network_detail.html
@@ -40,7 +40,7 @@
 
     <ul class="nav nav-tabs mt-3 network-detail-tabs" role="tablist">
       <li class="nav-item"><a class="nav-link active" id="network-overview-tab" data-toggle="tab" href="#network-overview-pane" role="tab" aria-controls="network-overview-pane" aria-selected="true">Overview</a></li>
-      <li class="nav-item"><a class="nav-link" id="network-devices-tab" data-toggle="tab" href="#network-devices-pane" role="tab" aria-controls="network-devices-pane" aria-selected="false">Devices <span class="badge badge-light border">{{ network.client_count }}</span></a></li>
+      <li class="nav-item"><a class="nav-link" id="network-devices-tab" data-toggle="tab" href="#network-devices-pane" role="tab" aria-controls="network-devices-pane" aria-selected="false">Devices <span class="badge badge-light border" data-network-device-count>{{ network.client_count }}</span></a></li>
       <li class="nav-item"><a class="nav-link" id="network-ap-tab" data-toggle="tab" href="#network-ap-pane" role="tab" aria-controls="network-ap-pane" aria-selected="false">AP Details <span class="badge badge-light border">{{ network.access_points | length }}</span></a></li>
     </ul>
 

--- a/templates/wireless_network_detail.html
+++ b/templates/wireless_network_detail.html
@@ -118,6 +118,17 @@
               </div>
               <div class="network-scan-all-status small text-muted" data-port-scan-all-status></div>
             </div>
+            <div class="passive-analytics-panel alert alert-dark" role="region" aria-label="Passive observation analytics" data-passive-analytics-panel data-interface="{{ network.interface }}">
+              <div class="d-flex justify-content-between align-items-start flex-wrap">
+                <div>
+                  <strong>Passive-only analytics</strong>
+                  <p class="mb-0 small">Tracks observed/quiet device churn from passive scans and continuous passive capture without sending probe packets.</p>
+                </div>
+                <button type="button" class="btn btn-outline-info btn-sm" data-passive-analytics-refresh>Refresh analytics</button>
+              </div>
+              <div class="small mt-2" data-passive-analytics-summary>Passive analytics will appear after a passive scan or continuous capture sample.</div>
+              <div class="theme-grid mt-2" data-passive-analytics-devices></div>
+            </div>
             {% if network.clients %}
               <div class="network-device-filterbar mb-3" role="region" aria-label="Network device filters">
                 <div>

--- a/templates/wireless_network_detail.html
+++ b/templates/wireless_network_detail.html
@@ -21,7 +21,13 @@
         </div>
       </div>
       <div class="interface-actions">
-        {% if network.interface %}<a class="btn btn-primary" href="#network-device-scan">Device scan</a>{% endif %}
+        {% if network.interface %}
+          <label class="btn btn-outline-success mb-0" title="Continuously poll passive ARP/neighbor observations without refreshing this page. The app does not send probe packets for this mode.">
+            <input class="mr-1" type="checkbox" data-passive-monitor-toggle data-interface="{{ network.interface }}"> Continuous passive capture
+          </label>
+          <label class="small mb-0 text-muted">Every <input class="form-control form-control-sm d-inline-block" style="width: 4.5rem;" data-passive-monitor-interval value="10" inputmode="numeric"> sec</label>
+          <span class="small text-muted" data-passive-monitor-status>Passive monitor is off.</span>
+        {% endif %}
         <a class="btn btn-outline-secondary" href="{{ back_url }}">Back to adapter</a>
       </div>
     </section>
@@ -80,7 +86,7 @@
             <div class="card-body">
               <h2 class="interface-section-title">Network Device Scan</h2>
               <p class="text-muted">Run device scans from this tab. Results are saved into inventory and this device list refreshes instead of rendering a separate scan result list.</p>
-              <form id="scan-form" class="theme-form interface-scan-form" data-network-device-list-scan>
+              <form id="scan-form" class="theme-form interface-scan-form" data-network-device-list-scan data-interface="{{ network.interface }}" data-ssid="{{ network.ssid }}" data-bssid="{{ network.bssid or '' }}">
                 <select id="interface-select-Scan" class="d-none" aria-hidden="true">
                   <option value="{{ network.interface }}" selected>{{ network.interface }}</option>
                 </select>
@@ -104,20 +110,6 @@
           <div class="card-body">
             <h2 class="interface-section-title">Devices Found On This Network Interface</h2>
             <p class="text-muted">This list is persisted from wireless client observations and inventory records tied to {{ network.interface or 'this interface' }}, so devices remain visible after page reloads.</p>
-            <div class="network-scan-all-toolbar alert alert-secondary" role="region" aria-label="Continuous passive device capture">
-              <div>
-                <strong>Continuous passive capture</strong>
-                <p class="mb-0 small">Polls local ARP/neighbor observations in the background. The app does not send probe packets for this mode, but normal host traffic can still exist.</p>
-              </div>
-              <div class="theme-actions mb-0">
-                <label class="form-check form-switch mb-0">
-                  <input class="form-check-input" type="checkbox" data-passive-monitor-toggle data-interface="{{ network.interface }}">
-                  <span class="form-check-label">Keep passive capture running</span>
-                </label>
-                <label class="small mb-0">Every <input class="form-control form-control-sm d-inline-block" style="width: 5rem;" data-passive-monitor-interval value="10" inputmode="numeric"> sec</label>
-              </div>
-              <div class="network-scan-all-status small text-muted" data-passive-monitor-status>Passive monitor is off.</div>
-            </div>
             <div class="network-scan-all-toolbar alert alert-secondary" role="region" aria-label="Port scan all network devices">
               <div><strong>Port scan all listed IP devices</strong><p class="mb-0 small">These buttons start background scans for every IP device currently listed in this tab.</p></div>
               <div class="theme-actions mb-0">
@@ -141,7 +133,7 @@
                 </div>
                 <a class="btn btn-outline-primary btn-sm" href="/wireless/network/clients.csv?interface={{ network.interface|urlencode }}&ssid={{ network.ssid|urlencode }}&bssid={{ (network.bssid or '')|urlencode }}">Export device list</a>
               </div>
-              <div class="wireless-network-grid network-device-card-grid">
+              <div class="wireless-network-grid network-device-card-grid" data-network-device-list>
                 {% for client in network.clients %}
                   <article class="wireless-network-card network-device-card" data-network-device-card data-host="{{ client.ip or '' }}" data-role="{{ client.network_role or '' }}" data-known-state="{{ client.network_known_state or 'Known' }}" data-has-open-ports="{{ 'true' if client.open_port_details else 'false' }}" data-unknown="{{ 'true' if not client.ip or client.manufacturer == 'Unknown' else 'false' }}">
                     <div class="wireless-network-main">
@@ -227,7 +219,8 @@
                 {% endfor %}
               </div>
             {% else %}
-              <p class="text-muted mb-0">No client devices have been discovered for this SSID/interface yet. Wireless packet observations or device scans can populate this section.</p>
+              <div class="wireless-network-grid network-device-card-grid" data-network-device-list></div>
+              <p class="text-muted mb-0" data-network-device-empty>No client devices have been discovered for this SSID/interface yet. Wireless packet observations or device scans can populate this section.</p>
             {% endif %}
           </div>
         </article>

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2161,6 +2161,40 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertNotIn(b'192.168.77.20', response.data)
         self.assertNotIn(b'8c:49:62:bd:7d:37', response.data)
 
+    @patch('scripts.wifi.utils.get_network_detail')
+    @patch('app.passive_scan')
+    def test_passive_scan_scopes_found_devices_to_selected_network(self, passive_scan, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        passive_scan.return_value = [{'ip': '192.168.88.44', 'mac': '8c:49:62:bd:7d:37'}]
+        get_detail.return_value = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'access_points': [],
+            'clients': [],
+            'interface': 'wlan0',
+        }
+
+        response = self.client.post('/passive-scan', data={
+            'selectedInterface': 'wlan0',
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(any(client.get('ip') == '192.168.88.44' for client in response.get_json()['network_clients']))
+
+        response = self.client.get('/wireless/network/clients.json?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(any(client.get('ip') == '192.168.88.44' for client in response.get_json()['clients']))
+
+    def test_network_scan_buttons_show_busy_spinner_and_disable_reclicks(self):
+        js = open('static/js/network_scan.js').read()
+
+        self.assertIn('setScanControlsBusy(button, true', js)
+        self.assertIn('spinner-border spinner-border-sm', js)
+        self.assertIn('setScanControlsBusy(button, false)', js)
+
     def test_wireless_network_cards_link_to_device_scan_panel(self):
         js = open('static/js/wireless-adapters.js').read()
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2000,6 +2000,7 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'Export device list', response.data)
         self.assertIn(b'data-network-device-label-form', response.data)
         self.assertIn(b'data-port-scan-quick-progress', response.data)
+        self.assertIn(b'data-network-device-count', response.data)
         self.assertIn(b'Scan all common ports', response.data)
         self.assertIn(b'data-hosts="192.168.50.22"', response.data)
 
@@ -2194,6 +2195,7 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn('setScanControlsBusy(button, true', js)
         self.assertIn('spinner-border spinner-border-sm', js)
         self.assertIn('setScanControlsBusy(button, false)', js)
+        self.assertIn('updateNetworkDeviceTabCount(items || [])', js)
 
     def test_wireless_network_cards_link_to_device_scan_panel(self):
         js = open('static/js/wireless-adapters.js').read()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1222,6 +1222,37 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'Watched', response.data)
         self.assertIn(b'router', response.data)
 
+    @patch('app.scan_common_client_ports')
+    @patch('app.run_ping_check')
+    def test_scheduled_check_can_run_saved_plan_on_demand_and_due(self, ping_check, common_ports):
+        app_module.device_inventory.clear()
+        app_module.scheduled_client_checks.clear()
+        app_module.client_timelines.clear()
+        ping_check.return_value = {'host': '192.168.20.10', 'reachable': True, 'packet_loss_percent': 0}
+        common_ports.return_value = [{'port': 80, 'service': 'HTTP', 'description': 'Web service'}]
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.10', 'mac': '48:b0:2d:ef:ec:f2', 'interfaces': ['eth0']}
+        ], 'active-scan', 'eth0')
+
+        response = self.client.post('/clients/192.168.20.10/scheduled-check', data={
+            'intervalMinutes': '30',
+            'checks': 'ping,common-ports,baseline-drift',
+        })
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.post('/clients/192.168.20.10/scheduled-check/run')
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIn('ping', payload['plan']['last_result'])
+        self.assertIn('common_ports', payload['plan']['last_result'])
+        self.assertIsNotNone(payload['plan']['last_run'])
+        self.assertIn('192.168.20.10', app_module.client_timelines)
+
+        app_module.scheduled_client_checks['192.168.20.10']['last_run'] = 0
+        response = self.client.post('/scheduled-checks/run-due')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['count'], 1)
+
     def test_client_watch_alerts_on_new_open_ports(self):
         app_module.device_inventory.clear()
         app_module.new_device_alerts.clear()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,9 +1,11 @@
+import time
 import unittest
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import app as app_module
 from app import app
+from scripts.interfaceTools import lookup_manufacturer, oui_database_status
 
 
 class RouteSmokeTest(unittest.TestCase):
@@ -18,10 +20,14 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'id="theme-toggle"', response.data)
         self.assertIn(b'id="adapter-auto-update-status"', response.data)
         self.assertIn(b'Tools', response.data)
+        self.assertNotIn(b'href="/network-scan"', response.data)
         self.assertNotIn(b'href="/bluetooth-phone"', response.data)
         self.assertIn(b'Records', response.data)
         self.assertIn(b'System', response.data)
         self.assertNotIn(b'id="listAdapters', response.data)
+        self.assertIn(b'Browser screenshot tooling', response.data)
+        self.assertIn(b'Install for me', response.data)
+        self.assertIn(b'install-host-dependency', response.data)
 
     def test_roadmap_page_renders_project_ideas(self):
         response = self.client.get('/roadmap')
@@ -54,9 +60,16 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'Reporting and evidence trophies', response.data)
         self.assertIn(b'Training completion trophies', response.data)
         self.assertIn(b'Grouped discovery notifications', response.data)
+        self.assertIn(b'Comprehensive network device scan', response.data)
+        self.assertIn(b'IP client profiles and watchlists', response.data)
+        self.assertIn(b'Client relationship map', response.data)
+        self.assertIn(b'Scheduled client checks', response.data)
+        self.assertIn(b'Client remediation checklist', response.data)
+        self.assertIn(b'Client change approval log', response.data)
         self.assertIn(b'Core network tools', response.data)
         self.assertIn(b'Ping and reachability testing', response.data)
         self.assertIn(b'ARP and neighbor discovery viewer', response.data)
+        self.assertIn(b'Comprehensive network scans now include local ARP cache', response.data)
         self.assertIn(b'DNS lookup and diagnostics toolkit', response.data)
         self.assertIn(b'Route table and gateway diagnostics', response.data)
         self.assertIn(b'Packet capture and protocol summary', response.data)
@@ -141,6 +154,10 @@ class RouteSmokeTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Scan for Networks', response.data)
+        self.assertIn(b'Network Device Scan', response.data)
+        self.assertIn(b'id="comprehensive-scan-btn"', response.data)
+        self.assertIn(b'<option value="WiFi" selected>', response.data)
+        self.assertIn(b'network_scan.js', response.data)
         self.assertIn(b'Action Readiness', response.data)
         self.assertIn(b'id="wlans-WiFi"', response.data)
         self.assertIn(b'data-interface="WiFi"', response.data)
@@ -173,6 +190,32 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'bluetooth-phone-autosave.js', response.data)
         self.assertNotIn(b'Save and apply', response.data)
         self.assertIn(b'Pair phones and request authorised contacts', response.data)
+        self.assertNotIn(b'Network Device Scan', response.data)
+        self.assertNotIn(b'network_scan.js', response.data)
+
+    def test_network_scan_controls_render_on_interface_detail(self):
+        ethernet_interface = SimpleNamespace(
+            name='eth0',
+            interface_type='Ethernet',
+            addresses=[],
+            manufacturer='Unknown',
+            state='UP',
+            extra_info={},
+            get_mac_address=lambda: '00:11:22:33:44:55',
+        )
+        with (
+            patch.object(app_module, 'network_interfaces', [ethernet_interface]),
+            patch.object(app_module, 'networkTechnologies', {'Ethernet'}),
+        ):
+            response = self.client.get('/ethernet/eth0')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Network Device Scan', response.data)
+        self.assertIn(b'id="active-scan-btn"', response.data)
+        self.assertIn(b'id="passive-scan-btn"', response.data)
+        self.assertIn(b'id="comprehensive-scan-btn"', response.data)
+        self.assertIn(b'<option value="eth0" selected>', response.data)
+        self.assertIn(b'network_scan.js', response.data)
 
     def test_red_team_card_forms_are_constrained_to_card_width(self):
         css = open('static/css/red-team.css').read()
@@ -226,6 +269,148 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn('authorized lab deauth frames', response.get_json()['message'])
         deauth.assert_called_once_with('aa:bb:cc:dd:ee:ff', '11:22:33:44:55:66', 'wlan0mon', 2)
 
+    def test_evil_twin_lab_card_requires_explicit_targeting_and_consent(self):
+        response = self.client.get('/red-team')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Evil Twin &amp; Captive Portal Lab', response.data)
+        self.assertIn(b'id="EvilTwin-SSID"', response.data)
+        self.assertIn(b'id="EvilTwin-BSSID"', response.data)
+        self.assertIn(b'no credentials will be collected', response.data)
+        self.assertIn(b'Detection guidance', response.data)
+
+    def test_evil_twin_lab_route_requires_authorization_and_bounds(self):
+        response = self.client.post('/evil-twin-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'ssid': 'ClassLab',
+            'bssid': 'AA:BB:CC:DD:EE:FF',
+            'channel': '6',
+            'durationMinutes': '45',
+            'action': 'start',
+            'authorized': 'on',
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('between 1 and 30', response.get_json()['message'])
+
+        response = self.client.post('/evil-twin-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'ssid': 'ClassLab',
+            'bssid': 'AA:BB:CC:DD:EE:FF',
+            'channel': '6',
+            'durationMinutes': '10',
+            'action': 'plan',
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('authorized isolated lab', response.get_json()['message'])
+
+    def test_evil_twin_lab_route_records_safe_guidance(self):
+        response = self.client.post('/evil-twin-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'ssid': 'ClassLab',
+            'bssid': 'AA-BB-CC-DD-EE-FF',
+            'channel': '6',
+            'durationMinutes': '10',
+            'portalMessage': 'Training portal only.',
+            'action': 'cleanup',
+            'authorized': 'on',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIn('cleanup checklist', payload['message'])
+        self.assertEqual(payload['run']['bssid'], 'aa:bb:cc:dd:ee:ff')
+        self.assertIn('do not request, collect, or store credentials', ' '.join(payload['run']['operator_steps']))
+        self.assertIn('duplicate SSIDs', payload['run']['detection_guidance'][0])
+
+    def test_pineap_and_handshake_cards_are_available(self):
+        response = self.client.get('/red-team')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'PineAP-Style Lab Console', response.data)
+        self.assertIn(b'id="Pineap-Modules"', response.data)
+        self.assertIn(b'WPA Handshake Capture Lab', response.data)
+        self.assertIn(b'Export handshake catalog JSON', response.data)
+
+    def test_pineap_lab_recon_runs_scoped_scan_and_modules(self):
+        with (
+            patch('scripts.wifi.utils.scan_networks') as scan_networks,
+            patch('scripts.wifi.utils.get_networks_summary', return_value=[{'ssid': 'ClassLab', 'bssid': 'aa:bb:cc:dd:ee:ff'}]),
+        ):
+            response = self.client.post('/pineap-lab', data={
+                'selectedInterface': 'wlan0mon',
+                'action': 'recon',
+                'modules': 'recon,detection-report',
+                'authorized': 'on',
+            })
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertIn('Recorded recon workflow', payload['message'])
+        self.assertEqual(payload['run']['recon'][0]['ssid'], 'ClassLab')
+        self.assertIn('does not collect credentials', payload['run']['safety'])
+        scan_networks.assert_called_once_with('wlan0mon')
+
+    def test_pineap_lab_requires_authorization_and_known_modules(self):
+        response = self.client.post('/pineap-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'action': 'campaign',
+            'ssid': 'ClassLab',
+            'modules': 'recon,unknown',
+            'authorized': 'on',
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Unknown lab module', response.get_json()['message'])
+
+        response = self.client.post('/pineap-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'action': 'campaign',
+            'ssid': 'ClassLab',
+            'modules': 'recon',
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('authorized isolated lab', response.get_json()['message'])
+
+    def test_handshake_lab_catalogs_evidence_and_exports(self):
+        response = self.client.post('/handshake-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'ssid': 'ClassLab',
+            'bssid': 'AA-BB-CC-DD-EE-FF',
+            'channel': '6',
+            'captureType': 'pmkid',
+            'validationNotes': 'PMKID observed in authorized lab capture.',
+            'authorized': 'on',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['record']['bssid'], 'aa:bb:cc:dd:ee:ff')
+        self.assertEqual(payload['record']['validation_status'], 'cataloged')
+        self.assertIn('password cracking is out of scope', ' '.join(payload['record']['validation_checks']))
+
+        export = self.client.get('/handshake-lab.json')
+        self.assertEqual(export.status_code, 200)
+        self.assertTrue(any(item['ssid'] == 'ClassLab' for item in export.get_json()['handshakes']))
+
+        csv_export = self.client.get('/handshake-lab.csv')
+        self.assertEqual(csv_export.status_code, 200)
+        self.assertIn(b'ClassLab', csv_export.data)
+
+    def test_handshake_lab_requires_authorized_lab_scope(self):
+        response = self.client.post('/handshake-lab', data={
+            'selectedInterface': 'wlan0mon',
+            'ssid': 'ClassLab',
+            'bssid': 'AA:BB:CC:DD:EE:FF',
+            'channel': '6',
+            'captureType': 'wpa-handshake',
+        })
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('authorized isolated lab', response.get_json()['message'])
+
     @patch('app.threading.Thread')
     def test_scan_job_routes_start_and_report_status(self, thread_cls):
         thread_cls.return_value.start.return_value = None
@@ -266,6 +451,24 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertTrue(any(item['id'] == 'wifi-network-scan' for item in registry))
         self.assertTrue(any(item['id'] == 'reports' for item in registry))
 
+    @patch('routes.capabilities.install_host_dependency')
+    def test_capabilities_can_install_browser_screenshot_dependency(self, install_dependency):
+        install_dependency.return_value = {'dependency': 'browser-screenshot', 'installed': True, 'message': 'Browser screenshot tooling installed.'}
+
+        response = self.client.post('/capabilities/install-host-dependency', data={'dependency': 'browser-screenshot', 'confirm': 'install'})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['status'], 'success')
+        self.assertTrue(payload['installed'])
+        install_dependency.assert_called_once_with('browser-screenshot')
+
+    def test_capabilities_host_dependency_install_requires_confirmation(self):
+        response = self.client.post('/capabilities/install-host-dependency', data={'dependency': 'browser-screenshot'})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Confirm host package installation', response.get_json()['message'])
+
     def test_adapter_updates_returns_partial_fragments_when_changed(self):
         response = self.client.post('/adapters/updates', json={'snapshot': 'stale', 'title': 'Home'})
 
@@ -286,6 +489,309 @@ class RouteSmokeTest(unittest.TestCase):
         response = self.client.get('/export/capabilities.json')
         self.assertEqual(response.status_code, 200)
         self.assertIn('capabilities', response.get_json())
+
+    def test_diagnostics_page_and_nav_render(self):
+        response = self.client.get('/diagnostics')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Ping &amp; Route Diagnostics', response.data)
+        self.assertIn(b'id="ping-host"', response.data)
+        self.assertIn(b'id="route-diagnostics-btn"', response.data)
+
+    def test_network_scan_page_includes_comprehensive_device_scan(self):
+        response = self.client.get('/network-scan')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Comprehensive Device Scan', response.data)
+        self.assertIn(b'id="sweep-cidr"', response.data)
+        self.assertIn(b'Include mDNS, UPnP/SSDP, and LLDP/CDP', response.data)
+        self.assertIn(b'interface.css', response.data)
+
+    def test_network_scan_results_render_device_cards_and_scan_all_actions(self):
+        with open('static/js/network_scan.js') as handle:
+            js = handle.read()
+
+        self.assertIn('network-device-card', js)
+        self.assertIn('Scan all common ports', js)
+        self.assertIn('Scan all ports', js)
+        self.assertIn('data-port-scan-all', js)
+        self.assertIn('Device profile', js)
+        self.assertIn('Port scan', js)
+
+    @patch('app.discover_lldp_neighbors')
+    @patch('app.discover_upnp_devices')
+    @patch('app.discover_mdns_services')
+    @patch('app._run_text_command')
+    @patch('app.passive_scan')
+    @patch('app.active_scan')
+    def test_comprehensive_scan_combines_methods_and_inventory(self, active, passive, run_command, mdns, upnp, lldp):
+        app_module.device_inventory.clear()
+        app_module.new_device_alerts.clear()
+        active.return_value = [{'ip': '192.168.1.10', 'mac': 'AA:BB:CC:DD:EE:10'}]
+        passive.return_value = [{'ip': '192.168.1.11', 'mac': 'AA:BB:CC:DD:EE:11'}]
+        run_command.side_effect = [
+            {'output': '192.168.1.12 dev eth0 lladdr aa:bb:cc:dd:ee:12 REACHABLE'},
+            {'output': '? (192.168.1.13) at aa:bb:cc:dd:ee:13 [ether] on eth0'},
+        ]
+        mdns.return_value = {'services': [{'ip': '192.168.1.14', 'hostname': 'printer.local', 'name': 'Printer', 'role': 'Printer'}]}
+        upnp.return_value = {'devices': [{'ip': '192.168.1.1', 'friendly_name': 'Gateway', 'manufacturer': 'Training', 'role': 'Gateway/router'}]}
+        lldp.return_value = {'neighbors': [{'management_address': '192.168.1.2', 'name': 'Switch', 'role': 'Switch/router neighbor'}]}
+
+        response = self.client.post('/comprehensive-scan', data={'selectedInterface': 'eth0', 'includePassive': 'on', 'includeServices': 'on'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertEqual(result['summary']['total_devices'], 7)
+        self.assertIn('active-arp', result['methods'])
+        self.assertIn('mdns', result['methods'])
+        self.assertTrue(any('neighbor-table' in item['discovery_methods'] for item in result['devices']))
+        self.assertIsNotNone(app_module.find_inventory_device('192.168.1.14'))
+        self.assertEqual(app_module.alert_records()[0]['alert_type'], 'grouped-discovery')
+
+    @patch('app.discover_lldp_neighbors')
+    @patch('app.discover_upnp_devices')
+    @patch('app.discover_mdns_services')
+    @patch('app._run_text_command')
+    @patch('app.run_ping_sweep')
+    @patch('app.passive_scan')
+    @patch('app.active_scan')
+    def test_comprehensive_scan_can_skip_passive_and_add_ping_sweep(self, active, passive, ping_sweep, run_command, mdns, upnp, lldp):
+        app_module.device_inventory.clear()
+        active.return_value = []
+        run_command.side_effect = [{'output': ''}, {'output': ''}]
+        mdns.return_value = {'services': []}
+        upnp.return_value = {'devices': []}
+        lldp.return_value = {'neighbors': []}
+        ping_sweep.return_value = {'results': [{'host': '192.168.1.20', 'reachable': True}]}
+
+        response = self.client.post('/comprehensive-scan', data={'selectedInterface': 'eth0', 'includePassive': '', 'includeServices': 'on', 'sweepCidr': '192.168.1.0/30'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertIn('ping-sweep', result['methods'])
+        self.assertFalse(passive.called)
+        self.assertEqual(result['devices'][0]['ip'], '192.168.1.20')
+
+    def test_service_discovery_page_renders_protocol_controls(self):
+        response = self.client.get('/service-discovery')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Service Discovery', response.data)
+        self.assertIn(b'id="mdns-discovery-btn"', response.data)
+        self.assertIn(b'id="upnp-discovery-btn"', response.data)
+        self.assertIn(b'id="neighbor-discovery-btn"', response.data)
+
+    def test_advanced_diagnostics_page_renders_toolkit_controls(self):
+        response = self.client.get('/advanced-diagnostics')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Advanced Diagnostics', response.data)
+        self.assertIn(b'id="vlan-discovery-btn"', response.data)
+        self.assertIn(b'id="egress-diagnostics-btn"', response.data)
+        self.assertIn(b'id="iperf-client-btn"', response.data)
+        self.assertIn(b'id="snmp-discovery-btn"', response.data)
+        self.assertIn(b'id="ipv6-assessment-btn"', response.data)
+
+    @patch('app._run_text_command')
+    @patch('app.shutil.which', return_value='/usr/bin/avahi-browse')
+    def test_mdns_discovery_parses_services_and_updates_inventory(self, which, run_command):
+        app_module.device_inventory.clear()
+        run_command.return_value = {
+            'returncode': 0,
+            'output': '=;eth0;IPv4;Office Printer;_ipp._tcp;local;printer.local;192.168.1.40;631;txtvers=1;note=Lab',
+        }
+
+        response = self.client.post('/mdns-discovery', data={'selectedInterface': 'eth0'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertEqual(result['services'][0]['hostname'], 'printer.local')
+        self.assertEqual(result['services'][0]['role'], 'Printer')
+        inventory = app_module.find_inventory_device('192.168.1.40')
+        self.assertEqual(inventory['service_metadata']['service_type'], '_ipp._tcp')
+
+    @patch('app.discover_upnp_devices')
+    def test_upnp_discovery_route_returns_devices(self, discover):
+        discover.return_value = {
+            'available': True,
+            'message': 'Discovered 1 UPnP/SSDP device(s).',
+            'devices': [{
+                'friendly_name': 'Lab Gateway',
+                'ip': '192.168.1.1',
+                'manufacturer': 'Training Vendor',
+                'model': 'Router 1',
+                'service_type': 'urn:schemas-upnp-org:device:InternetGatewayDevice:1',
+                'control_url': 'http://192.168.1.1/rootDesc.xml',
+            }],
+        }
+
+        response = self.client.post('/upnp-discovery', data={'timeout': '1'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['result']['devices'][0]['friendly_name'], 'Lab Gateway')
+        discover.assert_called_once_with(timeout=1)
+
+    @patch('app._run_text_command')
+    @patch('app.shutil.which', return_value='/usr/sbin/lldpctl')
+    def test_lldp_neighbor_discovery_parses_ports_vlans_and_management(self, which, run_command):
+        app_module.device_inventory.clear()
+        run_command.return_value = {
+            'returncode': 0,
+            'output': '\n'.join([
+                'lldp.eth0.chassis.name="Lab-Switch"',
+                'lldp.eth0.port.ifname="Gi1/0/1"',
+                'lldp.eth0.mgmt-ip="192.168.1.2"',
+                'lldp.eth0.vlan.1.vid="20"',
+            ]),
+        }
+
+        response = self.client.post('/neighbor-discovery', data={'selectedInterface': 'eth0'})
+
+        self.assertEqual(response.status_code, 200)
+        neighbor = response.get_json()['result']['neighbors'][0]
+        self.assertEqual(neighbor['name'], 'Lab-Switch')
+        self.assertEqual(neighbor['port_id'], 'Gi1/0/1')
+        self.assertEqual(neighbor['vlans'], ['20'])
+        inventory = app_module.find_inventory_device('192.168.1.2')
+        self.assertEqual(inventory['device_type'], 'Switch/router neighbor')
+
+    @patch('app._run_text_command')
+    def test_vlan_discovery_tracks_interfaces_and_notes(self, run_command):
+        app_module.vlan_segmentation_notes.clear()
+        run_command.return_value = {
+            'returncode': 0,
+            'output': '5: eth0.20@eth0: <BROADCAST> mtu 1500\n    vlan protocol 802.1Q id 20 <REORDER_HDR>',
+        }
+
+        response = self.client.post('/vlan-discovery', data={'ssid': 'CorpWiFi', 'vlanId': '20', 'notes': 'Guest blocked from admin VLAN'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertEqual(result['vlans'][0]['interface'], 'eth0.20')
+        self.assertEqual(result['created_note']['ssid'], 'CorpWiFi')
+        self.assertIn('inter-VLAN firewall rules', result['created_note']['validation_context'])
+
+    @patch('app.build_route_diagnostics', return_value={'vpn_hints': [{'interface': 'tun0'}]})
+    @patch('app._run_text_command')
+    def test_egress_diagnostics_reports_nat_dns_ipv6_and_proxy(self, run_command, route_diag):
+        run_command.side_effect = [
+            {'output': 'default via fe80::1 dev eth0'},
+            {'output': 'default via 192.168.1.1 dev eth0'},
+        ]
+        with (
+            patch('urllib.request.urlopen') as urlopen,
+            patch('builtins.open', unittest.mock.mock_open(read_data='nameserver 9.9.9.9\n')),
+            patch.dict('os.environ', {'HTTPS_PROXY': 'http://proxy.local:8080'}, clear=False),
+        ):
+            urlopen.return_value.__enter__.return_value.read.return_value = b'203.0.113.5'
+            response = self.client.post('/egress-diagnostics', data={'selectedInterface': 'eth0'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertEqual(result['public_ip'], '203.0.113.5')
+        self.assertEqual(result['dns_resolvers'], ['9.9.9.9'])
+        self.assertEqual(result['vpn_hints'][0]['interface'], 'tun0')
+        self.assertIn('HTTPS_PROXY', result['proxy_hints'])
+
+    @patch('app.subprocess.run')
+    @patch('app.shutil.which', return_value='/usr/bin/iperf3')
+    def test_iperf3_client_runs_bounded_json_test(self, which, run):
+        run.return_value = SimpleNamespace(returncode=0, stdout='{"end":{"sum_received":{"bits_per_second":1000}}}', stderr='')
+
+        response = self.client.post('/iperf3-test', data={'mode': 'client', 'host': '192.168.1.10', 'port': '5201', 'seconds': '3'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertEqual(result['summary']['bits_per_second'], 1000)
+        self.assertIn('-t', result['command'])
+
+    @patch('app.subprocess.run')
+    @patch('app.shutil.which', return_value='/usr/bin/snmpwalk')
+    def test_snmp_discovery_requires_authorization_and_records_inventory(self, which, run):
+        app_module.device_inventory.clear()
+        response = self.client.post('/snmp-discovery', data={'host': '192.168.1.2', 'community': 'public'})
+        self.assertEqual(response.status_code, 400)
+
+        run.return_value = SimpleNamespace(returncode=0, stdout='Lab Switch\nInterface 1\n', stderr='')
+        response = self.client.post('/snmp-discovery', data={'host': '192.168.1.2', 'community': 'public', 'authorized': 'on'})
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['result']['values'][0], 'Lab Switch')
+        inventory = app_module.find_inventory_device('192.168.1.2')
+        self.assertEqual(inventory['device_type'], 'SNMP device')
+
+    @patch('app.shutil.which', return_value='/usr/bin/traceroute')
+    @patch('app.socket.create_connection')
+    @patch('app.socket.getaddrinfo', return_value=[(None, None, None, None, ('2001:db8::10', 0, 0, 0))])
+    @patch('app._run_text_command')
+    def test_ipv6_assessment_reports_ping_dns_neighbors_and_ports(self, run_command, getaddrinfo, create_connection, which):
+        run_command.side_effect = [
+            {'output': '3 packets transmitted, 3 received'},
+            {'output': 'traceroute to 2001:db8::10'},
+            {'output': 'fe80::1 dev eth0 lladdr 00:11:22:33:44:55 router'},
+            {'output': 'default via fe80::1 dev eth0'},
+        ]
+        create_connection.return_value.__enter__.return_value = None
+
+        response = self.client.post('/ipv6-assessment', data={'host': '2001:db8::10', 'ports': '443'})
+
+        self.assertEqual(response.status_code, 200)
+        result = response.get_json()['result']
+        self.assertEqual(result['dns_aaaa'], ['2001:db8::10'])
+        self.assertIn('fe80::1', result['neighbors'])
+        self.assertEqual(result['ports'][0]['status'], 'open')
+
+    @patch('app.subprocess.run')
+    def test_ping_route_reports_loss_latency_and_history(self, run):
+        run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout='4 packets transmitted, 4 received, 0% packet loss\nrtt min/avg/max/mdev = 1.1/2.2/3.3/0.1 ms',
+            stderr='',
+        )
+        app_module.ping_history.clear()
+
+        response = self.client.post('/ping', data={'host': '192.0.2.10', 'count': '4', 'timeout': '1'})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['result']['packet_loss_percent'], 0.0)
+        self.assertEqual(payload['result']['latency']['avg_ms'], 2.2)
+        self.assertTrue(payload['history'])
+
+    @patch('app.run_ping_check')
+    def test_ping_sweep_limits_and_summarizes_hosts(self, ping_check):
+        ping_check.side_effect = lambda host, count=1, timeout=1: {
+            'host': host,
+            'reachable': host.endswith('.1'),
+            'packet_loss_percent': 0.0 if host.endswith('.1') else 100.0,
+            'latency': {},
+            'checked_at': 1,
+        }
+
+        response = self.client.post('/ping-sweep', data={'cidr': '192.168.1.0/30'})
+
+        self.assertEqual(response.status_code, 200)
+        sweep = response.get_json()['sweep']
+        self.assertEqual(sweep['total_hosts'], 2)
+        self.assertEqual(sweep['reachable_hosts'], 1)
+
+    @patch('app.subprocess.run')
+    def test_route_diagnostics_reports_gateways_vpn_and_scan_path(self, run):
+        def fake_run(command, **kwargs):
+            if command == ['ip', '-4', 'route', 'show']:
+                return SimpleNamespace(returncode=0, stdout='default via 192.168.1.1 dev eth0 proto dhcp metric 100\n10.8.0.0/24 dev tun0 proto kernel metric 50', stderr='')
+            if command == ['ip', '-6', 'route', 'show']:
+                return SimpleNamespace(returncode=0, stdout='default via fe80::1 dev eth0 metric 1024', stderr='')
+            return SimpleNamespace(returncode=0, stdout='1.1.1.1 via 192.168.1.1 dev eth0 src 192.168.1.20', stderr='')
+        run.side_effect = fake_run
+
+        response = self.client.post('/route-diagnostics', data={'target': '1.1.1.1'})
+
+        self.assertEqual(response.status_code, 200)
+        diagnostics = response.get_json()['diagnostics']
+        self.assertEqual(diagnostics['default_gateways'][0]['gateway'], '192.168.1.1')
+        self.assertEqual(diagnostics['vpn_hints'][0]['interface'], 'tun0')
+        self.assertIn('1.1.1.1 via 192.168.1.1', diagnostics['scan_path_context'])
 
 
 
@@ -360,6 +866,25 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Mobile Router Report', response.data)
 
+
+    def test_oui_lookup_accepts_common_formats_and_fallbacks(self):
+        status = oui_database_status()
+
+        self.assertTrue(status['loaded'])
+        self.assertGreaterEqual(status['entries'], status['fallback_entries'])
+        self.assertEqual(lookup_manufacturer('b8:27:eb:11:22:33'), 'Raspberry Pi Foundation')
+        self.assertEqual(lookup_manufacturer('B8-27-EB-11-22-33'), 'Raspberry Pi Foundation')
+        self.assertEqual(lookup_manufacturer('b827eb112233'), 'Raspberry Pi Foundation')
+        self.assertEqual(lookup_manufacturer('52:54:00:12:34:56'), 'QEMU/KVM Virtual NIC')
+        self.assertEqual(lookup_manufacturer('not-a-mac'), 'Unknown')
+
+    def test_capabilities_page_shows_oui_database_health(self):
+        response = self.client.get('/capabilities')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'OUI Vendor Lookup', response.data)
+        self.assertIn(b'Fallback entries', response.data)
+        self.assertIn(b'python scripts/update_oui_db.py', response.data)
 
     def test_inventory_page_renders_manufacturer_insights(self):
         app_module.device_inventory.clear()
@@ -437,10 +962,22 @@ class RouteSmokeTest(unittest.TestCase):
         ])
 
     @patch('scripts.networkScan._get_ipv4_cidr', return_value='10.0.0.1/20')
-    def test_active_scan_skips_overly_large_subnets(self, _cidr):
+    @patch('scripts.networkScan._parse_proc_arp', return_value=[])
+    @patch('scripts.networkScan._parse_arp_command', return_value=[])
+    def test_active_scan_skips_overly_large_subnets(self, _arp_command, _proc_arp, _cidr):
         from scripts.networkScan import active_scan
 
         self.assertEqual(active_scan('eth0'), [])
+
+    @patch('scripts.networkScan._parse_arp_command', return_value=[])
+    @patch('scripts.networkScan._parse_proc_arp')
+    @patch('scripts.networkScan._get_ipv4_cidr', return_value=None)
+    def test_active_scan_falls_back_to_arp_cache_when_cidr_unknown(self, _cidr, proc_arp, _arp_command):
+        from scripts.networkScan import active_scan
+
+        proc_arp.side_effect = [[], [{'ip': '192.168.20.40', 'mac': 'aa:bb:cc:dd:ee:40'}]]
+
+        self.assertEqual(active_scan('WiFi'), [{'ip': '192.168.20.40', 'mac': 'aa:bb:cc:dd:ee:40'}])
 
     def test_port_scan_page_mentions_device_prefill(self):
         response = self.client.get('/port-scan?host=192.168.20.10')
@@ -451,14 +988,266 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'port_scan_live.js', response.data)
 
     def test_client_detail_links_to_device_port_scan(self):
+        app_module.device_inventory.clear()
+        app_module.record_device_open_ports('192.168.20.10', [
+            {'port': 22, 'service': 'SSH', 'description': 'Secure shell remote administration'},
+            {'port': 80, 'service': 'HTTP', 'description': 'Web server'},
+        ])
+
         response = self.client.get('/clients/192.168.20.10')
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Saved Service Profile', response.data)
+        self.assertIn(b'22/tcp', response.data)
+        self.assertIn(b'SSH', response.data)
+        self.assertIn(b'href="http://192.168.20.10:80/"', response.data)
+        self.assertIn(b'target="_blank"', response.data)
         self.assertIn(b'Device Port Scan', response.data)
         self.assertIn(b'Common ports', response.data)
         self.assertIn(b'All ports', response.data)
         self.assertIn(b'/port-scan?host=192.168.20.10', response.data)
+        self.assertIn(b'IP Client Actions', response.data)
+        self.assertIn(b'Client Health', response.data)
+        self.assertIn(b'Watch this device', response.data)
+        self.assertIn(b'Inspect web services', response.data)
+        self.assertIn(b'Fingerprint services', response.data)
+        self.assertIn(b'Save baseline', response.data)
+        self.assertIn(b'Client Profile Metadata', response.data)
+        self.assertIn(b'Expected open ports', response.data)
+        self.assertIn(b'Export JSON', response.data)
+        self.assertIn(b'Export Markdown', response.data)
+        self.assertIn(b'Client Relationship Map', response.data)
+        self.assertIn(b'Scheduled Client Checks', response.data)
+        self.assertIn(b'Client Timeline', response.data)
+        self.assertIn(b'Port scan', response.data)
+        self.assertIn(b'data-ip-client-ping', response.data)
+        self.assertIn(b'data-ip-client-route', response.data)
+        self.assertIn(b'data-ip-client-traceroute', response.data)
+        self.assertIn(b'Save evidence note', response.data)
         self.assertIn(b'port_scan_live.js', response.data)
+        self.assertIn(b'ip_client.js', response.data)
+
+    def test_ip_client_detail_uses_detected_inventory_name_as_title(self):
+        app_module.device_inventory.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.30', 'hostname': 'printer.local', 'name': 'Lab Printer', 'manufacturer': 'PrinterCo'},
+        ], 'mdns-discovery', 'eth0')
+
+        response = self.client.get('/clients/192.168.20.30')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<h1 class="page-title">Lab Printer</h1>', response.data)
+        self.assertIn(b'Device identity and manufacturer details', response.data)
+
+    @patch('app._dhcp_lease_display_name', return_value='')
+    @patch('app.socket.gethostbyaddr', return_value=('camera.lab.local', [], ['192.168.20.31']))
+    def test_ip_client_detail_detects_reverse_dns_name(self, _reverse_dns, _dhcp):
+        app_module.device_inventory.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.31', 'mac': '48:b0:2d:ef:ec:f3', 'manufacturer': 'CameraCo'},
+        ], 'active-scan', 'eth0')
+
+        response = self.client.get('/clients/192.168.20.31')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'<h1 class="page-title">camera.lab.local</h1>', response.data)
+        self.assertIn(b'display name learned from reverse-dns', response.data)
+        device = app_module.find_inventory_device('192.168.20.31')
+        self.assertEqual(device['detected_display_name'], 'camera.lab.local')
+
+    def test_ip_client_actions_script_posts_diagnostics_and_evidence(self):
+        js = open('static/js/ip_client.js').read()
+
+        self.assertIn("url: '/ping'", js)
+        self.assertIn("url: '/route-diagnostics'", js)
+        self.assertIn("url: '/traceroute'", js)
+        self.assertIn("url: '/evidence'", js)
+        self.assertIn('data-ip-client-evidence-form', js)
+        self.assertIn('data-ip-client-watch', js)
+        self.assertIn('http-inspect', js)
+        self.assertIn('data-ip-client-baseline', js)
+        self.assertIn('data-ip-client-metadata-form', js)
+        self.assertIn('data-ip-client-fingerprint', js)
+        self.assertIn('data-ip-client-intelligence', js)
+        self.assertIn('/intelligence', js)
+        self.assertIn('Device intelligence snapshot', js)
+        self.assertIn('data-ip-client-scheduled-form', js)
+
+    def test_port_scan_scripts_link_web_ports_and_quick_scan_in_place(self):
+        live_js = open('static/js/port_scan_live.js').read()
+        jobs_js = open('static/js/jobs.js').read()
+        network_js = open('static/js/network_scan.js').read()
+
+        self.assertIn('info.web_url', live_js)
+        self.assertIn('target="_blank"', live_js)
+        self.assertIn('info.web_url', jobs_js)
+        self.assertIn('data-port-scan-quick', network_js)
+        self.assertIn("url: '/port-scan-jobs'", network_js)
+        self.assertIn('startQuickPortScan', network_js)
+        self.assertIn('pollQuickPortScan', network_js)
+        self.assertIn('/summary', network_js)
+        self.assertIn('data-network-device-notes-form', network_js)
+        self.assertIn('data-network-device-filter', network_js)
+        self.assertIn('data-port-scan-quick-progress', network_js)
+        self.assertIn('data-network-device-label-form', network_js)
+        self.assertIn('/wireless/network/label', network_js)
+        self.assertIn('isNetworkDeviceListMode', network_js)
+        self.assertIn('refreshNetworkDeviceList', network_js)
+        self.assertIn('Active scan saved', network_js)
+
+    def test_client_summary_returns_latest_card_fields(self):
+        app_module.device_inventory.clear()
+        app_module.record_device_open_ports('192.168.20.70', [
+            {'port': 80, 'service': 'HTTP', 'description': 'Web server', 'http_title': 'Router Console'},
+        ])
+        app_module.update_client_metadata('192.168.20.70', {'tags': 'router,critical', 'notes': 'Core gateway'})
+
+        response = self.client.get('/clients/192.168.20.70/summary')
+
+        self.assertEqual(response.status_code, 200)
+        device = response.get_json()['device']
+        self.assertEqual(device['client_tags'], ['critical', 'router'])
+        self.assertEqual(device['client_notes'], 'Core gateway')
+        self.assertEqual(device['open_port_details'][0]['web_url'], 'http://192.168.20.70:80/')
+        self.assertEqual(device['open_port_details'][0]['http_title'], 'Router Console')
+
+    @patch('app.fingerprint_client_services')
+    @patch('app._dhcp_lease_display_name', return_value='camera-dhcp')
+    @patch('app._reverse_dns_display_name', return_value='camera.lab.local')
+    @patch('app.socket.getaddrinfo', return_value=[(None, None, None, None, ('192.168.20.71', 0))])
+    def test_client_intelligence_reports_dns_dhcp_os_services_and_recommendations(self, _addrinfo, _reverse, _dhcp, fingerprint):
+        app_module.device_inventory.clear()
+        app_module.ping_history.clear()
+        fingerprint.return_value = [{'port': 80, 'service': 'HTTP', 'confidence': 'high'}]
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.71', 'mac': '02:11:22:33:44:55', 'manufacturer': 'Unknown'},
+        ], 'active-scan', 'eth0')
+        app_module.record_device_open_ports('192.168.20.71', [
+            {'port': 80, 'service': 'HTTP', 'description': 'Web service'},
+            {'port': 445, 'service': 'SMB', 'description': 'SMB file sharing'},
+        ])
+        app_module.ping_history.append({'host': '192.168.20.71', 'output': '64 bytes from 192.168.20.71: icmp_seq=1 ttl=64 time=1.2 ms', 'checked_at': time.time()})
+
+        response = self.client.post('/clients/192.168.20.71/intelligence', data={'activeProbe': 'on'})
+
+        self.assertEqual(response.status_code, 200)
+        info = response.get_json()['intelligence']
+        self.assertEqual(info['dhcp']['hostname'], 'camera-dhcp')
+        self.assertEqual(info['dns']['reverse'], 'camera.lab.local')
+        self.assertEqual(info['dns']['forward'][0]['addresses'], ['192.168.20.71'])
+        self.assertIn('Linux/Unix', info['os_hint']['hint'])
+        self.assertEqual(info['services']['open_port_count'], 2)
+        self.assertEqual(info['services']['sensitive_port_count'], 1)
+        self.assertEqual(info['services']['fingerprints'][0]['service'], 'HTTP')
+        self.assertTrue(any('Sensitive' in item for item in info['recommendations']))
+
+    def test_client_metadata_baseline_and_exports(self):
+        app_module.device_inventory.clear()
+        app_module.record_device_open_ports('192.168.20.10', [
+            {'port': 22, 'service': 'SSH', 'description': 'Secure shell remote administration'},
+            {'port': 80, 'service': 'HTTP', 'description': 'Web service'},
+        ])
+
+        response = self.client.post('/clients/192.168.20.10/metadata', data={
+            'tags': 'trusted, router',
+            'owner': 'Lab',
+            'location': 'Bench',
+            'expectedPorts': '22,443',
+            'notes': 'Expected lab gateway.',
+        })
+        self.assertEqual(response.status_code, 200)
+        device = response.get_json()['device']
+        self.assertEqual(device['client_tags'], ['router', 'trusted'])
+        self.assertEqual(device['client_owner'], 'Lab')
+        self.assertEqual(device['expected_open_ports'], [22, 443])
+
+        response = self.client.get('/clients/192.168.20.10')
+        self.assertIn(b'Drift detected', response.data)
+        self.assertIn(b'Unexpected 80', response.data)
+        self.assertIn(b'Missing 443', response.data)
+
+        response = self.client.post('/clients/192.168.20.10/baseline')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['baseline']['status'], 'Baseline saved')
+
+        response = self.client.get('/clients/192.168.20.10/export.json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['host'], '192.168.20.10')
+
+        response = self.client.get('/clients/192.168.20.10/export.md')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Client profile: 192.168.20.10', response.data)
+
+    @patch('app.inspect_http_services')
+    def test_client_relationship_fingerprint_schedule_and_inventory_badges(self, inspect_http):
+        app_module.device_inventory.clear()
+        app_module.scheduled_client_checks.clear()
+        app_module.watched_clients.clear()
+        inspect_http.return_value = [{'port': 80, 'url': 'http://192.168.20.10:80/', 'status': 200, 'title': 'Router UI', 'server': 'lab', 'error': None}]
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.10', 'mac': '48:b0:2d:ef:ec:f2', 'manufacturer': 'Example', 'interfaces': ['eth0']}
+        ], 'active-scan', 'eth0')
+        app_module.record_device_open_ports('192.168.20.10', [
+            {'port': 80, 'service': 'HTTP', 'description': 'Web service'},
+        ])
+        app_module.update_client_metadata('192.168.20.10', {'tags': 'router', 'expectedPorts': '22'})
+        app_module.watched_clients.add('192.168.20.10')
+
+        response = self.client.get('/clients/192.168.20.10/relationship-map')
+        self.assertEqual(response.status_code, 200)
+        node_labels = [node['label'] for node in response.get_json()['map']['nodes']]
+        self.assertIn('192.168.20.10', node_labels)
+        self.assertIn('80/tcp HTTP', node_labels)
+
+        response = self.client.post('/clients/192.168.20.10/fingerprint')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['fingerprints'][0]['http']['title'], 'Router UI')
+
+        response = self.client.post('/clients/192.168.20.10/scheduled-check', data={
+            'intervalMinutes': '30',
+            'checks': 'ping,common-ports,baseline-drift',
+        })
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['plan']['interval_minutes'], 30)
+        self.assertIn('baseline-drift', response.get_json()['plan']['checks'])
+
+        response = self.client.get('/inventory')
+        self.assertIn(b'Drift', response.data)
+        self.assertIn(b'Watched', response.data)
+        self.assertIn(b'router', response.data)
+
+    def test_client_watch_alerts_on_new_open_ports(self):
+        app_module.device_inventory.clear()
+        app_module.new_device_alerts.clear()
+        app_module.watched_clients.clear()
+
+        response = self.client.post('/clients/192.168.20.10/watch', data={'watch': 'on'})
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()['watched'])
+
+        app_module.record_device_open_ports('192.168.20.10', [
+            {'port': 22, 'service': 'SSH', 'description': 'Secure shell remote administration'},
+        ])
+
+        alerts = app_module.alert_records()
+        self.assertEqual(alerts[0]['alert_type'], 'watched-client')
+        self.assertIn('New open port', alerts[0]['title'])
+
+    @patch('app.inspect_http_services')
+    def test_client_http_inspector_uses_saved_web_ports(self, inspect_http):
+        app_module.device_inventory.clear()
+        inspect_http.return_value = [{'port': 80, 'url': 'http://192.168.20.10:80/', 'status': 200, 'title': 'Router', 'server': 'lab', 'error': None}]
+        app_module.record_device_open_ports('192.168.20.10', [
+            {'port': 22, 'service': 'SSH', 'description': 'Secure shell remote administration'},
+            {'port': 80, 'service': 'HTTP', 'description': 'Web service'},
+        ])
+
+        response = self.client.post('/clients/192.168.20.10/http-inspect')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['results'][0]['title'], 'Router')
+        inspect_http.assert_called_once_with('192.168.20.10', [80])
 
 
     def test_bluetooth_client_detail_uses_device_name_and_metadata(self):
@@ -494,7 +1283,9 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'bluetooth-scan.js', response.data)
         self.assertNotIn(b'Bluetooth Notes', response.data)
         self.assertNotIn(b'Device Port Scan', response.data)
+        self.assertNotIn(b'IP Client Actions', response.data)
         self.assertNotIn(b'port_scan_live.js', response.data)
+        self.assertNotIn(b'ip_client.js', response.data)
 
 
     def test_bluetooth_client_detail_uses_contextual_connected_actions(self):
@@ -561,8 +1352,54 @@ class RouteSmokeTest(unittest.TestCase):
         response = self.client.get('/inventory')
 
         self.assertEqual(response.status_code, 200)
+        self.assertIn(b'/clients/192.168.20.10', response.data)
         self.assertIn(b'/port-scan?host=192.168.20.10', response.data)
-        self.assertEqual(response.data.count(b'Check ports'), 1)
+        self.assertEqual(response.data.count(b'Device scan'), 1)
+        self.assertEqual(response.data.count(b'Tools scan'), 1)
+        self.assertIn(b'Export devices + ports', response.data)
+        self.assertIn(b'Import devices + ports', response.data)
+
+    def test_inventory_export_and_import_preserves_open_ports(self):
+        app_module.device_inventory.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.88', 'mac': '48:b0:2d:ef:ec:f8', 'hostname': 'nas.local', 'manufacturer': 'StorageCo'},
+        ], 'test-scan', 'eth0')
+        app_module.record_device_open_ports('192.168.20.88', [
+            {'port': 443, 'service': 'HTTPS', 'description': 'Secure web server', 'http_title': 'NAS Admin'},
+        ])
+
+        response = self.client.get('/inventory/export.json')
+
+        self.assertEqual(response.status_code, 200)
+        exported = response.get_json()
+        self.assertEqual(exported['schema'], 'mobile-router-inventory-v1')
+        exported_device = next(item for item in exported['devices'] if item.get('ip') == '192.168.20.88')
+        self.assertEqual(exported_device['open_port_details'][0]['port'], 443)
+
+        app_module.device_inventory.clear()
+        response = self.client.post('/inventory/import', json=exported, headers={'X-Requested-With': 'XMLHttpRequest'})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['imported_port_profiles'], 1)
+        device = app_module.find_inventory_device('192.168.20.88')
+        self.assertEqual(device['open_port_details'][0]['port'], 443)
+        self.assertEqual(device['open_port_details'][0]['http_title'], 'NAS Admin')
+
+    @patch('scripts.portScanner.scan_ports', return_value=[80, 443])
+    def test_port_scan_route_saves_open_ports_to_device_profile(self, _scan_ports):
+        app_module.device_inventory.clear()
+
+        response = self.client.post('/port-scan', data={'host': '192.168.20.44', 'start': '80', 'end': '443'})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['ports'], [80, 443])
+        device = app_module.find_inventory_device('192.168.20.44')
+        self.assertEqual(device['open_ports'], [80, 443])
+        self.assertEqual(device['open_port_details'][0]['service'], 'HTTP')
+        self.assertEqual(device['open_port_details'][1]['service'], 'HTTPS')
+        self.assertEqual(device['open_port_details'][1]['web_url'], 'https://192.168.20.44:443/')
 
     def test_new_device_alerts_are_created_and_can_be_read(self):
         app_module.device_inventory.clear()
@@ -584,6 +1421,34 @@ class RouteSmokeTest(unittest.TestCase):
         response = self.client.post(f'/alerts/{alert_id}/read')
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.get_json()['unread_count'], 0)
+
+    def test_grouped_discovery_alerts_batch_active_scan_devices(self):
+        app_module.device_inventory.clear()
+        app_module.new_device_alerts.clear()
+
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.10', 'mac': '48:b0:2d:ef:ec:f2'},
+            {'ip': '192.168.20.11', 'mac': 'b8:27:eb:11:22:33'},
+        ], 'active-scan', 'eth0')
+
+        alerts = app_module.alert_records()
+        self.assertEqual(len(alerts), 1)
+        self.assertEqual(alerts[0]['alert_type'], 'grouped-discovery')
+        self.assertEqual(alerts[0]['device_count'], 2)
+        self.assertEqual(alerts[0]['device_url'], '/inventory')
+
+    def test_passive_discovery_keeps_individual_later_alerts(self):
+        app_module.device_inventory.clear()
+        app_module.new_device_alerts.clear()
+
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.10', 'mac': '48:b0:2d:ef:ec:f2'},
+            {'ip': '192.168.20.11', 'mac': 'b8:27:eb:11:22:33'},
+        ], 'passive-scan', 'eth0')
+
+        alerts = app_module.alert_records()
+        self.assertEqual(len(alerts), 2)
+        self.assertTrue(all(alert.get('alert_type') != 'grouped-discovery' for alert in alerts))
 
     def test_alerts_page_and_nav_indicator_render(self):
         app_module.new_device_alerts.clear()
@@ -666,6 +1531,9 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(job['open_port_details'][0]['service'], 'SSH')
         self.assertEqual(job['scanned_ports'], 3)
         self.assertEqual(job['progress'], 100)
+        device = app_module.find_inventory_device('192.168.20.10')
+        self.assertEqual(device['open_ports'], [22])
+        self.assertEqual(device['open_port_details'][0]['service'], 'SSH')
 
     def test_jobs_page_and_status_show_running_count(self):
         app_module.scan_jobs.clear()
@@ -785,7 +1653,10 @@ class RouteSmokeTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'TrainingNet', response.data)
-        self.assertIn(b'Discovered Devices', response.data)
+        self.assertIn(b'id="network-devices-tab"', response.data)
+        self.assertIn(b'AP Details', response.data)
+        self.assertIn(b'Devices Found On This Network Interface', response.data)
+        self.assertIn(b'network-device-card', response.data)
         self.assertIn(b'192.168.1.1', response.data)
         self.assertIn(b'5 GHz', response.data)
         self.assertIn(b'AP Identity Hints', response.data)
@@ -793,6 +1664,256 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'WPS exposed', response.data)
         self.assertIn(b'Training Vendor', response.data)
         self.assertIn(b'11:22:33:44:55:66', response.data)
+        self.assertIn(b'href="#network-device-scan"', response.data)
+        self.assertIn(b'Network Device Scan', response.data)
+        self.assertIn(b'id="comprehensive-scan-btn"', response.data)
+        self.assertIn(b'<option value="wlan0" selected>', response.data)
+        self.assertLess(response.data.index(b'id="network-devices-pane"'), response.data.index(b'id="network-device-scan"'))
+        self.assertIn(b'data-network-device-list-scan', response.data)
+        self.assertIn(b'Scan all common ports', response.data)
+        self.assertIn(b'Scan all ports', response.data)
+        self.assertIn(b'network_scan.js', response.data)
+
+
+    def test_device_intelligence_tracks_names_role_and_randomized_mac(self):
+        app_module.device_inventory.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.30.20', 'mac': '02:11:22:33:44:55', 'hostname': 'office-printer.local'}
+        ], 'mdns-discovery', 'wlan0')
+        app_module.record_device_open_ports('192.168.30.20', [
+            {'port': 631, 'service': 'IPP', 'description': 'Internet Printing Protocol'}
+        ])
+
+        device = app_module.find_inventory_device('192.168.30.20')
+
+        self.assertTrue(device['likely_randomized_mac'])
+        self.assertEqual(device['device_role_guess']['role'], 'Printer')
+        self.assertEqual(device['observed_names'][0]['name'], 'office-printer.local')
+        payload = app_module.inventory_export_payload([device])
+        exported = payload['devices'][0]
+        self.assertTrue(exported['likely_randomized_mac'])
+        self.assertEqual(exported['device_role_guess']['role'], 'Printer')
+        self.assertEqual(exported['observed_names'][0]['source'], 'mdns-discovery')
+
+    @patch('app.device_intel.tls_certificate_metadata')
+    @patch('app.inspect_http_services')
+    def test_web_service_enrichment_adds_favicon_and_tls_metadata(self, inspect, tls):
+        inspect.return_value = [{
+            'port': 443,
+            'status': 200,
+            'title': 'NAS Admin',
+            'server': 'nginx',
+            'favicon': {'sha256': 'abc123', 'size': 42},
+        }]
+        tls.return_value = {'subject_common_name': 'nas.local', 'issuer_common_name': 'Lab CA'}
+
+        detail = app_module.enrich_web_port_metadata('192.168.30.30', {
+            'port': 443,
+            'service': 'HTTPS',
+            'description': 'HTTPS web service',
+        })
+
+        self.assertEqual(detail['http_favicon']['sha256'], 'abc123')
+        self.assertEqual(detail['tls_certificate']['subject_common_name'], 'nas.local')
+
+    def test_wireless_network_detail_exposes_passive_monitor_toggle(self):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        app_module.wireless_network_labels.clear()
+        app_module.passive_monitor_jobs.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.20.10', 'mac': 'AA:BB:CC:DD:EE:10', 'hostname': 'Camera'}
+        ], 'passive-monitor', 'wlan0')
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'data-passive-monitor-toggle', response.data)
+        with open('static/js/network_scan.js') as handle:
+            js = handle.read()
+        self.assertIn('/passive-monitor/status', js)
+        self.assertIn('/passive-monitor/toggle', js)
+        self.assertIn(b'The app does not send probe packets for this mode', response.data)
+
+    @patch('app.passive_scan')
+    def test_passive_monitor_toggle_records_observed_cache_devices(self, passive):
+        app_module.device_inventory.clear()
+        app_module.passive_monitor_jobs.clear()
+        passive.return_value = [{'ip': '192.168.20.55', 'mac': 'AA:BB:CC:DD:EE:55'}]
+
+        response = self.client.post('/passive-monitor/toggle', data={
+            'selectedInterface': 'wlan0',
+            'enabled': 'on',
+            'interval': '5',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        self.assertTrue(response.get_json()['status']['enabled'])
+        for _ in range(20):
+            if app_module.find_inventory_device('192.168.20.55'):
+                break
+            time.sleep(0.05)
+        device = app_module.find_inventory_device('192.168.20.55')
+        self.assertIsNotNone(device)
+        self.assertIn('passive-monitor', device['sources'])
+
+        response = self.client.post('/passive-monitor/toggle', data={
+            'selectedInterface': 'wlan0',
+            'enabled': '',
+            'interval': '5',
+        })
+        self.assertFalse(response.get_json()['status']['enabled'])
+
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_detail_persists_clients_between_reloads(self, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        first = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'channel': '6',
+            'signal': 82,
+            'signal_label': '82%',
+            'interface': 'wlan0',
+            'discovered': True,
+            'gateway': {},
+            'bands': ['5 GHz'],
+            'wps': False,
+            'wps_status': None,
+            'wps_note': None,
+            'wps_access_points': 0,
+            'ap_groups': [],
+            'access_points': [],
+            'clients': [{'mac': '11:22:33:44:55:66', 'signal_label': '-42 dBm', 'bssid': 'aa:bb:cc:dd:ee:ff', 'manufacturer': 'Client Vendor'}],
+        }
+        second = {**first, 'clients': [], 'discovered': False}
+        get_detail.side_effect = [first, second]
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+        self.assertIn(b'11:22:33:44:55:66', response.data)
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'11:22:33:44:55:66', response.data)
+        self.assertIn(b'This list is persisted', response.data)
+
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_detail_lists_inventory_devices_for_interface(self, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.50.22', 'mac': '48:b0:2d:ef:ec:f2', 'hostname': 'laptop.local', 'manufacturer': 'LaptopCo'},
+        ], 'comprehensive-network-scan', 'wlan0')
+        get_detail.return_value = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'channel': '6',
+            'signal': 82,
+            'signal_label': '82%',
+            'interface': 'wlan0',
+            'discovered': True,
+            'gateway': {},
+            'bands': [],
+            'wps': False,
+            'wps_status': None,
+            'wps_note': None,
+            'wps_access_points': 0,
+            'ap_groups': [],
+            'access_points': [],
+            'clients': [],
+        }
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'laptop.local', response.data)
+        self.assertIn(b'192.168.50.22', response.data)
+        self.assertIn(b'/clients/192.168.50.22', response.data)
+        self.assertIn(b'data-port-scan-quick', response.data)
+        self.assertIn(b'data-label="common port scan"', response.data)
+        self.assertIn(b'data-label="all-port scan"', response.data)
+        self.assertIn(b'data-network-device-filter="gateway"', response.data)
+        self.assertIn(b'data-network-device-notes-form', response.data)
+        self.assertIn(b'data-known-state="New"', response.data)
+        self.assertIn(b'Export device list', response.data)
+        self.assertIn(b'data-network-device-label-form', response.data)
+        self.assertIn(b'data-port-scan-quick-progress', response.data)
+        self.assertIn(b'Scan all common ports', response.data)
+        self.assertIn(b'data-hosts="192.168.50.22"', response.data)
+
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_labels_disappeared_and_export(self, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        app_module.wireless_network_labels.clear()
+        first = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'channel': '6',
+            'signal': 82,
+            'signal_label': '82%',
+            'interface': 'wlan0',
+            'discovered': True,
+            'gateway': {},
+            'bands': [],
+            'wps': False,
+            'wps_status': None,
+            'wps_note': None,
+            'wps_access_points': 0,
+            'ap_groups': [],
+            'access_points': [],
+            'clients': [{'ip': '192.168.50.33', 'mac': '48:b0:2d:ef:ec:f3', 'manufacturer': 'TvCo'}],
+        }
+        second = {**first, 'clients': []}
+        get_detail.side_effect = [first, second, second]
+
+        self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+        response = self.client.post('/wireless/network/label', data={
+            'interface': 'wlan0',
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'identity': '48:b0:2d:ef:ec:f3',
+            'label': 'Living room TV',
+        })
+        self.assertEqual(response.status_code, 200)
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+        self.assertIn(b'Recently Disappeared Devices', response.data)
+        self.assertIn(b'Living room TV', response.data)
+
+        response = self.client.get('/wireless/network/clients.csv?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Living room TV', response.data)
+        self.assertIn(b'disappeared', response.data)
+        self.assertIn(b'open_port_details_json', response.data)
+
+    def test_service_detail_page_and_port_card_links(self):
+        app_module.device_inventory.clear()
+        app_module.record_device_open_ports('192.168.20.80', [
+            {'port': 80, 'service': 'HTTP', 'description': 'Web server', 'http_title': 'Router Console'},
+        ])
+
+        response = self.client.get('/clients/192.168.20.80')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'class="port-service-number"', response.data)
+        self.assertIn(b'href="http://192.168.20.80:80/"', response.data)
+        self.assertIn(b'/clients/192.168.20.80/services/80', response.data)
+        self.assertIn(b'web-service-hover-preview', response.data)
+
+        response = self.client.get('/clients/192.168.20.80/services/80')
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'192.168.20.80:80', response.data)
+        self.assertIn(b'Router Console', response.data)
+
+    def test_wireless_network_cards_link_to_device_scan_panel(self):
+        js = open('static/js/wireless-adapters.js').read()
+
+        self.assertIn('#network-device-scan', js)
+        self.assertIn('Device scan', js)
 
     def test_bluetooth_scan_includes_manufacturer(self):
         async def fake_get_bluetooth_devices():

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2065,6 +2065,25 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'192.168.20.80:80', response.data)
         self.assertIn(b'Router Console', response.data)
 
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_device_cards_resolve_oui_manufacturer(self, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        get_detail.return_value = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'access_points': [],
+            'clients': [{'ip': '192.168.77.20', 'mac': '8c:49:62:bd:7d:37'}],
+            'interface': 'wlan0',
+        }
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Roku, Inc.', response.data)
+        self.assertNotIn(b'<i class="fa-solid fa-industry"></i> Unknown', response.data)
+
     def test_wireless_network_clients_json_returns_persisted_device_list(self):
         app_module.device_inventory.clear()
         app_module.record_inventory_devices([

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1093,6 +1093,8 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn('/wireless/network/label', network_js)
         self.assertIn('isNetworkDeviceListMode', network_js)
         self.assertIn('refreshNetworkDeviceList', network_js)
+        self.assertIn('/wireless/network/clients.json', network_js)
+        self.assertNotIn('window.location.reload()', network_js)
         self.assertIn('Active scan saved', network_js)
 
     def test_client_summary_returns_latest_card_fields(self):
@@ -1664,12 +1666,15 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'WPS exposed', response.data)
         self.assertIn(b'Training Vendor', response.data)
         self.assertIn(b'11:22:33:44:55:66', response.data)
-        self.assertIn(b'href="#network-device-scan"', response.data)
+        self.assertNotIn(b'href="#network-device-scan"', response.data)
+        self.assertIn(b'Continuous passive capture', response.data)
+        self.assertIn(b'data-passive-monitor-toggle', response.data)
         self.assertIn(b'Network Device Scan', response.data)
         self.assertIn(b'id="comprehensive-scan-btn"', response.data)
         self.assertIn(b'<option value="wlan0" selected>', response.data)
         self.assertLess(response.data.index(b'id="network-devices-pane"'), response.data.index(b'id="network-device-scan"'))
         self.assertIn(b'data-network-device-list-scan', response.data)
+        self.assertIn(b'data-network-device-list', response.data)
         self.assertIn(b'Scan all common ports', response.data)
         self.assertIn(b'Scan all ports', response.data)
         self.assertIn(b'network_scan.js', response.data)
@@ -1908,6 +1913,19 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'192.168.20.80:80', response.data)
         self.assertIn(b'Router Console', response.data)
+
+    def test_wireless_network_clients_json_returns_persisted_device_list(self):
+        app_module.device_inventory.clear()
+        app_module.record_inventory_devices([
+            {'ip': '192.168.77.10', 'mac': '48:b0:2d:ef:77:10', 'manufacturer': 'ClientCo', 'interfaces': ['wlan0']},
+        ], 'active-scan', 'wlan0')
+
+        response = self.client.get('/wireless/network/clients.json?interface=wlan0&ssid=TrainingNet')
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertTrue(any(client.get('ip') == '192.168.77.10' for client in payload['clients']))
+        self.assertGreaterEqual(payload['client_count'], 1)
 
     def test_wireless_network_cards_link_to_device_scan_panel(self):
         js = open('static/js/wireless-adapters.js').read()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -876,6 +876,8 @@ class RouteSmokeTest(unittest.TestCase):
 
         self.assertTrue(status['loaded'])
         self.assertGreaterEqual(status['entries'], status['fallback_entries'])
+        self.assertIn(status['coverage'], {'compact', 'full'})
+        self.assertEqual(status['needs_refresh'], status['entries'] < status['full_entry_threshold'])
         self.assertEqual(lookup_manufacturer('b8:27:eb:11:22:33'), 'Raspberry Pi Foundation')
         self.assertEqual(lookup_manufacturer('B8-27-EB-11-22-33'), 'Raspberry Pi Foundation')
         self.assertEqual(lookup_manufacturer('b827eb112233'), 'Raspberry Pi Foundation')
@@ -884,6 +886,37 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(lookup_manufacturer('8C-49-62-BD-7D-37'), 'Roku, Inc.')
         self.assertEqual(lookup_manufacturer('not-a-mac'), 'Unknown')
 
+    def test_oui_downloader_tries_fallback_urls(self):
+        from scripts import update_oui_db
+
+        calls = []
+
+        class FakeResponse:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b'Registry,Assignment,Organization Name\nMA-L,8C4962,"Roku, Inc."\n'
+
+        def fake_open(request, timeout=30):
+            calls.append(request.full_url)
+            if len(calls) == 1:
+                raise OSError('blocked')
+            return FakeResponse()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path, count = update_oui_db.download_oui_database(
+                output_path=os.path.join(tmpdir, 'oui_db.csv'),
+                opener=fake_open,
+            )
+            self.assertEqual(count, 1)
+            self.assertGreaterEqual(len(calls), 2)
+            with open(path, encoding='utf-8') as handle:
+                self.assertIn('8c:49:62,Roku, Inc.', handle.read())
+
     def test_capabilities_page_shows_oui_database_health(self):
         response = self.client.get('/capabilities')
 
@@ -891,6 +924,7 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'OUI Vendor Lookup', response.data)
         self.assertIn(b'Fallback entries', response.data)
         self.assertIn(b'python scripts/update_oui_db.py', response.data)
+        self.assertIn(b'Coverage', response.data)
 
     def test_inventory_page_renders_manufacturer_insights(self):
         app_module.device_inventory.clear()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1902,6 +1902,10 @@ class RouteSmokeTest(unittest.TestCase):
             'interval': '5',
         })
         self.assertFalse(response.get_json()['status']['enabled'])
+        for _ in range(20):
+            if not app_module.passive_monitor_jobs.get('wlan0', {}).get('thread_alive'):
+                break
+            time.sleep(0.05)
 
     @patch('app.packet_passive_scan')
     def test_passive_monitor_packet_mode_records_packet_observations(self, packet_scan):
@@ -1940,6 +1944,10 @@ class RouteSmokeTest(unittest.TestCase):
             'mode': 'packet',
         })
         self.assertFalse(response.get_json()['status']['enabled'])
+        for _ in range(20):
+            if not app_module.passive_monitor_jobs.get('wlan0', {}).get('thread_alive'):
+                break
+            time.sleep(0.05)
 
     @patch('app.passive_scan')
     def test_passive_scan_records_passive_only_analytics_and_quiet_devices(self, passive):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -880,6 +880,8 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(lookup_manufacturer('B8-27-EB-11-22-33'), 'Raspberry Pi Foundation')
         self.assertEqual(lookup_manufacturer('b827eb112233'), 'Raspberry Pi Foundation')
         self.assertEqual(lookup_manufacturer('52:54:00:12:34:56'), 'QEMU/KVM Virtual NIC')
+        self.assertEqual(lookup_manufacturer('8c:49:62:bd:7d:37'), 'Roku, Inc.')
+        self.assertEqual(lookup_manufacturer('8C-49-62-BD-7D-37'), 'Roku, Inc.')
         self.assertEqual(lookup_manufacturer('not-a-mac'), 'Unknown')
 
     def test_capabilities_page_shows_oui_database_health(self):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -8,7 +8,7 @@ from unittest.mock import Mock, patch
 
 import app as app_module
 from app import app
-from scripts.interfaceTools import lookup_manufacturer, oui_database_status
+from services.oui import lookup_manufacturer, oui_database_status
 
 
 class RouteSmokeTest(unittest.TestCase):
@@ -884,6 +884,9 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(lookup_manufacturer('52:54:00:12:34:56'), 'QEMU/KVM Virtual NIC')
         self.assertEqual(lookup_manufacturer('8c:49:62:bd:7d:37'), 'Roku, Inc.')
         self.assertEqual(lookup_manufacturer('8C-49-62-BD-7D-37'), 'Roku, Inc.')
+        from scripts.wifi import utils as wifi_utils
+        self.assertEqual(wifi_utils._mac_manufacturer('8c:49:62:bd:7d:37'), 'Roku, Inc.')
+        self.assertEqual(app_module.lookup_manufacturer('8c:49:62:bd:7d:37'), 'Roku, Inc.')
         self.assertEqual(lookup_manufacturer('not-a-mac'), 'Unknown')
 
     def test_oui_downloader_tries_fallback_urls(self):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1792,6 +1792,8 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertNotIn(b'href="#network-device-scan"', response.data)
         self.assertIn(b'Continuous passive capture', response.data)
         self.assertIn(b'data-passive-monitor-toggle', response.data)
+        self.assertIn(b'data-passive-monitor-mode', response.data)
+        self.assertIn(b'Live packet capture', response.data)
         self.assertIn(b'Passive-only analytics', response.data)
         self.assertIn(b'data-passive-analytics-panel', response.data)
         self.assertIn(b'Network Device Scan', response.data)
@@ -1860,12 +1862,15 @@ class RouteSmokeTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'data-passive-monitor-toggle', response.data)
+        self.assertIn(b'data-passive-monitor-mode', response.data)
+        self.assertIn(b'Live packet capture', response.data)
         self.assertIn(b'Passive-only analytics', response.data)
         self.assertIn(b'data-passive-analytics-panel', response.data)
         with open('static/js/network_scan.js') as handle:
             js = handle.read()
         self.assertIn('/passive-monitor/status', js)
         self.assertIn('/passive-monitor/toggle', js)
+        self.assertIn("mode: mode", js)
         self.assertIn('/passive-analytics.json', js)
         self.assertIn(b'The app does not send probe packets for this mode', response.data)
 
@@ -1895,6 +1900,44 @@ class RouteSmokeTest(unittest.TestCase):
             'selectedInterface': 'wlan0',
             'enabled': '',
             'interval': '5',
+        })
+        self.assertFalse(response.get_json()['status']['enabled'])
+
+    @patch('app.packet_passive_scan')
+    def test_passive_monitor_packet_mode_records_packet_observations(self, packet_scan):
+        app_module.device_inventory.clear()
+        app_module.passive_monitor_jobs.clear()
+        app_module.passive_observation_analytics.clear()
+        packet_scan.return_value = [{'ip': '192.168.20.77', 'mac': 'AA:BB:CC:DD:EE:77'}]
+
+        response = self.client.post('/passive-monitor/toggle', data={
+            'selectedInterface': 'wlan0',
+            'enabled': 'on',
+            'interval': '1',
+            'mode': 'packet',
+        })
+
+        self.assertEqual(response.status_code, 200)
+        status = response.get_json()['status']
+        self.assertTrue(status['enabled'])
+        self.assertEqual(status['mode'], 'packet')
+        self.assertEqual(status['interval'], 1)
+        for _ in range(20):
+            if app_module.find_inventory_device('192.168.20.77'):
+                break
+            time.sleep(0.05)
+        device = app_module.find_inventory_device('192.168.20.77')
+        self.assertIsNotNone(device)
+        self.assertIn('passive-packet-monitor', device['sources'])
+
+        response = self.client.get('/passive-monitor/status?selectedInterface=wlan0')
+        self.assertEqual(response.get_json()['status']['mode'], 'packet')
+
+        response = self.client.post('/passive-monitor/toggle', data={
+            'selectedInterface': 'wlan0',
+            'enabled': '',
+            'interval': '1',
+            'mode': 'packet',
         })
         self.assertFalse(response.get_json()['status']['enabled'])
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,3 +1,6 @@
+import json
+import os
+import tempfile
 import time
 import unittest
 from types import SimpleNamespace
@@ -34,6 +37,7 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'Project Roadmap', response.data)
         self.assertIn(b'Device inventory page', response.data)
+        self.assertIn(b'Persistent local inventory state', response.data)
         self.assertIn(b'Bluetooth action checklist', response.data)
         self.assertIn(b'WPS exposure checks', response.data)
         self.assertNotIn(b'Authorization guardrails', response.data)
@@ -1360,6 +1364,35 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertEqual(response.data.count(b'Tools scan'), 1)
         self.assertIn(b'Export devices + ports', response.data)
         self.assertIn(b'Import devices + ports', response.data)
+
+    def test_runtime_state_persists_inventory_ports_labels_and_profiles(self):
+        app_module.device_inventory.clear()
+        app_module.client_timelines.clear()
+        app_module.wireless_network_labels.clear()
+        app_module.watched_clients.clear()
+        app_module.scheduled_client_checks.clear()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            state_path = os.path.join(tmpdir, 'runtime_state.json')
+            with patch.object(app_module.persistence_service, 'state_path', return_value=state_path):
+                app_module.record_inventory_devices([
+                    {'ip': '192.168.90.10', 'mac': 'b8:27:eb:90:00:10', 'interfaces': ['wlan0']},
+                ], 'active-scan', 'wlan0')
+                app_module.record_device_open_ports('192.168.90.10', [
+                    {'port': 80, 'service': 'HTTP', 'description': 'Web service'},
+                ])
+                app_module.update_client_metadata('192.168.90.10', {'tags': 'trusted', 'notes': 'Do not rescan heavily.'})
+                app_module.wireless_network_labels['wlan0|TrainingNet||b8:27:eb:90:00:10'] = 'Living room TV'
+                app_module.save_runtime_state('test')
+
+            with open(state_path, encoding='utf-8') as handle:
+                payload = json.load(handle)
+
+        device = next(item for item in payload['device_inventory'].values() if item.get('ip') == '192.168.90.10')
+        self.assertEqual(device['open_ports'], [80])
+        self.assertEqual(device['client_tags'], ['trusted'])
+        self.assertEqual(payload['wireless_network_labels']['wlan0|TrainingNet||b8:27:eb:90:00:10'], 'Living room TV')
+        self.assertIn('192.168.90.10', payload['client_timelines'])
 
     def test_inventory_export_and_import_preserves_open_ports(self):
         app_module.device_inventory.clear()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1733,6 +1733,8 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertNotIn(b'href="#network-device-scan"', response.data)
         self.assertIn(b'Continuous passive capture', response.data)
         self.assertIn(b'data-passive-monitor-toggle', response.data)
+        self.assertIn(b'Passive-only analytics', response.data)
+        self.assertIn(b'data-passive-analytics-panel', response.data)
         self.assertIn(b'Network Device Scan', response.data)
         self.assertIn(b'id="comprehensive-scan-btn"', response.data)
         self.assertIn(b'<option value="wlan0" selected>', response.data)
@@ -1790,6 +1792,7 @@ class RouteSmokeTest(unittest.TestCase):
         app_module.wireless_network_client_cache.clear()
         app_module.wireless_network_labels.clear()
         app_module.passive_monitor_jobs.clear()
+        app_module.passive_observation_analytics.clear()
         app_module.record_inventory_devices([
             {'ip': '192.168.20.10', 'mac': 'AA:BB:CC:DD:EE:10', 'hostname': 'Camera'}
         ], 'passive-monitor', 'wlan0')
@@ -1798,10 +1801,13 @@ class RouteSmokeTest(unittest.TestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertIn(b'data-passive-monitor-toggle', response.data)
+        self.assertIn(b'Passive-only analytics', response.data)
+        self.assertIn(b'data-passive-analytics-panel', response.data)
         with open('static/js/network_scan.js') as handle:
             js = handle.read()
         self.assertIn('/passive-monitor/status', js)
         self.assertIn('/passive-monitor/toggle', js)
+        self.assertIn('/passive-analytics.json', js)
         self.assertIn(b'The app does not send probe packets for this mode', response.data)
 
     @patch('app.passive_scan')
@@ -1832,6 +1838,31 @@ class RouteSmokeTest(unittest.TestCase):
             'interval': '5',
         })
         self.assertFalse(response.get_json()['status']['enabled'])
+
+    @patch('app.passive_scan')
+    def test_passive_scan_records_passive_only_analytics_and_quiet_devices(self, passive):
+        app_module.device_inventory.clear()
+        app_module.passive_observation_analytics.clear()
+        passive.return_value = [{'ip': '192.168.20.55', 'mac': 'AA:BB:CC:DD:EE:55'}]
+
+        response = self.client.post('/passive-scan', data={'selectedInterface': 'wlan0'})
+        self.assertEqual(response.status_code, 200)
+        analytics = response.get_json()['analytics']
+        self.assertEqual(analytics['known_device_count'], 1)
+        self.assertEqual(analytics['active_device_count'], 1)
+        self.assertEqual(analytics['recently_disappeared_count'], 0)
+
+        passive.return_value = []
+        response = self.client.post('/passive-scan', data={'selectedInterface': 'wlan0'})
+        self.assertEqual(response.status_code, 200)
+        analytics = response.get_json()['analytics']
+        self.assertEqual(analytics['known_device_count'], 1)
+        self.assertEqual(analytics['active_device_count'], 0)
+        self.assertEqual(analytics['recently_disappeared_count'], 1)
+
+        response = self.client.get('/passive-analytics.json?selectedInterface=wlan0')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()['analytics']['recently_disappeared'][0]['ip'], '192.168.20.55')
 
     @patch('scripts.wifi.utils.get_network_detail')
     def test_wireless_network_detail_persists_clients_between_reloads(self, get_detail):

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1982,7 +1982,7 @@ class RouteSmokeTest(unittest.TestCase):
             'wps_access_points': 0,
             'ap_groups': [],
             'access_points': [],
-            'clients': [],
+            'clients': [{'ip': '192.168.50.22', 'mac': '48:b0:2d:ef:ec:f2'}],
         }
 
         response = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
@@ -2087,18 +2087,79 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'Roku, Inc.', response.data)
         self.assertNotIn(b'<i class="fa-solid fa-industry"></i> Unknown', response.data)
 
-    def test_wireless_network_clients_json_returns_persisted_device_list(self):
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_clients_json_returns_network_scoped_cache_only(self, get_detail):
         app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
         app_module.record_inventory_devices([
             {'ip': '192.168.77.10', 'mac': '48:b0:2d:ef:77:10', 'manufacturer': 'ClientCo', 'interfaces': ['wlan0']},
         ], 'active-scan', 'wlan0')
+        get_detail.return_value = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'access_points': [],
+            'clients': [],
+            'interface': 'wlan0',
+        }
 
-        response = self.client.get('/wireless/network/clients.json?interface=wlan0&ssid=TrainingNet')
+        response = self.client.get('/wireless/network/clients.json?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
 
         self.assertEqual(response.status_code, 200)
         payload = response.get_json()
-        self.assertTrue(any(client.get('ip') == '192.168.77.10' for client in payload['clients']))
-        self.assertGreaterEqual(payload['client_count'], 1)
+        self.assertFalse(any(client.get('ip') == '192.168.77.10' for client in payload['clients']))
+        self.assertEqual(payload['client_count'], 0)
+
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_pages_do_not_leak_clients_between_ssids(self, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        network_a = {
+            'ssid': 'TrainingNet',
+            'bssid': 'aa:bb:cc:dd:ee:ff',
+            'security': 'WPA2-Personal',
+            'access_points': [],
+            'clients': [{'ip': '192.168.77.20', 'mac': '8c:49:62:bd:7d:37'}],
+            'interface': 'wlan0',
+        }
+        network_b = {**network_a, 'ssid': 'GuestNet', 'bssid': '11:22:33:44:55:66', 'clients': []}
+        get_detail.side_effect = [network_a, network_b]
+
+        first = self.client.get('/wireless/network?interface=wlan0&ssid=TrainingNet&bssid=aa:bb:cc:dd:ee:ff')
+        second = self.client.get('/wireless/network?interface=wlan0&ssid=GuestNet&bssid=11:22:33:44:55:66')
+
+        self.assertEqual(first.status_code, 200)
+        self.assertEqual(second.status_code, 200)
+        self.assertIn(b'192.168.77.20', first.data)
+        self.assertNotIn(b'192.168.77.20', second.data)
+        self.assertNotIn(b'8c:49:62:bd:7d:37', second.data)
+
+    @patch('scripts.wifi.utils.get_network_detail')
+    def test_wireless_network_prunes_legacy_inventory_only_cache_entries(self, get_detail):
+        app_module.device_inventory.clear()
+        app_module.wireless_network_client_cache.clear()
+        app_module.wireless_network_client_cache[(
+            'wlan0', 'GuestNet', '11:22:33:44:55:66'
+        )] = [{
+            'ip': '192.168.77.20',
+            'mac': '8c:49:62:bd:7d:37',
+            'source': 'inventory',
+            'currently_visible': False,
+        }]
+        get_detail.return_value = {
+            'ssid': 'GuestNet',
+            'bssid': '11:22:33:44:55:66',
+            'security': 'WPA2-Personal',
+            'access_points': [],
+            'clients': [],
+            'interface': 'wlan0',
+        }
+
+        response = self.client.get('/wireless/network?interface=wlan0&ssid=GuestNet&bssid=11:22:33:44:55:66')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertNotIn(b'192.168.77.20', response.data)
+        self.assertNotIn(b'8c:49:62:bd:7d:37', response.data)
 
     def test_wireless_network_cards_link_to_device_scan_panel(self):
         js = open('static/js/wireless-adapters.js').read()

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -917,6 +917,25 @@ class RouteSmokeTest(unittest.TestCase):
             with open(path, encoding='utf-8') as handle:
                 self.assertIn('8c:49:62,Roku, Inc.', handle.read())
 
+    @patch('routes.capabilities.refresh_oui_database')
+    @patch('routes.capabilities.download_oui_database')
+    def test_capabilities_can_download_full_oui_database(self, download_oui, refresh_oui):
+        download_oui.return_value = ('/tmp/oui_db.csv', 35000)
+        refresh_oui.return_value = {'loaded': True, 'entries': 35000, 'coverage': 'full', 'needs_refresh': False}
+
+        response = self.client.post('/capabilities/update-oui-database', data={'confirm': 'download'})
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload['count'], 35000)
+        self.assertEqual(payload['oui_database']['coverage'], 'full')
+
+    def test_capabilities_oui_download_requires_confirmation(self):
+        response = self.client.post('/capabilities/update-oui-database', data={})
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('Confirm full IEEE OUI database download', response.get_json()['message'])
+
     def test_capabilities_page_shows_oui_database_health(self):
         response = self.client.get('/capabilities')
 
@@ -925,6 +944,7 @@ class RouteSmokeTest(unittest.TestCase):
         self.assertIn(b'Fallback entries', response.data)
         self.assertIn(b'python scripts/update_oui_db.py', response.data)
         self.assertIn(b'Coverage', response.data)
+        self.assertIn(b'Download full OUI database', response.data)
 
     def test_inventory_page_renders_manufacturer_insights(self):
         app_module.device_inventory.clear()


### PR DESCRIPTION
### Motivation
- Consolidate inventory, port-scan, diagnostics, and wireless-client logic out of route handlers into isolated service modules to simplify route code and enable richer device intelligence workflows.
- Improve local OUI/vendor lookup resiliency and add browser-based HTTP previewing for saved web services.
- Provide operator-friendly, non-destructive lab tooling (PineAP, evil-twin, handshake catalog) with explicit authorization checks and guidance.
- Surface richer client profiles, scheduled checks, watchlists, and export/import for inventory and saved port profiles.

### Description
- Extracted core helpers into `services/` modules: `inventory.py`, `port_scans.py`, `diagnostics.py`, `device_intel.py`, and `wireless_clients.py`, and wired them into `app.py` to replace in-place logic for merging devices, port-scan job handling, ping/sweep, route diagnostics, and wireless client caching.
- Added device intelligence helpers in `services/device_intel.py` for role inference, favicon/TLS metadata, and MAC privacy detection, and used them to enrich inventory and saved service details.
- Improved OUI handling in `scripts/interfaceTools.py` by adding a compact builtin fallback DB and `oui_database_status()` along with tolerant CSV parsing; surfaced OUI status in the capabilities UI and added host dependency installation for browser screenshot tooling in `scripts/capabilities.py` plus a new UI action route in `routes/capabilities.py`.
- Implemented HTTP inspection and thumbnail preview support (`inspect_http_services`, `capture_http_preview_thumbnail`) and web-service enrichment (`enrich_web_port_metadata`) to attach `web_url`, thumbnails, titles, favicon/TLS hints to port details.
- Added comprehensive network device scan workflow combining active ARP/ping, passive observations, ARP/neighbor tables, optional ping sweeps, mDNS/UPnP/LLDP discovery, de-duplication and inventory merge logic (`comprehensive_network_device_scan`).
- Introduced non-destructive Red Team lab forms and handlers: PineAP-style lab (`/pineap-lab`), evil-twin/captive-portal plan/start/cleanup (`/evil-twin-lab`), and handshake evidence cataloging with validation and exports (`/handshake-lab`, `/handshake-lab.<fmt>`), with request validation and recorded guidance.
- Implemented client-focused features: display-name detection, timeline events, client health summary, scheduled checks, watchlist alerts, profile export, metadata editing, baseline saving/diffing, service fingerprinting and HTTP inspection endpoints and templates.
- Reworked port-scan job state and execution into `services/port_scans.py`, and simplified job snapshot/update flows in `app.py` to use the service API; port-scan route now persists open ports into device profiles.
- Added many UI assets and pages: `diagnostics.html`, `advanced_diagnostics.html`, `service_discovery.html`, client/service detail enhancements, wireless network device lists with persistent client caches, new red-team lab partials, JS modules (`network_scan.js`, `ip_client.js`, `diagnostics.js`, `service-discovery.js`, etc.), and CSS updates for new cards/previews.
- Inventory import/export support implemented via `services/inventory.py`, plus endpoints `/inventory/export.json` and `/inventory/import` and template changes to surface import results.

### Testing
- Ran the route smoke/unit tests in `tests/test_routes.py` exercising the new pages, scan flows, lab handlers, import/export, and client/profile features; all assertions in that test module passed. 
- Exercised diagnostic helpers with unit-level mocks for `ping`, `ip route` parsing, `avahi-browse`/`lldpctl` outputs, `iperf3` and `snmpwalk` calls via the existing test coverage in `tests/test_routes.py`, and validated JSON/CSV exports and inventory merges succeeded.  
- Manual sanity checks invoked new endpoints (`/diagnostics`, `/service-discovery`, `/advanced-diagnostics`, `/comprehensive-scan`, `/evil-twin-lab`, `/pineap-lab`, `/handshake-lab`) via the updated tests to confirm validation, recording, and export behaviors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5aaa99031c832fb77b34c55536bb59)