### PR TITLE
Add Train Controller (DCC-EX) integration with UI, service, and tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.py[cod]
 *$py.class
 .pytest_cache/
+instance/train_controller.json

--- a/README.md
+++ b/README.md
@@ -1,5 +1,48 @@
 # Mobile Router Web Interface
 
+## Train Controller integration
+
+Mobile Router includes a native, tabbed DCC-EX workspace at `/train-controller`.
+It supports editable layout, controller, and engine rosters; setup and emergency
+commands; bounded throttles; lights and horn functions; cancellable background
+engine discovery with selective roster import; collapsible controller cards;
+action history and Evidence Vault capture; and a persistent guided Training mode
+with trophies. This is a clean-room Python implementation; it does not embed or
+run the source Node app.
+
+Hardware commands are disabled by default. After connecting Mobile Router to an
+authorized model-railway network, enable them with:
+
+```bash
+export TRAIN_CONTROLLER_ENABLED=1
+export TRAIN_CONTROLLER_PORT=2560       # optional
+export TRAIN_CONTROLLER_TIMEOUT=2       # optional, seconds
+```
+
+State is stored in `instance/train_controller.json`. Raw DCC commands are never
+accepted from the browser: supported commands are validated and generated in the
+service module, and every hardware request requires authorization confirmation.
+
+### Source compatibility inventory
+
+The inspected source is an Express/EJS app that stores layouts, TCP controller
+addresses, names, and engine rosters in `config.json`. It provides setup,
+emergency stop, cab scanning (1–127), speed/direction, lights, horn, stop, inline
+roster management, themes, status toasts, and controller-card collapse state. Its
+runtime dependencies are Express and EJS; TCP uses Node's standard library. Its
+two Mocha/Supertest tests cover layout naming and basic roster CRUD. The attached
+checkout contains no license file or package license field, so no source code or
+assets were copied.
+
+The protocol behavior and roster model were suitable to reimplement. Express
+routes, EJS templates, CSS/theme code, browser persistence, and unimplemented
+“Red Team” buttons required replacement with Mobile Router's Flask, Jinja,
+Bootstrap, capability, safety, history, and server-persistence patterns. The
+DCC-EX TCP endpoint is LAN/hardware-specific, unauthenticated, unencrypted, and
+can move physical trains; deploy only on an authorized trusted network. Node
+dependencies are not added. Hardware behavior is mock-tested and never simulated
+in the UI.
+
 This project exposes a Flask based web UI for interacting with network interfaces and
 running basic red team tools. It is intended for local use while experimenting with
 wireless and wired adapters.

--- a/app.py
+++ b/app.py
@@ -1364,6 +1364,7 @@ def roadmap_page():
     )
 
 
+app.config['TRAIN_CONTROLLER_EVIDENCE_RECORDER'] = create_evidence_record
 register_blueprints(app, current_context)
 
 

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -1,9 +1,11 @@
 from .bluetooth_phone import create_bluetooth_phone_blueprint
 from .capabilities import create_capabilities_blueprint
 from .minecraft import create_minecraft_blueprint
+from .train_controller import create_train_controller_blueprint
 
 
 def register_blueprints(app, context_provider):
     app.register_blueprint(create_bluetooth_phone_blueprint(context_provider))
     app.register_blueprint(create_capabilities_blueprint(context_provider))
     app.register_blueprint(create_minecraft_blueprint(context_provider))
+    app.register_blueprint(create_train_controller_blueprint(context_provider))

--- a/routes/train_controller.py
+++ b/routes/train_controller.py
@@ -1,0 +1,201 @@
+import os
+import json
+import threading
+import uuid
+
+from flask import Blueprint, current_app, jsonify, render_template, request
+
+from scripts.train_controller import TRAINING_STEPS, TrainControllerError, TrainControllerService
+
+
+def create_train_controller_blueprint(context_provider):
+    blueprint = Blueprint("train_controller", __name__)
+    scan_jobs = {}
+    scan_jobs_lock = threading.Lock()
+
+    def service():
+        configured = current_app.config.get("TRAIN_CONTROLLER_SERVICE")
+        if configured:
+            return configured
+        return TrainControllerService(os.path.join(current_app.instance_path, "train_controller.json"))
+
+    def payload():
+        return request.get_json(silent=True) or request.form
+
+    def error_response(error, unavailable=False):
+        return jsonify({"status": "error", "message": str(error)}), 503 if unavailable else 400
+
+    @blueprint.get("/train-controller")
+    def page():
+        train_service = service()
+        return render_template(
+            "train_controller.html", title="Train Controller", train_state=train_service.state(),
+            train_capability=train_service.capability(), training_steps=TRAINING_STEPS, **context_provider()
+        )
+
+    @blueprint.get("/api/train-controller")
+    def get_state():
+        train_service = service()
+        return jsonify({"status": "success", "state": train_service.state(), "capability": train_service.capability()})
+
+    @blueprint.post("/api/train-controller/mode")
+    def mode():
+        try:
+            state = service().set_mode(payload().get("mode"))
+            return jsonify({"status": "success", "state": state})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.put("/api/train-controller/layout")
+    def update_layout():
+        try:
+            return jsonify({"status": "success", "state": service().set_layout_name(payload().get("name", ""))})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.post("/api/train-controller/controllers")
+    def add_controller():
+        data = payload()
+        try:
+            state = service().add_controller(data.get("ip"), data.get("name", ""))
+            return jsonify({"status": "success", "state": state}), 201
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.delete("/api/train-controller/controllers/<controller_id>")
+    def delete_controller(controller_id):
+        try:
+            return jsonify({"status": "success", "state": service().delete_controller(controller_id)})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.put("/api/train-controller/controllers/<controller_id>")
+    def update_controller(controller_id):
+        data = payload()
+        try:
+            state = service().update_controller(controller_id, data.get("ip"), data.get("name", ""))
+            return jsonify({"status": "success", "state": state})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.post("/api/train-controller/controllers/<controller_id>/engines")
+    def add_engine(controller_id):
+        data = payload()
+        try:
+            state = service().add_engine(controller_id, data.get("address"), data.get("name", ""))
+            return jsonify({"status": "success", "state": state}), 201
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.delete("/api/train-controller/controllers/<controller_id>/engines/<engine_id>")
+    def delete_engine(controller_id, engine_id):
+        try:
+            return jsonify({"status": "success", "state": service().delete_engine(controller_id, engine_id)})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.put("/api/train-controller/controllers/<controller_id>/engines/<engine_id>")
+    def update_engine(controller_id, engine_id):
+        data = payload()
+        try:
+            state = service().update_engine(controller_id, engine_id, data.get("address"), data.get("name", ""))
+            return jsonify({"status": "success", "state": state})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.post("/api/train-controller/controllers/<controller_id>/engines/import")
+    def import_engines(controller_id):
+        try:
+            state = service().import_engines(controller_id, payload().get("addresses"))
+            return jsonify({"status": "success", "state": state})
+        except TrainControllerError as error:
+            return error_response(error)
+
+    @blueprint.post("/api/train-controller/controllers/<controller_id>/actions")
+    def action(controller_id):
+        data = payload()
+        if str(data.get("authorized", "")).lower() != "true":
+            return error_response(TrainControllerError("Authorization confirmation is required for hardware commands"))
+        train_service = service()
+        try:
+            result = train_service.run_action(controller_id, data.get("action"), data.get("engine_id"), data.get("speed"))
+            return jsonify({"status": "success", "result": result, "state": train_service.state()})
+        except TrainControllerError as error:
+            return error_response(error, unavailable=not train_service.capability()["available"])
+
+    @blueprint.post("/api/train-controller/controllers/<controller_id>/scan-jobs")
+    def start_scan(controller_id):
+        data = payload()
+        if str(data.get("authorized", "")).lower() != "true":
+            return error_response(TrainControllerError("Authorization confirmation is required for network scanning"))
+        train_service = service()
+        try:
+            if not train_service.capability()["available"]:
+                raise TrainControllerError(train_service.capability()["reason"])
+            maximum = int(data.get("maximum", 127))
+            if not 1 <= maximum <= 127:
+                raise TrainControllerError("Scan maximum must be between 1 and 127")
+            train_service._controller(train_service.state(), controller_id)
+        except (TrainControllerError, ValueError) as error:
+            return error_response(error, unavailable=not train_service.capability()["available"])
+
+        job_id = uuid.uuid4().hex
+        with scan_jobs_lock:
+            scan_jobs[job_id] = {"id": job_id, "controller_id": controller_id, "status": "queued", "current": 0, "maximum": maximum, "progress": 0, "engines": [], "cancel_requested": False, "error": None}
+
+        def run_scan():
+            def progress(current, total, engines):
+                with scan_jobs_lock:
+                    job = scan_jobs[job_id]
+                    job.update(status="running", current=current, progress=round(current * 100 / total), engines=engines)
+
+            def cancelled():
+                with scan_jobs_lock:
+                    return scan_jobs[job_id]["cancel_requested"]
+
+            try:
+                engines = train_service.scan_engines(controller_id, maximum, progress, cancelled)
+                with scan_jobs_lock:
+                    scan_jobs[job_id].update(status="completed", current=maximum, progress=100, engines=engines)
+            except TrainControllerError as error:
+                with scan_jobs_lock:
+                    status = "cancelled" if scan_jobs[job_id]["cancel_requested"] else "failed"
+                    scan_jobs[job_id].update(status=status, error=str(error))
+
+        threading.Thread(target=run_scan, daemon=True, name=f"train-scan-{job_id[:8]}").start()
+        return jsonify({"status": "success", "job": dict(scan_jobs[job_id])}), 202
+
+    @blueprint.get("/api/train-controller/scan-jobs/<job_id>")
+    def scan_status(job_id):
+        with scan_jobs_lock:
+            job = scan_jobs.get(job_id)
+            if not job:
+                return jsonify({"status": "error", "message": "Engine scan job not found"}), 404
+            return jsonify({"status": "success", "job": dict(job)})
+
+    @blueprint.post("/api/train-controller/scan-jobs/<job_id>/cancel")
+    def cancel_scan(job_id):
+        with scan_jobs_lock:
+            job = scan_jobs.get(job_id)
+            if not job:
+                return jsonify({"status": "error", "message": "Engine scan job not found"}), 404
+            if job["status"] not in {"queued", "running"}:
+                return error_response(TrainControllerError("Only queued or running scans can be cancelled"))
+            job["cancel_requested"] = True
+            return jsonify({"status": "success", "job": dict(job)})
+
+    @blueprint.post("/api/train-controller/evidence")
+    def save_evidence():
+        recorder = current_app.config.get("TRAIN_CONTROLLER_EVIDENCE_RECORDER")
+        if not recorder:
+            return jsonify({"status": "error", "message": "Evidence integration is unavailable"}), 503
+        state = service().state()
+        record = recorder(
+            title=f"Train Controller history — {state['layout_name'] or 'Layout'}",
+            category="scan-output", source="Train Controller",
+            notes="Validated DCC-EX hardware action and discovery history.",
+            content=json.dumps(state["history"], indent=2),
+        )
+        return jsonify({"status": "success", "record": record}), 201
+
+    return blueprint

--- a/scripts/train_controller.py
+++ b/scripts/train_controller.py
@@ -1,0 +1,298 @@
+"""Native DCC-EX controller integration.
+
+The module deliberately owns persistence, validation and TCP protocol details so
+the web layer never accepts arbitrary DCC commands or writes configuration.
+"""
+from __future__ import annotations
+
+import ipaddress
+import json
+import os
+import socket
+import threading
+import uuid
+from copy import deepcopy
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+class TrainControllerError(ValueError):
+    """A safe, user-facing train controller error."""
+
+
+TRAINING_STEPS = (
+    ("add_controller", "Add a controller", "Record the address of an authorized DCC-EX command station."),
+    ("setup", "Initialize the controller", "Connect and send the standard track setup sequence."),
+    ("add_engine", "Add an engine", "Add a DCC cab address assigned to this controller."),
+    ("lights", "Turn on lights", "Send the first safe locomotive function command."),
+    ("throttle", "Move the engine", "Use a bounded speed control, then return it to zero."),
+)
+
+
+class TrainControllerService:
+    def __init__(self, data_path, enabled=None, port=None, timeout=None, socket_factory=None):
+        self.data_path = Path(data_path)
+        self.enabled = _env_bool("TRAIN_CONTROLLER_ENABLED") if enabled is None else bool(enabled)
+        self.port = int(port or os.getenv("TRAIN_CONTROLLER_PORT", "2560"))
+        self.timeout = float(timeout or os.getenv("TRAIN_CONTROLLER_TIMEOUT", "2"))
+        self.socket_factory = socket_factory or socket.create_connection
+        self._lock = threading.RLock()
+
+    def capability(self):
+        reason = None if self.enabled else "Set TRAIN_CONTROLLER_ENABLED=1 after connecting to an authorized DCC-EX controller network."
+        return {"available": self.enabled, "reason": reason, "port": self.port, "protocol": "DCC-EX TCP"}
+
+    def state(self):
+        with self._lock:
+            return deepcopy(self._load())
+
+    def set_mode(self, mode):
+        if mode not in {"full", "training"}:
+            raise TrainControllerError("Mode must be full or training")
+        return self._mutate(lambda data: data.update(mode=mode))
+
+    def set_layout_name(self, name):
+        name = _short_text(name, "Layout name")
+        return self._mutate(lambda data: data.update(layout_name=name))
+
+    def add_controller(self, ip, name=""):
+        address = _valid_ip(ip)
+        name = _short_text(name, "Controller name")
+        def change(data):
+            if any(item["ip"] == address for item in data["controllers"]):
+                raise TrainControllerError("Controller already exists")
+            data["controllers"].append({"id": uuid.uuid4().hex[:12], "ip": address, "name": name, "engines": []})
+            self._complete(data, "add_controller")
+        return self._mutate(change)
+
+    def delete_controller(self, controller_id):
+        def change(data):
+            controller = self._controller(data, controller_id)
+            data["controllers"].remove(controller)
+        return self._mutate(change)
+
+    def update_controller(self, controller_id, ip, name=""):
+        address = _valid_ip(ip)
+        name = _short_text(name, "Controller name")
+
+        def change(data):
+            controller = self._controller(data, controller_id)
+            if any(item["id"] != controller_id and item["ip"] == address for item in data["controllers"]):
+                raise TrainControllerError("Controller already exists")
+            controller.update(ip=address, name=name)
+
+        return self._mutate(change)
+
+    def add_engine(self, controller_id, address, name=""):
+        cab = _cab(address)
+        name = _short_text(name, "Engine name")
+        def change(data):
+            if data["mode"] == "training" and not self._step_unlocked(data, "add_engine"):
+                raise TrainControllerError("Complete the current Training Guide step before adding an engine")
+            controller = self._controller(data, controller_id)
+            if any(engine["address"] == cab for engine in controller["engines"]):
+                raise TrainControllerError("Engine address already exists on this controller")
+            controller["engines"].append({"id": uuid.uuid4().hex[:12], "address": cab, "name": name})
+            self._complete(data, "add_engine")
+        return self._mutate(change)
+
+    def delete_engine(self, controller_id, engine_id):
+        def change(data):
+            controller = self._controller(data, controller_id)
+            engine = self._engine(controller, engine_id)
+            controller["engines"].remove(engine)
+        return self._mutate(change)
+
+    def update_engine(self, controller_id, engine_id, address, name=""):
+        cab = _cab(address)
+        name = _short_text(name, "Engine name")
+
+        def change(data):
+            controller = self._controller(data, controller_id)
+            engine = self._engine(controller, engine_id)
+            if any(item["id"] != engine_id and item["address"] == cab for item in controller["engines"]):
+                raise TrainControllerError("Engine address already exists on this controller")
+            engine.update(address=cab, name=name)
+
+        return self._mutate(change)
+
+    def import_engines(self, controller_id, addresses):
+        if not isinstance(addresses, list):
+            raise TrainControllerError("Engine addresses must be a list")
+        cabs = list(dict.fromkeys(_cab(value) for value in addresses))
+        if len(cabs) > 127:
+            raise TrainControllerError("At most 127 engine addresses can be imported")
+
+        def change(data):
+            controller = self._controller(data, controller_id)
+            existing = {engine["address"] for engine in controller["engines"]}
+            for cab in cabs:
+                if cab not in existing:
+                    controller["engines"].append({"id": uuid.uuid4().hex[:12], "address": cab, "name": ""})
+            if cabs:
+                self._complete(data, "add_engine")
+
+        return self._mutate(change)
+
+    def run_action(self, controller_id, action, engine_id=None, speed=None):
+        if not self.enabled:
+            raise TrainControllerError(self.capability()["reason"])
+        data = self.state()
+        controller = self._controller(data, controller_id)
+        required_step = {"setup": "setup", "lights": "lights", "throttle": "throttle"}.get(action)
+        if data["mode"] == "training" and action == "horn" and "throttle" not in data["training"]["completed"]:
+            raise TrainControllerError("Complete the Training Guide before using the horn")
+        if data["mode"] == "training" and required_step and not self._step_unlocked(data, required_step):
+            raise TrainControllerError("Complete the current Training Guide step before using this control")
+        if action == "setup":
+            commands = ["<1>", "<1 MAIN>", "<1 PROG>", "<1 JOIN>"]
+        elif action == "emergency_stop":
+            commands = ["<!>"]
+        else:
+            engine = self._engine(controller, engine_id)
+            cab = engine["address"]
+            if action == "lights":
+                commands = [f"<f {cab} 0 1>"]
+            elif action == "horn":
+                commands = [f"<f {cab} 1 1>"]
+            elif action == "stop":
+                commands = [f"<t {cab} 0 1>"]
+            elif action == "throttle":
+                try:
+                    value = int(speed)
+                except (TypeError, ValueError):
+                    raise TrainControllerError("Speed must be an integer")
+                if not -127 <= value <= 127:
+                    raise TrainControllerError("Speed must be between -127 and 127")
+                commands = [f"<t {cab} {abs(value)} {1 if value >= 0 else 0}>"]
+            else:
+                raise TrainControllerError("Unsupported train action")
+        response = self._send(controller["ip"], commands)
+        def record(current):
+            self._complete(current, required_step)
+            current["history"].insert(0, {"at": _now(), "controller": controller_id, "engine": engine_id, "action": action, "status": "success"})
+            del current["history"][100:]
+        self._mutate(record)
+        return {"action": action, "response": response}
+
+    def scan_engines(self, controller_id, maximum=127, progress=None, cancelled=None):
+        if not self.enabled:
+            raise TrainControllerError(self.capability()["reason"])
+        data = self.state()
+        controller = self._controller(data, controller_id)
+        maximum = int(maximum)
+        if not 1 <= maximum <= 127:
+            raise TrainControllerError("Scan maximum must be between 1 and 127")
+        found = []
+        for cab in range(1, maximum + 1):
+            if cancelled and cancelled():
+                raise TrainControllerError("Engine scan was cancelled")
+            reply = self._send(controller["ip"], [f"<s {cab} 1 128 0>"])
+            if f"<l {cab} " in reply:
+                found.append(cab)
+            if progress:
+                progress(cab, maximum, list(found))
+        self._mutate(lambda current: current["history"].insert(0, {"at": _now(), "controller": controller_id, "action": "scan", "status": "success", "engines": found}))
+        return found
+
+    def _send(self, ip, commands):
+        try:
+            connection = self.socket_factory((ip, self.port), self.timeout)
+            with connection:
+                connection.settimeout(self.timeout)
+                connection.sendall("".join(command + "\n" for command in commands).encode("ascii"))
+                try:
+                    return connection.recv(4096).decode("ascii", "replace")
+                except socket.timeout:
+                    return ""
+        except OSError as error:
+            raise TrainControllerError(f"Controller connection failed: {error}")
+
+    def _load(self):
+        if not self.data_path.exists():
+            return self._default()
+        try:
+            data = json.loads(self.data_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise TrainControllerError(f"Train controller data could not be loaded: {error}")
+        default = self._default()
+        for key, value in default.items():
+            data.setdefault(key, value)
+        return data
+
+    def _mutate(self, callback):
+        with self._lock:
+            data = self._load()
+            callback(data)
+            self.data_path.parent.mkdir(parents=True, exist_ok=True)
+            temporary = self.data_path.with_suffix(".tmp")
+            temporary.write_text(json.dumps(data, indent=2), encoding="utf-8")
+            temporary.replace(self.data_path)
+            return deepcopy(data)
+
+    @staticmethod
+    def _default():
+        return {"version": 1, "layout_name": "", "mode": "full", "controllers": [], "history": [], "training": {"completed": [], "trophies": []}}
+
+    @staticmethod
+    def _controller(data, controller_id):
+        controller = next((item for item in data["controllers"] if item["id"] == controller_id), None)
+        if not controller:
+            raise TrainControllerError("Controller not found")
+        return controller
+
+    @staticmethod
+    def _engine(controller, engine_id):
+        engine = next((item for item in controller["engines"] if item["id"] == engine_id), None)
+        if not engine:
+            raise TrainControllerError("Engine not found on this controller")
+        return engine
+
+    @staticmethod
+    def _complete(data, step):
+        if not step:
+            return
+        completed = data["training"]["completed"]
+        if step not in completed:
+            completed.append(step)
+        trophy = {"add_controller": "Dispatcher", "setup": "Track Online", "add_engine": "Roster Builder", "lights": "First Lights", "throttle": "Qualified Driver"}.get(step)
+        if trophy and trophy not in data["training"]["trophies"]:
+            data["training"]["trophies"].append(trophy)
+
+    @staticmethod
+    def _step_unlocked(data, step):
+        names = [item[0] for item in TRAINING_STEPS]
+        index = names.index(step)
+        return index == 0 or names[index - 1] in data["training"]["completed"]
+
+
+def _env_bool(name):
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _valid_ip(value):
+    try:
+        return str(ipaddress.ip_address(str(value).strip()))
+    except ValueError:
+        raise TrainControllerError("A valid IPv4 or IPv6 controller address is required")
+
+
+def _cab(value):
+    try:
+        value = int(value)
+    except (TypeError, ValueError):
+        raise TrainControllerError("Engine address must be an integer")
+    if not 1 <= value <= 10239:
+        raise TrainControllerError("Engine address must be between 1 and 10239")
+    return value
+
+
+def _short_text(value, label):
+    value = str(value or "").strip()
+    if len(value) > 80:
+        raise TrainControllerError(f"{label} must be 80 characters or fewer")
+    return value
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")

--- a/static/css/train-controller.css
+++ b/static/css/train-controller.css
@@ -1,0 +1,127 @@
+.train-hero,
+.train-card-heading {
+  align-items: center;
+  display: flex;
+  gap: 1rem;
+  justify-content: space-between;
+}
+
+.train-mode {
+  white-space: nowrap;
+}
+
+.train-tabs {
+  flex-wrap: nowrap;
+  margin-top: 1rem;
+  overflow-x: auto;
+}
+
+.train-workspace > .tab-pane {
+  padding: 1rem 0;
+}
+
+.train-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+}
+
+.train-empty {
+  border: 1px dashed var(--theme-border, #bbb);
+  border-radius: .5rem;
+  color: var(--theme-muted, #666);
+  padding: 2rem;
+  text-align: center;
+}
+
+.train-engine {
+  min-width: 0;
+}
+
+.train-controller-summary {
+  cursor: pointer;
+  font-size: 1.15rem;
+  font-weight: 600;
+  list-style-position: inside;
+}
+
+.train-controller-summary span {
+  color: var(--theme-muted, #666);
+  float: right;
+  font-size: .8rem;
+  font-weight: 400;
+}
+
+.train-scan-row {
+  align-items: end;
+  display: grid;
+  gap: .75rem;
+  grid-template-columns: minmax(180px, 1fr) 110px auto;
+  margin-bottom: 1rem;
+}
+
+.train-engine-choices {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .5rem 1rem;
+  margin: 1rem 0;
+}
+
+.training-list li {
+  margin: .75rem 0;
+}
+
+.training-list li span {
+  display: block;
+}
+
+.training-list li.complete {
+  color: #218838;
+}
+
+.training-list li.complete strong::before {
+  content: '✓ ';
+}
+
+.train-training-mode .training-locked {
+  opacity: .35;
+}
+
+.train-training-mode .training-spotlight {
+  border-radius: .4rem;
+  box-shadow: 0 0 0 4px #ffc107;
+  position: relative;
+  z-index: 2;
+}
+
+.train-training-mode .training-spotlight::after {
+  background: #ffc107;
+  border-radius: .2rem;
+  color: #212529;
+  content: 'Current guided step';
+  font-size: .75rem;
+  padding: .15rem .4rem;
+  position: absolute;
+  right: 0;
+  top: -1.8rem;
+}
+
+@media (max-width: 600px) {
+  .train-hero,
+  .train-card-heading {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .train-mode {
+    width: 100%;
+  }
+
+  .train-mode .btn {
+    width: 48%;
+  }
+
+  .train-scan-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/static/js/train-controller.js
+++ b/static/js/train-controller.js
@@ -1,0 +1,170 @@
+(function () {
+  const state = window.trainControllerState;
+  const status = document.getElementById('train-status');
+  const scanOutput = document.getElementById('train-scan-job');
+  const stepOrder = ['add_controller', 'setup', 'add_engine', 'lights', 'throttle'];
+
+  function message(text, kind) {
+    status.textContent = text;
+    status.className = `alert alert-${kind || 'info'}`;
+  }
+
+  async function api(url, method, body) {
+    message('Working…', 'info');
+    const response = await fetch(url, {
+      method,
+      headers: {'Content-Type': 'application/json'},
+      body: body ? JSON.stringify(body) : undefined
+    });
+    const result = await response.json();
+    if (!response.ok) throw new Error(result.message || 'Request failed');
+    message('Completed successfully.', 'success');
+    return result;
+  }
+
+  async function refresh(task) {
+    try {
+      await task();
+      window.location.reload();
+    } catch (error) {
+      message(error.message, 'danger');
+    }
+  }
+
+  function authorized() {
+    return window.confirm('Confirm that you are authorized to control this model railway hardware.');
+  }
+
+  function formBody(form) {
+    return Object.fromEntries(new FormData(form));
+  }
+
+  document.querySelectorAll('.mode-button').forEach(button => button.addEventListener('click', () =>
+    refresh(() => api('/api/train-controller/mode', 'POST', {mode: button.dataset.mode}))
+  ));
+  document.getElementById('layout-name-form').addEventListener('submit', event => {
+    event.preventDefault();
+    refresh(() => api('/api/train-controller/layout', 'PUT', formBody(event.target)));
+  });
+  document.getElementById('add-controller-form').addEventListener('submit', event => {
+    event.preventDefault();
+    refresh(() => api('/api/train-controller/controllers', 'POST', formBody(event.target)));
+  });
+  document.querySelectorAll('.edit-controller-form').forEach(form => form.addEventListener('submit', event => {
+    event.preventDefault();
+    refresh(() => api(`/api/train-controller/controllers/${form.dataset.controller}`, 'PUT', formBody(form)));
+  }));
+  document.querySelectorAll('.add-engine-form').forEach(form => form.addEventListener('submit', event => {
+    event.preventDefault();
+    refresh(() => api(`/api/train-controller/controllers/${form.dataset.controller}/engines`, 'POST', formBody(form)));
+  }));
+  document.querySelectorAll('.edit-engine-form').forEach(form => form.addEventListener('submit', event => {
+    event.preventDefault();
+    refresh(() => api(`/api/train-controller/controllers/${form.dataset.controller}/engines/${form.dataset.engine}`, 'PUT', formBody(form)));
+  }));
+  document.querySelectorAll('.delete-controller').forEach(button => button.addEventListener('click', () => {
+    if (window.confirm('Delete this controller and its engine roster?')) {
+      refresh(() => api(`/api/train-controller/controllers/${button.dataset.controller}`, 'DELETE'));
+    }
+  }));
+  document.querySelectorAll('.delete-engine').forEach(button => button.addEventListener('click', () =>
+    refresh(() => api(`/api/train-controller/controllers/${button.dataset.controller}/engines/${button.dataset.engine}`, 'DELETE'))
+  ));
+  document.querySelectorAll('.train-action').forEach(button => button.addEventListener('click', () => {
+    if (!authorized()) return;
+    refresh(() => api(`/api/train-controller/controllers/${button.dataset.controller}/actions`, 'POST', {
+      action: button.dataset.action, engine_id: button.dataset.engine, authorized: true
+    }));
+  }));
+  document.querySelectorAll('.train-speed').forEach(slider => {
+    slider.addEventListener('input', () => {
+      document.getElementById(`speed-output-${slider.dataset.engine}`).value = slider.value;
+    });
+    slider.addEventListener('change', () => {
+      if (!authorized()) { slider.value = 0; return; }
+      refresh(() => api(`/api/train-controller/controllers/${slider.dataset.controller}/actions`, 'POST', {
+        action: 'throttle', engine_id: slider.dataset.engine, speed: slider.value, authorized: true
+      }));
+    });
+  });
+
+  document.querySelectorAll('.train-controller-panel').forEach(panel => {
+    const key = `train-controller-collapsed-${panel.dataset.controller}`;
+    panel.open = window.localStorage.getItem(key) !== 'true';
+    panel.addEventListener('toggle', () => window.localStorage.setItem(key, String(!panel.open)));
+  });
+
+  async function pollScan(jobId, controllerId) {
+    const result = await api(`/api/train-controller/scan-jobs/${jobId}`, 'GET');
+    const job = result.job;
+    scanOutput.innerHTML = `<div class="progress"><div class="progress-bar" style="width:${job.progress}%">${job.progress}%</div></div><p>Checked ${job.current} of ${job.maximum}; found ${job.engines.length}.</p>`;
+    if (['queued', 'running'].includes(job.status)) {
+      const cancel = document.createElement('button');
+      cancel.className = 'btn btn-sm btn-outline-danger';
+      cancel.textContent = 'Cancel scan';
+      cancel.addEventListener('click', () => api(`/api/train-controller/scan-jobs/${jobId}/cancel`, 'POST'));
+      scanOutput.appendChild(cancel);
+      window.setTimeout(() => pollScan(jobId, controllerId), 500);
+    } else if (job.status === 'completed') {
+      if (!job.engines.length) {
+        scanOutput.insertAdjacentHTML('beforeend', '<div class="alert alert-info">No active engines were found.</div>');
+        return;
+      }
+      const importButton = document.createElement('button');
+      importButton.className = 'btn btn-success';
+      importButton.textContent = 'Import selected engines';
+      const choices = document.createElement('div');
+      choices.className = 'train-engine-choices';
+      job.engines.forEach(address => {
+        const label = document.createElement('label');
+        label.innerHTML = `<input type="checkbox" value="${address}" checked> Address ${address}`;
+        choices.appendChild(label);
+      });
+      scanOutput.appendChild(choices);
+      importButton.addEventListener('click', () => {
+        const addresses = Array.from(choices.querySelectorAll('input:checked')).map(input => Number(input.value));
+        if (!addresses.length) { message('Select at least one discovered engine.', 'warning'); return; }
+        refresh(() => api(`/api/train-controller/controllers/${controllerId}/engines/import`, 'POST', {addresses}));
+      });
+      scanOutput.appendChild(importButton);
+    } else {
+      message(job.error || `Scan ${job.status}.`, job.status === 'cancelled' ? 'warning' : 'danger');
+    }
+  }
+
+  document.querySelectorAll('.train-scan').forEach(button => button.addEventListener('click', async () => {
+    if (!authorized()) return;
+    try {
+      const maximum = document.getElementById(`scan-max-${button.dataset.controller}`).value;
+      const result = await api(`/api/train-controller/controllers/${button.dataset.controller}/scan-jobs`, 'POST', {maximum, authorized: true});
+      pollScan(result.job.id, button.dataset.controller);
+    } catch (error) {
+      message(error.message, 'danger');
+    }
+  }));
+
+  document.getElementById('save-train-evidence').addEventListener('click', () =>
+    refresh(() => api('/api/train-controller/evidence', 'POST', {}))
+  );
+
+  if (state.mode === 'training') {
+    const current = stepOrder.find(step => !state.training.completed.includes(step));
+    document.body.classList.add('train-training-mode');
+    document.querySelectorAll('.train-action,.train-speed,.train-scan').forEach(control => {
+      if (!['emergency_stop', 'stop'].includes(control.dataset.action)) control.disabled = true;
+    });
+    document.querySelectorAll('[data-training-step]').forEach(control => {
+      if (control.dataset.trainingStep !== current) {
+        control.classList.add('training-locked');
+        control.querySelectorAll('button,input').forEach(item => { item.disabled = true; });
+        if (control.matches('button,input')) control.disabled = true;
+      } else {
+        control.classList.add('training-spotlight');
+        if (window.trainControllerCapability.available || ['add_controller', 'add_engine'].includes(current)) {
+          control.querySelectorAll('button,input').forEach(item => { item.disabled = false; });
+          if (control.matches('button,input')) control.disabled = false;
+        }
+      }
+    });
+  }
+}());

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -7,6 +7,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='font-awesome/css/all.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/adapters-card.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/train-controller.css') }}">
 <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
 
 <script>

--- a/templates/_primary-nav-links.html
+++ b/templates/_primary-nav-links.html
@@ -14,7 +14,7 @@
 {% endfor %}
 
 <div class="nav-item dropdown nav-compact-group">
-  <a href="#" class="nav-link {% if title in ['Network Scan', 'Port Scan', 'Traceroute', 'Red Team', 'Minecraft Attack'] %}active{% endif %}" data-toggle="dropdown">Tools</a>
+  <a href="#" class="nav-link {% if title in ['Network Scan', 'Port Scan', 'Traceroute', 'Red Team', 'Minecraft Attack', 'Train Controller'] %}active{% endif %}" data-toggle="dropdown">Tools</a>
   <div class="dropdown-menu">
     <a href="/network-scan" class="dropdown-item {% if title == 'Network Scan' %}active{% endif %}">Network Scan</a>
     <a href="/port-scan" class="dropdown-item {% if title == 'Port Scan' %}active{% endif %}">Port Scan</a>
@@ -22,6 +22,7 @@
     <div class="dropdown-divider"></div>
     <a href="/red-team" class="dropdown-item {% if title == 'Red Team' %}active{% endif %}">Red Team</a>
     <a href="/minecraft-attack" class="dropdown-item {% if title == 'Minecraft Attack' %}active{% endif %}">Minecraft Attack</a>
+    <a href="/train-controller" class="dropdown-item {% if title == 'Train Controller' %}active{% endif %}">Train Controller</a>
   </div>
 </div>
 

--- a/templates/train_controller.html
+++ b/templates/train_controller.html
@@ -1,0 +1,81 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-hero train-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">DCC-EX workspace</p>
+    <h1 class="page-title">Train Controller</h1>
+    <p class="page-subtitle">Manage command stations and send bounded DCC commands over TCP. Hardware actions always require authorization.</p>
+  </div>
+  <div class="train-mode" aria-label="Operating mode">
+    <button class="btn btn-sm mode-button {% if train_state.mode == 'full' %}btn-primary{% else %}btn-outline-primary{% endif %}" data-mode="full">Full</button>
+    <button class="btn btn-sm mode-button {% if train_state.mode == 'training' %}btn-primary{% else %}btn-outline-primary{% endif %}" data-mode="training">Training</button>
+  </div>
+</section>
+
+{% if not train_capability.available %}
+<div class="alert alert-warning" role="status"><strong>Hardware unavailable.</strong> {{ train_capability.reason }}</div>
+{% endif %}
+<div id="train-status" class="alert d-none" role="status" aria-live="polite"></div>
+
+<nav class="train-tabs nav nav-tabs" role="tablist" aria-label="Train Controller sections">
+  {% for id, label in [('overview','Overview'),('controllers','Controllers'),('controls','Controls'),('automation','Discovery'),('diagnostics','Diagnostics'),('history','History'),('guide','Training Guide')] %}
+  <a class="nav-item nav-link {% if loop.first %}active{% endif %}" data-toggle="tab" href="#train-{{ id }}" role="tab">{{ label }}</a>
+  {% endfor %}
+</nav>
+
+<div class="tab-content train-workspace" data-mode="{{ train_state.mode }}">
+  <section id="train-overview" class="tab-pane fade show active" role="tabpanel">
+    <div class="train-grid">
+      <article class="theme-card card"><div class="card-body"><h2>Layout status</h2><p class="display-4 mb-0">{{ train_state.controllers|length }}</p><p>configured controller{{ '' if train_state.controllers|length == 1 else 's' }}</p></div></article>
+      <article class="theme-card card"><div class="card-body"><h2>Capability</h2><span class="badge badge-{{ 'success' if train_capability.available else 'secondary' }}">{{ 'Ready' if train_capability.available else 'Unavailable' }}</span><p class="mt-2 mb-0">{{ train_capability.protocol }} on port {{ train_capability.port }}</p></div></article>
+      <article class="theme-card card"><div class="card-body"><h2>Safety boundary</h2><p>Only setup, discovery, emergency stop, locomotive functions, stop, and bounded throttle commands are generated server-side. Raw commands are not accepted.</p></div></article>
+    </div>
+    <article class="theme-card card mt-3"><div class="card-body"><h2>Layout identity</h2><form id="layout-name-form" class="form-inline"><label class="sr-only" for="layout-name">Layout name</label><input id="layout-name" name="name" maxlength="80" class="form-control mr-2" value="{{ train_state.layout_name }}" placeholder="Layout name"><button class="btn btn-primary" type="submit">Save layout name</button></form></div></article>
+  </section>
+
+  <section id="train-controllers" class="tab-pane fade" role="tabpanel">
+    <article class="theme-card card training-target" data-training-step="add_controller"><div class="card-body">
+      <h2>Add controller</h2>
+      <form id="add-controller-form" class="form-row align-items-end">
+        <div class="col-md-4 form-group"><label for="controller-name">Name</label><input id="controller-name" name="name" maxlength="80" class="form-control" placeholder="Main command station"></div>
+        <div class="col-md-4 form-group"><label for="controller-ip">IP address</label><input id="controller-ip" name="ip" class="form-control" required placeholder="192.0.2.10"></div>
+        <div class="col-md-4 form-group"><button class="btn btn-primary" type="submit">Add controller</button></div>
+      </form>
+    </div></article>
+    {% if not train_state.controllers %}<div class="train-empty">No controllers configured. Add an authorized command station above.</div>{% endif %}
+    {% for controller in train_state.controllers %}
+    <article class="theme-card card"><div class="card-body"><div class="train-card-heading"><div><h2>{{ controller.name or 'Controller' }}</h2><code>{{ controller.ip }}</code></div><button class="btn btn-outline-danger btn-sm delete-controller" data-controller="{{ controller.id }}">Delete</button></div>
+      <form class="edit-controller-form form-row mt-3" data-controller="{{ controller.id }}"><div class="col-md-4"><label>Name<input name="name" maxlength="80" class="form-control" value="{{ controller.name }}"></label></div><div class="col-md-4"><label>IP address<input name="ip" class="form-control" value="{{ controller.ip }}" required></label></div><div class="col-md-4 align-self-end"><button class="btn btn-outline-primary" type="submit">Save controller</button></div></form>
+      <form class="add-engine-form form-row mt-3 training-target" data-controller="{{ controller.id }}" data-training-step="add_engine">
+        <div class="col-md-3"><input name="address" type="number" min="1" max="10239" class="form-control" required placeholder="DCC address"></div>
+        <div class="col-md-5"><input name="name" maxlength="80" class="form-control" placeholder="Engine name"></div>
+        <div class="col-md-4"><button class="btn btn-secondary" type="submit">Add engine</button></div>
+      </form>
+    </div></article>
+    {% endfor %}
+  </section>
+
+  <section id="train-controls" class="tab-pane fade" role="tabpanel">
+    {% if not train_state.controllers %}<div class="train-empty">Controls appear after a controller and engine have been configured.</div>{% endif %}
+    {% for controller in train_state.controllers %}
+    <details class="theme-card card train-controller-panel" data-controller="{{ controller.id }}" open><summary class="card-header train-controller-summary">{{ controller.name or controller.ip }} <span>Show or hide controls</span></summary><div class="card-body"><div class="train-card-heading"><h2 class="sr-only">{{ controller.name or controller.ip }}</h2><div>
+      <button class="btn btn-secondary train-action training-target" data-training-step="setup" data-controller="{{ controller.id }}" data-action="setup" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>Setup track</button>
+      <button class="btn btn-danger train-action" data-controller="{{ controller.id }}" data-action="emergency_stop" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>Emergency stop</button>
+    </div></div>
+    <div class="train-grid mt-3">
+    {% for engine in controller.engines %}<div class="train-engine card"><div class="card-body"><div class="train-card-heading"><div><h3>{{ engine.name or 'Engine' }}</h3><small>Address {{ engine.address }}</small></div><button class="btn btn-link text-danger delete-engine" data-controller="{{ controller.id }}" data-engine="{{ engine.id }}">Remove</button></div><form class="edit-engine-form form-row mb-3" data-controller="{{ controller.id }}" data-engine="{{ engine.id }}"><div class="col-5"><input name="name" maxlength="80" class="form-control form-control-sm" value="{{ engine.name }}" aria-label="Engine name"></div><div class="col-3"><input name="address" type="number" min="1" max="10239" class="form-control form-control-sm" value="{{ engine.address }}" required aria-label="DCC address"></div><div class="col-4"><button class="btn btn-sm btn-outline-primary" type="submit">Save engine</button></div></form>
+      <label for="speed-{{ engine.id }}">Speed <output id="speed-output-{{ engine.id }}">0</output></label>
+      <input id="speed-{{ engine.id }}" class="custom-range train-speed training-target" data-training-step="throttle" data-controller="{{ controller.id }}" data-engine="{{ engine.id }}" type="range" min="-127" max="127" value="0" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>
+      <div class="theme-actions"><button class="btn btn-primary train-action training-target" data-training-step="lights" data-controller="{{ controller.id }}" data-engine="{{ engine.id }}" data-action="lights" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>Lights</button><button class="btn btn-secondary train-action" data-controller="{{ controller.id }}" data-engine="{{ engine.id }}" data-action="horn" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>Horn</button><button class="btn btn-danger train-action" data-controller="{{ controller.id }}" data-engine="{{ engine.id }}" data-action="stop" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>Stop</button></div>
+    </div></div>{% else %}<div class="train-empty">No engines assigned to this controller.</div>{% endfor %}
+    </div></div></details>{% endfor %}
+  </section>
+
+  <section id="train-automation" class="tab-pane fade" role="tabpanel"><article class="theme-card card"><div class="card-body"><h2>Engine discovery</h2><p>Run a cancellable background scan across a bounded DCC cab range, then choose which discovered engines to import.</p>{% for controller in train_state.controllers %}<div class="train-scan-row"><label for="scan-max-{{ controller.id }}">{{ controller.name or controller.ip }} maximum address</label><input id="scan-max-{{ controller.id }}" class="form-control train-scan-maximum" type="number" min="1" max="127" value="127"><button class="btn btn-primary train-scan" data-controller="{{ controller.id }}" {% if not train_capability.available %}disabled title="{{ train_capability.reason }}"{% endif %}>Start scan</button></div>{% else %}<div class="train-empty">Add a controller before scanning.</div>{% endfor %}<div id="train-scan-job" class="mt-3" aria-live="polite"></div></div></article></section>
+  <section id="train-diagnostics" class="tab-pane fade" role="tabpanel"><article class="theme-card card"><div class="card-body"><h2>Integration diagnostics</h2><dl><dt>Hardware actions</dt><dd>{{ 'Enabled' if train_capability.available else 'Disabled' }}</dd><dt>Protocol</dt><dd>{{ train_capability.protocol }}</dd><dt>TCP port</dt><dd>{{ train_capability.port }}</dd><dt>Unavailable reason</dt><dd>{{ train_capability.reason or 'None' }}</dd></dl><p>Connectivity errors are reported without pretending that a command succeeded.</p></div></article></section>
+  <section id="train-history" class="tab-pane fade" role="tabpanel"><article class="theme-card card"><div class="card-body"><div class="train-card-heading"><h2>Action history</h2><button id="save-train-evidence" class="btn btn-outline-primary" {% if not train_state.history %}disabled{% endif %}>Save to Evidence Vault</button></div>{% if train_state.history %}<div class="table-responsive"><table class="table"><thead><tr><th>Time</th><th>Action</th><th>Status</th></tr></thead><tbody>{% for item in train_state.history %}<tr><td>{{ item.at }}</td><td>{{ item.action }}</td><td>{{ item.status }}</td></tr>{% endfor %}</tbody></table></div>{% else %}<div class="train-empty">No hardware actions have been recorded.</div>{% endif %}</div></article></section>
+  <section id="train-guide" class="tab-pane fade" role="tabpanel"><article class="theme-card card"><div class="card-body"><h2>Training Guide</h2><p>Training mode unlocks one safe task at a time. Progress is stored on the server and survives refreshes.</p><ol class="training-list">{% for id, title, description in training_steps %}<li class="{% if id in train_state.training.completed %}complete{% endif %}"><strong>{{ title }}</strong><span>{{ description }}</span></li>{% endfor %}</ol><h3>Trophies</h3>{% if train_state.training.trophies %}{% for trophy in train_state.training.trophies %}<span class="badge badge-warning mr-1">🏆 {{ trophy }}</span>{% endfor %}{% else %}<p>No trophies earned yet.</p>{% endif %}</div></article></section>
+</div>
+<script>window.trainControllerState = {{ train_state|tojson }}; window.trainControllerCapability = {{ train_capability|tojson }};</script>
+<script src="/static/js/train-controller.js"></script>
+{% endblock %}

--- a/tests/test_train_controller.py
+++ b/tests/test_train_controller.py
@@ -1,0 +1,154 @@
+import json
+import time
+
+import pytest
+
+from app import app
+from scripts.train_controller import TrainControllerError, TrainControllerService
+
+
+class FakeSocket:
+    def __init__(self, response=b""):
+        self.response, self.sent = response, b""
+    def __enter__(self): return self
+    def __exit__(self, *_): return None
+    def settimeout(self, _): return None
+    def sendall(self, value): self.sent += value
+    def recv(self, _): return self.response
+
+
+def service(tmp_path, enabled=True, response=b""):
+    connection = FakeSocket(response)
+    instance = TrainControllerService(tmp_path / "trains.json", enabled=enabled, socket_factory=lambda *_: connection)
+    return instance, connection
+
+
+def test_capability_detection_explains_disabled_hardware(tmp_path):
+    capability = service(tmp_path, enabled=False)[0].capability()
+    assert capability["available"] is False
+    assert "TRAIN_CONTROLLER_ENABLED=1" in capability["reason"]
+
+
+def test_service_persists_roster_sends_generated_command_and_history(tmp_path):
+    instance, connection = service(tmp_path)
+    controller = instance.add_controller("192.0.2.10", "Yard")["controllers"][0]
+    engine = instance.add_engine(controller["id"], 3, "Switcher")["controllers"][0]["engines"][0]
+    assert instance.run_action(controller["id"], "lights", engine["id"])["action"] == "lights"
+    assert connection.sent == b"<f 3 0 1>\n"
+    assert instance.state()["history"][0]["status"] == "success"
+    assert json.loads((tmp_path / "trains.json").read_text())["controllers"][0]["name"] == "Yard"
+
+
+def test_service_updates_layout_roster_and_imports_discovered_engines(tmp_path):
+    instance, _ = service(tmp_path)
+    instance.set_layout_name("Branch Line")
+    controller = instance.add_controller("192.0.2.10", "Old")["controllers"][0]
+    state = instance.update_controller(controller["id"], "192.0.2.11", "Main")
+    assert state["layout_name"] == "Branch Line"
+    assert state["controllers"][0]["ip"] == "192.0.2.11"
+    engine = instance.add_engine(controller["id"], 3, "Old engine")["controllers"][0]["engines"][0]
+    state = instance.update_engine(controller["id"], engine["id"], 4, "Switcher")
+    assert state["controllers"][0]["engines"][0]["name"] == "Switcher"
+    state = instance.import_engines(controller["id"], [4, 5, 5, 6])
+    assert [item["address"] for item in state["controllers"][0]["engines"]] == [4, 5, 6]
+
+
+def test_service_rejects_invalid_values_duplicates_and_unavailable_hardware(tmp_path):
+    instance, _ = service(tmp_path, enabled=False)
+    with pytest.raises(TrainControllerError, match="valid IPv4"):
+        instance.add_controller("not a host")
+    controller = instance.add_controller("192.0.2.10")["controllers"][0]
+    with pytest.raises(TrainControllerError, match="already exists"):
+        instance.add_controller("192.0.2.10")
+    with pytest.raises(TrainControllerError, match="TRAIN_CONTROLLER_ENABLED"):
+        instance.run_action(controller["id"], "setup")
+
+
+def test_connection_failure_is_not_reported_as_success(tmp_path):
+    instance = TrainControllerService(tmp_path / "trains.json", enabled=True, socket_factory=lambda *_: (_ for _ in ()).throw(OSError("offline")))
+    controller = instance.add_controller("192.0.2.10")["controllers"][0]
+    with pytest.raises(TrainControllerError, match="offline"):
+        instance.run_action(controller["id"], "setup")
+    assert instance.state()["history"] == []
+
+
+def test_training_progression_persists_and_locks_later_steps(tmp_path):
+    instance, _ = service(tmp_path)
+    instance.set_mode("training")
+    controller = instance.add_controller("192.0.2.10")["controllers"][0]
+    with pytest.raises(TrainControllerError, match="current Training Guide"):
+        instance.run_action(controller["id"], "lights", "missing")
+    with pytest.raises(TrainControllerError, match="before adding an engine"):
+        instance.add_engine(controller["id"], 4)
+    instance.run_action(controller["id"], "setup")
+    engine = instance.add_engine(controller["id"], 4)["controllers"][0]["engines"][0]
+    instance.run_action(controller["id"], "lights", engine["id"])
+    assert instance.state()["training"]["completed"] == ["add_controller", "setup", "add_engine", "lights"]
+    assert "First Lights" in instance.state()["training"]["trophies"]
+
+
+@pytest.fixture
+def train_client(tmp_path):
+    instance, _ = service(tmp_path)
+    app.config.update(TESTING=True, TRAIN_CONTROLLER_SERVICE=instance)
+    yield app.test_client(), instance
+    app.config.pop("TRAIN_CONTROLLER_SERVICE", None)
+
+
+def test_page_renders_tabs_controls_empty_state_and_navigation(train_client):
+    client, _ = train_client
+    response = client.get("/train-controller")
+    assert response.status_code == 200
+    for value in (b"Overview", b"Controllers", b"Controls", b"Discovery", b"Diagnostics", b"History", b"Training Guide", b"No controllers configured"):
+        assert value in response.data
+    assert b"Train Controller" in client.get("/").data
+    assert b'id="layout-name-form"' in response.data
+    assert b"Save to Evidence Vault" in response.data
+
+
+def test_routes_validate_authorization_input_and_success(train_client):
+    client, _ = train_client
+    assert client.post("/api/train-controller/controllers", json={"ip": "bad"}).status_code == 400
+    created = client.post("/api/train-controller/controllers", json={"ip": "192.0.2.20", "name": "Lab"})
+    controller_id = created.get_json()["state"]["controllers"][0]["id"]
+    assert created.status_code == 201
+    unauthorized = client.post(f"/api/train-controller/controllers/{controller_id}/actions", json={"action": "setup"})
+    assert unauthorized.status_code == 400
+    assert "Authorization" in unauthorized.get_json()["message"]
+    success = client.post(f"/api/train-controller/controllers/{controller_id}/actions", json={"action": "setup", "authorized": True})
+    assert success.status_code == 200
+    assert success.get_json()["result"]["action"] == "setup"
+
+
+def test_update_import_background_scan_and_evidence_routes(train_client):
+    client, instance = train_client
+    instance.socket_factory = lambda *_: FakeSocket(b"<l 1 0 0 0>")
+    created = client.post("/api/train-controller/controllers", json={"ip": "192.0.2.30", "name": "Old"}).get_json()
+    controller_id = created["state"]["controllers"][0]["id"]
+    assert client.put("/api/train-controller/layout", json={"name": "Test Layout"}).status_code == 200
+    assert client.put(f"/api/train-controller/controllers/{controller_id}", json={"ip": "192.0.2.31", "name": "New"}).status_code == 200
+    started = client.post(f"/api/train-controller/controllers/{controller_id}/scan-jobs", json={"maximum": 2, "authorized": True})
+    assert started.status_code == 202
+    job_id = started.get_json()["job"]["id"]
+    for _ in range(50):
+        job = client.get(f"/api/train-controller/scan-jobs/{job_id}").get_json()["job"]
+        if job["status"] == "completed":
+            break
+        time.sleep(.01)
+    assert job["engines"] == [1]
+    imported = client.post(f"/api/train-controller/controllers/{controller_id}/engines/import", json={"addresses": job["engines"]})
+    engine = imported.get_json()["state"]["controllers"][0]["engines"][0]
+    assert client.put(f"/api/train-controller/controllers/{controller_id}/engines/{engine['id']}", json={"address": 2, "name": "Edited"}).status_code == 200
+    assert client.post("/api/train-controller/evidence", json={}).status_code == 201
+
+
+def test_route_reports_unavailable_hardware(tmp_path):
+    instance, _ = service(tmp_path, enabled=False)
+    controller = instance.add_controller("192.0.2.21")["controllers"][0]
+    app.config["TRAIN_CONTROLLER_SERVICE"] = instance
+    try:
+        response = app.test_client().post(f"/api/train-controller/controllers/{controller['id']}/actions", json={"action": "setup", "authorized": True})
+        assert response.status_code == 503
+        assert "TRAIN_CONTROLLER_ENABLED" in response.get_json()["message"]
+    finally:
+        app.config.pop("TRAIN_CONTROLLER_SERVICE", None)


### PR DESCRIPTION
### Motivation
- Add a native Train Controller workspace to manage DCC-EX command stations, bounded locomotive commands, discovery, and a guided training mode while keeping hardware control safe and explicit.
- Keep protocol and persistence logic server-side so the browser never submits raw DCC commands and hardware actions require explicit authorization. 
- Integrate the feature into the existing Flask app and provide automated unit coverage for validation, persistence, networking, and route behavior.

### Description
- Implemented a new service `scripts/train_controller.py` that encapsulates persistence, validation, DCC-EX TCP communication, training progression, and safe command generation, and introduced `TrainControllerService` and `TrainControllerError`.
- Added a blueprint `routes/train_controller.py` and registered it in `routes/__init__.py`, exposing UI pages and JSON APIs for state, controllers, engines, actions, discovery scan jobs, cancellation, and Evidence Vault recording; the blueprint uses `TRAIN_CONTROLLER_SERVICE` if provided by app config.
- Added a Jinja template `templates/train_controller.html`, static assets `static/js/train-controller.js` and `static/css/train-controller.css`, and updated `_header.html` and `_primary-nav-links.html` to surface the UI and styles in navigation.
- Hooked evidence recording integration via `app.config['TRAIN_CONTROLLER_EVIDENCE_RECORDER'] = create_evidence_record` and added `instance/train_controller.json` to `.gitignore` while documenting usage and environment variables (`TRAIN_CONTROLLER_ENABLED`, `TRAIN_CONTROLLER_PORT`, `TRAIN_CONTROLLER_TIMEOUT`) in `README.md`.

### Testing
- Added `tests/test_train_controller.py` containing unit tests for the service and Flask routes and exercised controller/engine CRUD, command generation, history persistence, training progression, background scan jobs, import flow, and evidence recording using `pytest`.
- Ran `pytest tests/test_train_controller.py` (app configured with `TRAIN_CONTROLLER_SERVICE` fixture) and all tests passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67983dcad4832f984192e1c1d038b8)