### PR TITLE
Add guided first-run setup wizard

### DIFF
--- a/app_support/navigation.py
+++ b/app_support/navigation.py
@@ -21,6 +21,7 @@ STATIC_SEARCH_ITEMS = (
     ('VIN Lookup', '/automotive/vin', 'vehicle vin lookup'),
     ('Code Lookup', '/automotive/codes', 'dtc diagnostic codes'),
     ('Diagnostic Sessions', '/automotive/sessions', 'automotive sessions'),
+    ('Setup Wizard', '/setup-wizard', 'first run configuration optional downloads'),
     ('Capabilities', '/capabilities', 'system capabilities'),
     ('Roadmap', '/roadmap', 'system roadmap'),
     ('My Account', '/account', 'profile password preferences'),
@@ -76,7 +77,7 @@ def _breadcrumb_items(path, title, technologies):
         items.append(_current_item('Records'))
     elif lower_path in {'/network-scan', '/service-discovery', '/port-scan', '/traceroute', '/diagnostics', '/advanced-diagnostics', '/jobs', '/red-team', '/minecraft-attack', '/train-controller'}:
         items.append(_current_item('Tools'))
-    elif lower_path in {'/capabilities', '/roadmap', '/users'}:
+    elif lower_path in {'/capabilities', '/roadmap', '/users', '/setup-wizard'}:
         items.append(_current_item('System'))
     elif lower_path.startswith('/account'):
         items.append(_current_item('Account'))

--- a/app_support/navigation.py
+++ b/app_support/navigation.py
@@ -119,10 +119,11 @@ def _section_items(path):
     return items
 
 
-def _search_items(interfaces, technologies, favourites):
+def _search_items(interfaces, technologies, favourites, include_admin=False):
     items = [
         {'label': label, 'url': url, 'keywords': keywords, 'favourite': False}
         for label, url, keywords in STATIC_SEARCH_ITEMS
+        if include_admin or url != '/setup-wizard'
     ]
     for technology in sorted((str(item) for item in technologies if str(item).casefold() != 'loopback'), key=str.casefold):
         items.append({
@@ -179,7 +180,12 @@ def build_navigation_context(path, title, endpoint, user, network_technologies, 
     return {
         'breadcrumbs': _breadcrumb_items(current_path, title, technologies),
         'section_items': _section_items(current_path),
-        'search_items': _search_items(interfaces, technologies, favourites),
+        'search_items': _search_items(
+            interfaces,
+            technologies,
+            favourites,
+            include_admin=user.get('role') == 'admin',
+        ),
         'favourites': favourites,
         'current_url': current_path,
         'current_label': str(title or 'Current page'),

--- a/routes/setup_wizard.py
+++ b/routes/setup_wizard.py
@@ -9,15 +9,24 @@ from services import setup_wizard as setup_wizard_service
 _PERSISTED_RESULT_FIELDS = {
     'component', 'dependency', 'package', 'installed', 'message', 'path', 'count'
 }
+_MAX_INSTALL_MESSAGE = 1000
+
+
+def _bounded_message(value):
+    message = str(value or '').strip()
+    return message[:_MAX_INSTALL_MESSAGE]
 
 
 def _persistable_result(result):
     """Exclude pip and package-manager command output from durable user state."""
-    return {
+    summary = {
         key: value
         for key, value in (result or {}).items()
         if key in _PERSISTED_RESULT_FIELDS
     }
+    if 'message' in summary:
+        summary['message'] = _bounded_message(summary['message'])
+    return summary
 
 
 def register_setup_wizard_routes(app, context_provider):
@@ -54,35 +63,37 @@ def register_setup_wizard_routes(app, context_provider):
             return json_error('Choose a setup component.', 400)
         try:
             result = setup_wizard_service.install_component(component_id)
+            safe_result = _persistable_result(result)
             setup_wizard_service.record_component_result(
                 username,
                 component_id,
                 'installed' if result.get('installed') else 'warning',
-                result.get('message'),
-                _persistable_result(result),
+                safe_result.get('message'),
+                safe_result,
                 social_users,
                 social_users_lock,
             )
         except ValueError as exc:
-            return json_error(str(exc), 400)
+            return json_error(_bounded_message(exc), 400)
         except Exception as exc:
+            message = _bounded_message(exc)
             setup_wizard_service.record_component_result(
                 username,
                 component_id,
                 'failed',
-                str(exc),
+                message,
                 {},
                 social_users,
                 social_users_lock,
             )
             record_social_audit(
-                'setup.component.failed', detail=f'{component_id}:{exc}'
+                'setup.component.failed', detail=f'{component_id}:{message}'
             )
             save_runtime_state('setup-component-failed')
-            return json_error(str(exc), 500)
+            return json_error(message, 500)
         record_social_audit('setup.component.install', detail=component_id)
         save_runtime_state('setup-component-install')
-        return json_success(result=result)
+        return json_success(result=safe_result)
 
     @app.route('/setup-wizard/complete', methods=['POST'])
     @social_login_required({'admin'})

--- a/routes/setup_wizard.py
+++ b/routes/setup_wizard.py
@@ -6,6 +6,20 @@ from app_support.context import bind_context
 from services import setup_wizard as setup_wizard_service
 
 
+_PERSISTED_RESULT_FIELDS = {
+    'component', 'dependency', 'package', 'installed', 'message', 'path', 'count'
+}
+
+
+def _persistable_result(result):
+    """Exclude pip and package-manager command output from durable user state."""
+    return {
+        key: value
+        for key, value in (result or {}).items()
+        if key in _PERSISTED_RESULT_FIELDS
+    }
+
+
 def register_setup_wizard_routes(app, context_provider):
     _refresh_context = bind_context(globals(), context_provider)
 
@@ -45,7 +59,7 @@ def register_setup_wizard_routes(app, context_provider):
                 component_id,
                 'installed' if result.get('installed') else 'warning',
                 result.get('message'),
-                result,
+                _persistable_result(result),
                 social_users,
                 social_users_lock,
             )

--- a/routes/setup_wizard.py
+++ b/routes/setup_wizard.py
@@ -1,0 +1,97 @@
+"""Administrator-only guided setup routes."""
+
+from flask import redirect, render_template, request
+
+from app_support.context import bind_context
+from services import setup_wizard as setup_wizard_service
+
+
+def register_setup_wizard_routes(app, context_provider):
+    _refresh_context = bind_context(globals(), context_provider)
+
+    def setup_wizard_response(error=None, status=200):
+        record = current_user_record() or {}
+        state = setup_wizard_service.setup_state(record)
+        response = render_template(
+            'setup_wizard.html',
+            title='Setup Wizard',
+            components=setup_wizard_service.component_catalog(),
+            setup_state=state,
+            first_run=setup_wizard_service.setup_required(record),
+            error=error,
+            csrf_token=social_csrf_token(),
+            **current_context(),
+        )
+        return (response, status) if status != 200 else response
+
+    @app.route('/setup-wizard')
+    @social_login_required({'admin'})
+    @_refresh_context
+    def setup_wizard_page():
+        return setup_wizard_response()
+
+    @app.route('/setup-wizard/install', methods=['POST'])
+    @social_login_required({'admin'})
+    @_refresh_context
+    def install_setup_component():
+        username = (current_app_user() or {}).get('username')
+        component_id = request.form.get('component')
+        if not component_id:
+            return json_error('Choose a setup component.', 400)
+        try:
+            result = setup_wizard_service.install_component(component_id)
+            setup_wizard_service.record_component_result(
+                username,
+                component_id,
+                'installed' if result.get('installed') else 'warning',
+                result.get('message'),
+                result,
+                social_users,
+                social_users_lock,
+            )
+        except ValueError as exc:
+            return json_error(str(exc), 400)
+        except Exception as exc:
+            setup_wizard_service.record_component_result(
+                username,
+                component_id,
+                'failed',
+                str(exc),
+                {},
+                social_users,
+                social_users_lock,
+            )
+            record_social_audit(
+                'setup.component.failed', detail=f'{component_id}:{exc}'
+            )
+            save_runtime_state('setup-component-failed')
+            return json_error(str(exc), 500)
+        record_social_audit('setup.component.install', detail=component_id)
+        save_runtime_state('setup-component-install')
+        return json_success(result=result)
+
+    @app.route('/setup-wizard/complete', methods=['POST'])
+    @social_login_required({'admin'})
+    @_refresh_context
+    def complete_setup_wizard():
+        username = (current_app_user() or {}).get('username')
+        mode = request.form.get('mode') or 'completed'
+        try:
+            state = setup_wizard_service.complete_setup(
+                username, mode, social_users, social_users_lock
+            )
+        except ValueError as exc:
+            return json_error(str(exc), 400)
+        record_social_audit('setup.complete', detail=mode)
+        save_runtime_state('setup-wizard-complete')
+        record = current_user_record() or {}
+        destination = social_auth_service.default_landing_page(record)
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return json_success(state=state, redirect=destination)
+        return redirect(destination)
+
+    return {
+        'setup_wizard_page': setup_wizard_page,
+        'install_setup_component': install_setup_component,
+        'complete_setup_wizard': complete_setup_wizard,
+    }

--- a/routes/social_auth.py
+++ b/routes/social_auth.py
@@ -1,7 +1,8 @@
-"""Authentication and local application-user routes."""
+"""Authentication, first-run setup, and local application-user routes."""
 
 from app_support import navigation as navigation_service
 from app_support.context import bind_context
+from services import setup_wizard as setup_wizard_service
 
 
 def register_social_auth_routes(app, context_provider):
@@ -53,6 +54,21 @@ def register_social_auth_routes(app, context_provider):
         )
         return (response, status) if status != 200 else response
 
+    def setup_wizard_response(error=None, status=200):
+        record = current_user_record() or {}
+        state = setup_wizard_service.setup_state(record)
+        response = render_template(
+            'setup_wizard.html',
+            title='Setup Wizard',
+            components=setup_wizard_service.component_catalog(),
+            setup_state=state,
+            first_run=setup_wizard_service.setup_required(record),
+            error=error,
+            csrf_token=social_csrf_token(),
+            **current_context(),
+        )
+        return (response, status) if status != 200 else response
+
     @app.route('/setup', methods=['GET', 'POST'])
     @_refresh_context
     def social_auth_setup():
@@ -71,6 +87,9 @@ def register_social_auth_routes(app, context_provider):
                     'admin',
                     social_users,
                     social_users_lock,
+                )
+                setup_wizard_service.begin_setup(
+                    user['username'], social_users, social_users_lock
                 )
             except ValueError as exc:
                 return render_template(
@@ -91,11 +110,7 @@ def register_social_auth_routes(app, context_provider):
                     profile.setdefault('owner', user['username'])
             record_social_audit('auth.setup')
             save_runtime_state('social-auth-setup')
-            destination = (
-                login_destination(next_url)
-                if next_url else social_auth_service.default_landing_page(user)
-            )
-            return redirect(destination)
+            return redirect(url_for('setup_wizard_page'))
         return render_template(
             'social_auth.html',
             title='Social Profile Setup',
@@ -138,6 +153,8 @@ def register_social_auth_routes(app, context_provider):
             }
             record_social_audit('auth.login')
             save_runtime_state('social-auth-login')
+            if setup_wizard_service.setup_required(user):
+                return redirect(url_for('setup_wizard_page'))
             destination = (
                 login_destination(next_url)
                 if next_url else social_auth_service.default_landing_page(user)
@@ -160,6 +177,72 @@ def register_social_auth_routes(app, context_provider):
         save_runtime_state('social-auth-logout')
         session.pop('social_user', None)
         return redirect(url_for('social_auth_login'))
+
+    @app.route('/setup-wizard')
+    @social_login_required({'admin'})
+    @_refresh_context
+    def setup_wizard_page():
+        return setup_wizard_response()
+
+    @app.route('/setup-wizard/install', methods=['POST'])
+    @social_login_required({'admin'})
+    @_refresh_context
+    def install_setup_component():
+        username = (current_app_user() or {}).get('username')
+        component_id = request.form.get('component')
+        if not component_id:
+            return json_error('Choose a setup component.', 400)
+        try:
+            result = setup_wizard_service.install_component(component_id)
+            setup_wizard_service.record_component_result(
+                username,
+                component_id,
+                'installed' if result.get('installed') else 'warning',
+                result.get('message'),
+                result,
+                social_users,
+                social_users_lock,
+            )
+        except ValueError as exc:
+            return json_error(str(exc), 400)
+        except Exception as exc:
+            setup_wizard_service.record_component_result(
+                username,
+                component_id,
+                'failed',
+                str(exc),
+                {},
+                social_users,
+                social_users_lock,
+            )
+            record_social_audit(
+                'setup.component.failed', detail=f'{component_id}:{exc}'
+            )
+            save_runtime_state('setup-component-failed')
+            return json_error(str(exc), 500)
+        record_social_audit('setup.component.install', detail=component_id)
+        save_runtime_state('setup-component-install')
+        return json_success(result=result)
+
+    @app.route('/setup-wizard/complete', methods=['POST'])
+    @social_login_required({'admin'})
+    @_refresh_context
+    def complete_setup_wizard():
+        username = (current_app_user() or {}).get('username')
+        mode = request.form.get('mode') or 'completed'
+        try:
+            state = setup_wizard_service.complete_setup(
+                username, mode, social_users, social_users_lock
+            )
+        except ValueError as exc:
+            return json_error(str(exc), 400)
+        record_social_audit('setup.complete', detail=mode)
+        save_runtime_state('setup-wizard-complete')
+        record = current_user_record() or {}
+        destination = social_auth_service.default_landing_page(record)
+        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
+            return json_success(state=state, redirect=destination)
+        return redirect(destination)
 
     @app.route('/account')
     @social_login_required()
@@ -300,6 +383,9 @@ def register_social_auth_routes(app, context_provider):
         'social_auth_setup': social_auth_setup,
         'social_auth_login': social_auth_login,
         'social_auth_logout': social_auth_logout,
+        'setup_wizard_page': setup_wizard_page,
+        'install_setup_component': install_setup_component,
+        'complete_setup_wizard': complete_setup_wizard,
         'application_account_page': application_account_page,
         'update_application_account': update_application_account,
         'change_application_password': change_application_password,

--- a/routes/social_auth.py
+++ b/routes/social_auth.py
@@ -2,6 +2,7 @@
 
 from app_support import navigation as navigation_service
 from app_support.context import bind_context
+from routes.setup_wizard import register_setup_wizard_routes
 from services import setup_wizard as setup_wizard_service
 
 
@@ -12,17 +13,11 @@ def register_social_auth_routes(app, context_provider):
     def inject_navigation_context():
         context = context_provider()
         record = current_user_record()
-        app_user = (
-            social_auth_service.public_user(record)
-            if record else current_app_user()
-        )
+        app_user = social_auth_service.public_user(record) if record else current_app_user()
 
         def app_navigation(title=''):
             return navigation_service.build_navigation_context(
-                request.path,
-                title,
-                request.endpoint,
-                app_user,
+                request.path, title, request.endpoint, app_user,
                 context.get('networkTechnologies', ()),
                 context.get('network_interfaces', ()),
             )
@@ -54,21 +49,6 @@ def register_social_auth_routes(app, context_provider):
         )
         return (response, status) if status != 200 else response
 
-    def setup_wizard_response(error=None, status=200):
-        record = current_user_record() or {}
-        state = setup_wizard_service.setup_state(record)
-        response = render_template(
-            'setup_wizard.html',
-            title='Setup Wizard',
-            components=setup_wizard_service.component_catalog(),
-            setup_state=state,
-            first_run=setup_wizard_service.setup_required(record),
-            error=error,
-            csrf_token=social_csrf_token(),
-            **current_context(),
-        )
-        return (response, status) if status != 200 else response
-
     @app.route('/setup', methods=['GET', 'POST'])
     @_refresh_context
     def social_auth_setup():
@@ -82,11 +62,8 @@ def register_social_auth_routes(app, context_provider):
                 return json_error('Invalid or expired form token.', 400)
             try:
                 user = social_auth_service.create_user(
-                    request.form.get('username'),
-                    request.form.get('password'),
-                    'admin',
-                    social_users,
-                    social_users_lock,
+                    request.form.get('username'), request.form.get('password'),
+                    'admin', social_users, social_users_lock,
                 )
                 setup_wizard_service.begin_setup(
                     user['username'], social_users, social_users_lock
@@ -132,10 +109,8 @@ def register_social_auth_routes(app, context_provider):
             ):
                 return json_error('Invalid or expired form token.', 400)
             user = social_auth_service.authenticate(
-                request.form.get('username'),
-                request.form.get('password'),
-                social_users,
-                social_users_lock,
+                request.form.get('username'), request.form.get('password'),
+                social_users, social_users_lock,
             )
             if not user:
                 return render_template(
@@ -177,72 +152,6 @@ def register_social_auth_routes(app, context_provider):
         save_runtime_state('social-auth-logout')
         session.pop('social_user', None)
         return redirect(url_for('social_auth_login'))
-
-    @app.route('/setup-wizard')
-    @social_login_required({'admin'})
-    @_refresh_context
-    def setup_wizard_page():
-        return setup_wizard_response()
-
-    @app.route('/setup-wizard/install', methods=['POST'])
-    @social_login_required({'admin'})
-    @_refresh_context
-    def install_setup_component():
-        username = (current_app_user() or {}).get('username')
-        component_id = request.form.get('component')
-        if not component_id:
-            return json_error('Choose a setup component.', 400)
-        try:
-            result = setup_wizard_service.install_component(component_id)
-            setup_wizard_service.record_component_result(
-                username,
-                component_id,
-                'installed' if result.get('installed') else 'warning',
-                result.get('message'),
-                result,
-                social_users,
-                social_users_lock,
-            )
-        except ValueError as exc:
-            return json_error(str(exc), 400)
-        except Exception as exc:
-            setup_wizard_service.record_component_result(
-                username,
-                component_id,
-                'failed',
-                str(exc),
-                {},
-                social_users,
-                social_users_lock,
-            )
-            record_social_audit(
-                'setup.component.failed', detail=f'{component_id}:{exc}'
-            )
-            save_runtime_state('setup-component-failed')
-            return json_error(str(exc), 500)
-        record_social_audit('setup.component.install', detail=component_id)
-        save_runtime_state('setup-component-install')
-        return json_success(result=result)
-
-    @app.route('/setup-wizard/complete', methods=['POST'])
-    @social_login_required({'admin'})
-    @_refresh_context
-    def complete_setup_wizard():
-        username = (current_app_user() or {}).get('username')
-        mode = request.form.get('mode') or 'completed'
-        try:
-            state = setup_wizard_service.complete_setup(
-                username, mode, social_users, social_users_lock
-            )
-        except ValueError as exc:
-            return json_error(str(exc), 400)
-        record_social_audit('setup.complete', detail=mode)
-        save_runtime_state('setup-wizard-complete')
-        record = current_user_record() or {}
-        destination = social_auth_service.default_landing_page(record)
-        if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
-            return json_success(state=state, redirect=destination)
-        return redirect(destination)
 
     @app.route('/account')
     @social_login_required()
@@ -338,7 +247,10 @@ def register_social_auth_routes(app, context_provider):
     @_refresh_context
     def application_users_page():
         with social_users_lock:
-            users = [social_auth_service.public_user(user) for user in social_users.values()]
+            users = [
+                social_auth_service.public_user(user)
+                for user in social_users.values()
+            ]
         return render_template(
             'application_users.html',
             title='User Management',
@@ -379,13 +291,10 @@ def register_social_auth_routes(app, context_provider):
         save_runtime_state('application-user-create')
         return redirect(url_for('application_users_page'))
 
-    return {
+    routes = {
         'social_auth_setup': social_auth_setup,
         'social_auth_login': social_auth_login,
         'social_auth_logout': social_auth_logout,
-        'setup_wizard_page': setup_wizard_page,
-        'install_setup_component': install_setup_component,
-        'complete_setup_wizard': complete_setup_wizard,
         'application_account_page': application_account_page,
         'update_application_account': update_application_account,
         'change_application_password': change_application_password,
@@ -395,3 +304,5 @@ def register_social_auth_routes(app, context_provider):
         'application_users_page': application_users_page,
         'create_application_user': create_application_user,
     }
+    routes.update(register_setup_wizard_routes(app, context_provider))
+    return routes

--- a/services/setup_wizard.py
+++ b/services/setup_wizard.py
@@ -1,0 +1,248 @@
+"""First-run setup state and approved optional component installers."""
+
+from __future__ import annotations
+
+import platform
+import shutil
+import time
+from copy import deepcopy
+
+from scripts.capabilities import (
+    OPTIONAL_PACKAGE_SPECS,
+    command_status,
+    install_host_dependency,
+    install_optional_package,
+    package_status,
+)
+from scripts.update_oui_db import download_oui_database
+from services.oui import oui_database_status, refresh_oui_database
+
+
+SETUP_VERSION = 1
+_SETUP_STATUSES = {'in_progress', 'complete'}
+_BROWSER_COMMANDS = ['wkhtmltoimage', 'chromium', 'chromium-browser', 'google-chrome']
+_PACKAGE_MANAGERS = ['apt-get', 'apk', 'dnf', 'yum', 'pacman']
+
+
+def _blank_state():
+    return {
+        'version': SETUP_VERSION,
+        'status': 'in_progress',
+        'started_at': None,
+        'completed_at': None,
+        'completed_by': None,
+        'completion_mode': None,
+        'components': {},
+    }
+
+
+def setup_state(user):
+    """Return normalized setup state without forcing legacy users into onboarding."""
+    raw = (user or {}).get('setup_wizard')
+    if not isinstance(raw, dict):
+        return {
+            'version': SETUP_VERSION,
+            'status': 'complete',
+            'legacy_installation': True,
+            'started_at': None,
+            'completed_at': None,
+            'completed_by': None,
+            'completion_mode': 'legacy',
+            'components': {},
+        }
+    state = _blank_state()
+    state.update(deepcopy(raw))
+    if state.get('status') not in _SETUP_STATUSES:
+        state['status'] = 'in_progress'
+    if not isinstance(state.get('components'), dict):
+        state['components'] = {}
+    return state
+
+
+def setup_required(user):
+    """Return True only for accounts explicitly enrolled in first-run setup."""
+    raw = (user or {}).get('setup_wizard')
+    return isinstance(raw, dict) and setup_state(user).get('status') != 'complete'
+
+
+def begin_setup(username, store, lock):
+    """Enroll the first administrator in guided setup."""
+    username = str(username or '').strip().casefold()
+    with lock:
+        user = store.get(username)
+        if not user:
+            raise ValueError('Account not found.')
+        previous = setup_state(user)
+        state = _blank_state()
+        state['started_at'] = time.time()
+        state['components'] = deepcopy(previous.get('components') or {})
+        user['setup_wizard'] = state
+        return deepcopy(state)
+
+
+def record_component_result(username, component_id, status, message, details, store, lock):
+    """Persist one installer result in the enrolled administrator account."""
+    username = str(username or '').strip().casefold()
+    component_id = str(component_id or '').strip()
+    with lock:
+        user = store.get(username)
+        if not user:
+            raise ValueError('Account not found.')
+        state = setup_state(user)
+        state.setdefault('components', {})[component_id] = {
+            'status': str(status or 'unknown'),
+            'message': str(message or ''),
+            'details': deepcopy(details or {}),
+            'updated_at': time.time(),
+        }
+        user['setup_wizard'] = state
+        return deepcopy(state['components'][component_id])
+
+
+def complete_setup(username, mode, store, lock):
+    """Mark guided setup complete while retaining component results."""
+    username = str(username or '').strip().casefold()
+    mode = str(mode or 'completed').strip().casefold()
+    if mode not in {'completed', 'skipped'}:
+        raise ValueError('Unsupported setup completion mode.')
+    with lock:
+        user = store.get(username)
+        if not user:
+            raise ValueError('Account not found.')
+        state = setup_state(user)
+        state.update({
+            'version': SETUP_VERSION,
+            'status': 'complete',
+            'completed_at': time.time(),
+            'completed_by': username,
+            'completion_mode': mode,
+        })
+        user['setup_wizard'] = state
+        return deepcopy(state)
+
+
+def _python_component(package, name, description, question, recommended=False, applicable=True):
+    installed = package_status([package]).get(package, False)
+    return {
+        'id': f'python-{package}',
+        'category': 'Python integration',
+        'name': name,
+        'description': description,
+        'question': question,
+        'recommended': recommended,
+        'applicable': applicable,
+        'installable': applicable,
+        'installed': installed,
+        'status_label': 'Installed' if installed else 'Not installed',
+        'impact': f'Installs {OPTIONAL_PACKAGE_SPECS[package]} into the current Python environment.',
+    }
+
+
+def component_catalog(system_name=None):
+    """Return platform-aware optional downloads for the setup interface."""
+    system_name = system_name or platform.system()
+    oui_status = oui_database_status()
+    browser_commands = command_status(_BROWSER_COMMANDS)
+    browser_installed = any(item.get('available') for item in browser_commands.values())
+    browser_supported = system_name == 'Linux' and any(shutil.which(name) for name in _PACKAGE_MANAGERS)
+
+    components = [
+        {
+            'id': 'oui-database',
+            'category': 'Vendor data',
+            'name': 'Full IEEE OUI vendor database',
+            'description': 'Improves MAC-address manufacturer identification across inventory, scans, and reports. Core lookups still work with the compact bundled fallback.',
+            'question': 'Would you like to download the full IEEE OUI database?',
+            'recommended': True,
+            'applicable': True,
+            'installable': True,
+            'installed': not bool(oui_status.get('needs_refresh')),
+            'status_label': (
+                f"Full database available ({int(oui_status.get('entries') or 0):,} entries)"
+                if not oui_status.get('needs_refresh')
+                else f"Compact database active ({int(oui_status.get('entries') or 0):,} entries)"
+            ),
+            'impact': 'Downloads a public IEEE CSV and stores it locally for offline vendor lookup.',
+        },
+        _python_component(
+            'bleak',
+            'Bluetooth Low Energy support',
+            'Adds cross-platform BLE discovery when the host Bluetooth stack is available.',
+            'Would you like to install enhanced Bluetooth discovery support?',
+            recommended=False,
+        ),
+        _python_component(
+            'scapy',
+            'Advanced packet and wireless support',
+            'Enables deeper packet parsing and Linux monitor-mode workflows where the adapter and driver support them.',
+            'Would you like to install advanced packet support?',
+            recommended=False,
+        ),
+        _python_component(
+            'pywifi',
+            'Windows Wi-Fi management support',
+            'Adds optional Windows Wi-Fi connection management beyond the built-in netsh integration.',
+            'Would you like to install Windows Wi-Fi management support?',
+            recommended=False,
+            applicable=system_name == 'Windows',
+        ),
+        {
+            'id': 'browser-screenshot',
+            'category': 'Host integration',
+            'name': 'Browser screenshot tooling',
+            'description': 'Enables preview thumbnails for discovered HTTP services and saved service pages.',
+            'question': 'Would you like to install browser preview support?',
+            'recommended': False,
+            'applicable': system_name == 'Linux',
+            'installable': browser_supported,
+            'installed': browser_installed,
+            'status_label': (
+                'Installed'
+                if browser_installed
+                else ('Available to install' if browser_supported else 'Manual installation required')
+            ),
+            'impact': 'Uses the host package manager to install Chromium. This is larger than the Python-only options.',
+        },
+    ]
+    return [component for component in components if component.get('applicable')]
+
+
+def install_component(component_id):
+    """Install one allow-listed setup component and return a safe result."""
+    component_id = str(component_id or '').strip()
+    catalog = {component['id']: component for component in component_catalog()}
+    component = catalog.get(component_id)
+    if not component:
+        raise ValueError('Unsupported setup component.')
+    if not component.get('installable'):
+        raise ValueError('This component must be installed manually on this host.')
+    if component.get('installed'):
+        return {
+            'component': component_id,
+            'installed': True,
+            'message': f"{component['name']} is already available.",
+        }
+
+    if component_id == 'oui-database':
+        path, count = download_oui_database()
+        status = refresh_oui_database()
+        return {
+            'component': component_id,
+            'installed': not bool(status.get('needs_refresh')),
+            'message': f'Downloaded {count:,} IEEE OUI entries.',
+            'path': path,
+            'count': count,
+            'oui_database': status,
+        }
+    if component_id == 'browser-screenshot':
+        result = install_host_dependency('browser-screenshot')
+        return {'component': component_id, **result}
+    if component_id.startswith('python-'):
+        package = component_id.removeprefix('python-')
+        result = install_optional_package(package)
+        return {
+            'component': component_id,
+            'message': f"Installed {OPTIONAL_PACKAGE_SPECS[package]}.",
+            **result,
+        }
+    raise ValueError('Unsupported setup component.')

--- a/static/css/setup-wizard.css
+++ b/static/css/setup-wizard.css
@@ -1,0 +1,259 @@
+.setup-wizard-hero {
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.setup-wizard-progress-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .6rem;
+  max-width: 32rem;
+}
+
+.setup-progress-step {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  padding: .5rem .75rem;
+  border: 1px solid var(--theme-border, rgba(127, 127, 127, .35));
+  border-radius: 999px;
+  color: var(--theme-muted, #6c757d);
+  font-size: .88rem;
+}
+
+.setup-progress-step.is-complete,
+.setup-progress-step.is-current {
+  color: var(--theme-text, inherit);
+  border-color: var(--theme-primary, #0d6efd);
+}
+
+.setup-progress-step.is-current {
+  background: color-mix(in srgb, var(--theme-primary, #0d6efd) 12%, transparent);
+  font-weight: 700;
+}
+
+.setup-wizard-intro,
+.setup-component-card,
+.setup-wizard-actions {
+  margin-bottom: 1rem;
+}
+
+.setup-intro-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(17rem, .8fr);
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.setup-privacy-note {
+  display: flex;
+  align-items: flex-start;
+  gap: .8rem;
+  padding: 1rem;
+  border-radius: .8rem;
+  background: color-mix(in srgb, var(--theme-primary, #0d6efd) 8%, transparent);
+}
+
+.setup-privacy-note i {
+  margin-top: .15rem;
+  font-size: 1.35rem;
+}
+
+.setup-privacy-note span,
+.setup-privacy-note small {
+  display: block;
+}
+
+.setup-privacy-note small {
+  margin-top: .2rem;
+  color: var(--theme-muted, #6c757d);
+}
+
+.setup-component-list {
+  display: block;
+}
+
+.setup-component-card {
+  transition: border-color .18s ease, box-shadow .18s ease;
+}
+
+.setup-component-card:has(input:checked) {
+  border-color: var(--theme-primary, #0d6efd);
+  box-shadow: 0 0 0 2px color-mix(in srgb, var(--theme-primary, #0d6efd) 15%, transparent);
+}
+
+.setup-component-card.is-installed {
+  border-color: rgba(40, 167, 69, .45);
+}
+
+.setup-component-heading {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  gap: .9rem;
+  align-items: center;
+  margin-bottom: .9rem;
+}
+
+.setup-component-icon {
+  display: grid;
+  place-items: center;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: .75rem;
+  background: color-mix(in srgb, var(--theme-primary, #0d6efd) 12%, transparent);
+  font-size: 1.25rem;
+}
+
+.setup-component-title h2 {
+  margin: 0;
+  font-size: 1.15rem;
+}
+
+.setup-component-category {
+  display: block;
+  color: var(--theme-muted, #6c757d);
+  font-size: .75rem;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.setup-component-status {
+  padding: .35rem .6rem;
+  border-radius: 999px;
+  background: rgba(108, 117, 125, .12);
+  color: var(--theme-muted, #6c757d);
+  font-size: .78rem;
+  font-weight: 700;
+  white-space: nowrap;
+}
+
+.setup-component-status.is-success {
+  background: rgba(40, 167, 69, .15);
+  color: #218838;
+}
+
+.setup-component-status.is-error {
+  background: rgba(220, 53, 69, .15);
+  color: #c82333;
+}
+
+.setup-component-status.is-manual {
+  background: rgba(255, 193, 7, .18);
+  color: #8a6d00;
+}
+
+.setup-component-question {
+  margin-bottom: .35rem;
+}
+
+.setup-component-impact {
+  display: flex;
+  gap: .45rem;
+  align-items: flex-start;
+  color: var(--theme-muted, #6c757d);
+  font-size: .9rem;
+}
+
+.setup-component-choice {
+  display: flex;
+  align-items: center;
+  gap: .65rem;
+  margin: 1rem 0 0;
+  padding: .85rem 1rem;
+  border: 1px solid var(--theme-border, rgba(127, 127, 127, .35));
+  border-radius: .75rem;
+  cursor: pointer;
+}
+
+.setup-component-choice input {
+  width: 1.15rem;
+  height: 1.15rem;
+}
+
+.setup-component-choice em {
+  margin-left: .35rem;
+  color: var(--theme-primary, #0d6efd);
+  font-style: normal;
+  font-weight: 700;
+}
+
+.setup-component-choice.is-disabled {
+  cursor: default;
+  opacity: .72;
+}
+
+.setup-previous-result,
+.setup-component-live-result:not(:empty) {
+  margin-top: .75rem;
+  padding: .65rem .8rem;
+  border-radius: .6rem;
+  background: rgba(108, 117, 125, .1);
+  font-size: .9rem;
+}
+
+.setup-result-installed,
+.setup-component-live-result.is-success {
+  background: rgba(40, 167, 69, .13);
+}
+
+.setup-result-failed,
+.setup-component-live-result.is-error {
+  background: rgba(220, 53, 69, .13);
+}
+
+.setup-install-progress {
+  margin-bottom: 1rem;
+}
+
+.setup-progress-bar {
+  height: .65rem;
+  overflow: hidden;
+  border-radius: 999px;
+  background: rgba(108, 117, 125, .2);
+}
+
+.setup-progress-bar span {
+  display: block;
+  width: 0;
+  height: 100%;
+  border-radius: inherit;
+  background: var(--theme-primary, #0d6efd);
+  transition: width .2s ease;
+}
+
+.setup-install-progress p {
+  margin: .55rem 0 0;
+}
+
+.setup-action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: .75rem;
+  align-items: center;
+}
+
+.setup-skip-form {
+  margin: .25rem 0 2rem;
+  text-align: center;
+}
+
+.user-reduced-motion .setup-component-card,
+.user-reduced-motion .setup-progress-bar span {
+  transition: none;
+}
+
+@media (max-width: 800px) {
+  .setup-intro-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .setup-component-heading {
+    grid-template-columns: auto minmax(0, 1fr);
+  }
+
+  .setup-component-status {
+    grid-column: 1 / -1;
+    justify-self: start;
+  }
+}

--- a/static/js/setup-wizard.js
+++ b/static/js/setup-wizard.js
@@ -1,0 +1,150 @@
+document.addEventListener('DOMContentLoaded', function () {
+  const form = document.getElementById('setup-wizard-form');
+  if (!form) {
+    return;
+  }
+
+  const csrfToken = form.dataset.csrfToken || '';
+  const submitButton = document.getElementById('install-selected-components');
+  const finishAnywayButton = document.getElementById('finish-setup-anyway');
+  const progressPanel = document.getElementById('setup-install-progress');
+  const progressFill = document.getElementById('setup-progress-fill');
+  const progressLabel = document.getElementById('setup-progress-label');
+  const warning = document.getElementById('setup-install-warning');
+
+  function setBusy(isBusy) {
+    submitButton.disabled = isBusy;
+    form.querySelectorAll('input[name="components"]').forEach(function (input) {
+      if (!input.closest('.is-installed')) {
+        input.disabled = isBusy || input.dataset.permanentlyDisabled === 'true';
+      }
+    });
+  }
+
+  function updateCard(componentId, success, message) {
+    const card = form.querySelector(`[data-setup-component="${CSS.escape(componentId)}"]`);
+    if (!card) {
+      return;
+    }
+    const result = card.querySelector('[data-component-result]');
+    const status = card.querySelector('[data-component-status]');
+    result.textContent = message;
+    result.classList.toggle('is-success', success);
+    result.classList.toggle('is-error', !success);
+    status.textContent = success ? 'Installed' : 'Install failed';
+    status.classList.toggle('is-success', success);
+    status.classList.toggle('is-error', !success);
+    if (success) {
+      card.classList.add('is-installed');
+      const checkbox = card.querySelector('input[name="components"]');
+      if (checkbox) {
+        checkbox.checked = false;
+        checkbox.disabled = true;
+        checkbox.dataset.permanentlyDisabled = 'true';
+      }
+    }
+  }
+
+  async function postForm(url, fields) {
+    const body = new URLSearchParams({csrf_token: csrfToken, ...fields});
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded;charset=UTF-8',
+        'X-Requested-With': 'XMLHttpRequest'
+      },
+      body: body.toString()
+    });
+    let payload = {};
+    try {
+      payload = await response.json();
+    } catch (error) {
+      payload = {error: 'The server returned an unreadable response.'};
+    }
+    if (!response.ok) {
+      throw new Error(payload.error || payload.message || 'Installation failed.');
+    }
+    return payload;
+  }
+
+  async function finishSetup() {
+    progressLabel.textContent = 'Saving setup choices…';
+    const response = await postForm('/setup-wizard/complete', {mode: 'completed'});
+    window.location.assign(response.redirect || '/');
+  }
+
+  form.addEventListener('submit', async function (event) {
+    event.preventDefault();
+    const selected = Array.from(
+      form.querySelectorAll('input[name="components"]:checked:not(:disabled)')
+    ).map(function (input) { return input.value; });
+
+    progressPanel.hidden = false;
+    warning.hidden = true;
+    finishAnywayButton.hidden = true;
+    setBusy(true);
+
+    if (!selected.length) {
+      try {
+        await finishSetup();
+      } catch (error) {
+        progressLabel.textContent = error.message;
+        warning.hidden = false;
+        setBusy(false);
+      }
+      return;
+    }
+
+    let failures = 0;
+    for (let index = 0; index < selected.length; index += 1) {
+      const componentId = selected[index];
+      const card = form.querySelector(`[data-setup-component="${CSS.escape(componentId)}"]`);
+      const componentName = card && card.querySelector('h2')
+        ? card.querySelector('h2').textContent.trim()
+        : componentId;
+      progressLabel.textContent = `Installing ${componentName} (${index + 1} of ${selected.length})…`;
+      progressFill.style.width = `${Math.round((index / selected.length) * 100)}%`;
+
+      try {
+        const response = await postForm('/setup-wizard/install', {component: componentId});
+        const result = response.result || {};
+        updateCard(componentId, true, result.message || `${componentName} installed.`);
+      } catch (error) {
+        failures += 1;
+        updateCard(componentId, false, error.message);
+      }
+    }
+
+    progressFill.style.width = '100%';
+    if (failures) {
+      progressLabel.textContent = `${selected.length - failures} installed, ${failures} failed.`;
+      warning.hidden = false;
+      finishAnywayButton.hidden = false;
+      setBusy(false);
+      return;
+    }
+
+    try {
+      await finishSetup();
+    } catch (error) {
+      progressLabel.textContent = error.message;
+      warning.hidden = false;
+      finishAnywayButton.hidden = false;
+      setBusy(false);
+    }
+  });
+
+  finishAnywayButton.addEventListener('click', async function () {
+    finishAnywayButton.disabled = true;
+    try {
+      await finishSetup();
+    } catch (error) {
+      progressLabel.textContent = error.message;
+      finishAnywayButton.disabled = false;
+    }
+  });
+
+  form.querySelectorAll('input[name="components"]:disabled').forEach(function (input) {
+    input.dataset.permanentlyDisabled = 'true';
+  });
+});

--- a/templates/_primary-nav-links.html
+++ b/templates/_primary-nav-links.html
@@ -85,13 +85,17 @@
 <div class="nav-item dropdown nav-compact-group">
   <button type="button"
           id="system-menu"
-          class="nav-link dropdown-toggle {% if title in ['Capabilities', 'Roadmap'] %}active{% endif %}"
+          class="nav-link dropdown-toggle {% if title in ['Setup Wizard', 'Capabilities', 'Roadmap'] %}active{% endif %}"
           data-navigation-toggle="dropdown"
           aria-haspopup="true"
           aria-expanded="false">
     System
   </button>
   <div class="dropdown-menu navigation-menu" aria-labelledby="system-menu">
+    {% if app_user and app_user.role == 'admin' %}
+      <a href="/setup-wizard" class="dropdown-item {% if title == 'Setup Wizard' %}active{% endif %}" {% if title == 'Setup Wizard' %}aria-current="page"{% endif %}>Setup Wizard</a>
+      <div class="dropdown-divider"></div>
+    {% endif %}
     <a href="/capabilities" class="dropdown-item {% if title == 'Capabilities' %}active{% endif %}" {% if title == 'Capabilities' %}aria-current="page"{% endif %}>Capabilities</a>
     <a href="/roadmap" class="dropdown-item {% if title == 'Roadmap' %}active{% endif %}" {% if title == 'Roadmap' %}aria-current="page"{% endif %}>Roadmap</a>
   </div>

--- a/templates/setup_wizard.html
+++ b/templates/setup_wizard.html
@@ -1,0 +1,125 @@
+{% extends 'base.html' %}
+
+{% block title %}Setup Wizard{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" href="{{ url_for('static', filename='css/setup-wizard.css') }}">
+
+<section class="page-hero setup-wizard-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">{{ 'First-run configuration' if first_run else 'System configuration' }}</p>
+    <h1 class="page-title">{{ 'Welcome to Mobile Router' if first_run else 'Setup Wizard' }}</h1>
+    <p class="page-subtitle">
+      {% if first_run %}
+        The core application is ready. Choose which optional data and integrations you would like to download before continuing.
+      {% else %}
+        Review optional components, install anything you skipped previously, or refresh local data.
+      {% endif %}
+    </p>
+  </div>
+  <div class="setup-wizard-progress-summary" aria-label="Setup progress">
+    <span class="setup-progress-step is-complete"><i class="fa-solid fa-check" aria-hidden="true"></i> Administrator</span>
+    <span class="setup-progress-step is-current"><i class="fa-solid fa-download" aria-hidden="true"></i> Optional downloads</span>
+    <span class="setup-progress-step"><i class="fa-solid fa-flag-checkered" aria-hidden="true"></i> Finish</span>
+  </div>
+</section>
+
+{% if error %}<div class="alert alert-danger" role="alert">{{ error }}</div>{% endif %}
+
+<section class="setup-wizard-intro theme-card card">
+  <div class="card-body">
+    <div class="setup-intro-grid">
+      <div>
+        <h2 class="theme-section-title">Choose what to add</h2>
+        <p>Nothing on this page is required for the web interface, inventory, reports, or basic network tools. Each selection is installed only after you confirm it.</p>
+      </div>
+      <div class="setup-privacy-note">
+        <i class="fa-solid fa-shield-halved" aria-hidden="true"></i>
+        <span><strong>Local-first setup</strong><small>Downloaded data and packages remain on this device. No account or scan data is uploaded by the wizard.</small></span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<form id="setup-wizard-form" class="setup-component-list" data-csrf-token="{{ csrf_token }}">
+  {% for component in components %}
+    {% set previous = setup_state.components.get(component.id) if setup_state.components else none %}
+    <article class="setup-component-card theme-card card {% if component.installed %}is-installed{% endif %}" data-setup-component="{{ component.id }}">
+      <div class="card-body">
+        <div class="setup-component-heading">
+          <div class="setup-component-icon">
+            {% if component.id == 'oui-database' %}<i class="fa-solid fa-database" aria-hidden="true"></i>
+            {% elif component.id == 'browser-screenshot' %}<i class="fa-solid fa-camera" aria-hidden="true"></i>
+            {% elif component.id == 'python-bleak' %}<i class="fa-brands fa-bluetooth-b" aria-hidden="true"></i>
+            {% elif component.id == 'python-scapy' %}<i class="fa-solid fa-wave-square" aria-hidden="true"></i>
+            {% else %}<i class="fa-solid fa-wifi" aria-hidden="true"></i>{% endif %}
+          </div>
+          <div class="setup-component-title">
+            <span class="setup-component-category">{{ component.category }}</span>
+            <h2>{{ component.name }}</h2>
+          </div>
+          <span class="setup-component-status {% if component.installed %}is-success{% elif not component.installable %}is-manual{% endif %}" data-component-status>
+            {{ component.status_label }}
+          </span>
+        </div>
+
+        <p class="setup-component-question"><strong>{{ component.question }}</strong></p>
+        <p>{{ component.description }}</p>
+        <p class="setup-component-impact"><i class="fa-solid fa-circle-info" aria-hidden="true"></i> {{ component.impact }}</p>
+
+        {% if previous %}
+          <div class="setup-previous-result setup-result-{{ previous.status }}">
+            <strong>Previous result:</strong> {{ previous.message or previous.status }}
+          </div>
+        {% endif %}
+
+        <label class="setup-component-choice {% if component.installed or not component.installable %}is-disabled{% endif %}">
+          <input type="checkbox"
+                 name="components"
+                 value="{{ component.id }}"
+                 {% if component.recommended and not component.installed and component.installable %}checked{% endif %}
+                 {% if component.installed or not component.installable %}disabled{% endif %}>
+          <span>
+            {% if component.installed %}Already available
+            {% elif not component.installable %}Install manually from the Capabilities page
+            {% else %}Yes, install this optional component{% if component.recommended %} <em>Recommended</em>{% endif %}
+            {% endif %}
+          </span>
+        </label>
+        <div class="setup-component-live-result" data-component-result aria-live="polite"></div>
+      </div>
+    </article>
+  {% endfor %}
+
+  <section class="setup-wizard-actions theme-card card">
+    <div class="card-body">
+      <div id="setup-install-progress" class="setup-install-progress" hidden>
+        <div class="setup-progress-bar" aria-hidden="true"><span id="setup-progress-fill"></span></div>
+        <p id="setup-progress-label" role="status" aria-live="polite">Preparing optional downloads…</p>
+      </div>
+      <div id="setup-install-warning" class="alert alert-warning" hidden role="alert">
+        One or more optional components could not be installed. You can retry the failed items, finish without them, or install them later from this wizard.
+      </div>
+      <div class="setup-action-row">
+        <button id="install-selected-components" class="btn btn-primary btn-lg" type="submit">
+          <i class="fa-solid fa-download" aria-hidden="true"></i>
+          Install selected and finish
+        </button>
+        <button id="finish-setup-anyway" class="btn btn-outline-primary" type="button" hidden>
+          Finish without failed components
+        </button>
+      </div>
+    </div>
+  </section>
+</form>
+
+<form class="setup-skip-form" method="post" action="/setup-wizard/complete">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+  <input type="hidden" name="mode" value="skipped">
+  <button class="btn btn-link" type="submit">
+    {{ 'Skip optional downloads and continue' if first_run else 'Close setup wizard without installing anything' }}
+  </button>
+</form>
+
+<script src="{{ url_for('static', filename='js/setup-wizard.js') }}"></script>
+{% endblock %}

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -5,6 +5,7 @@ import pytest
 
 import app as app_module
 from app import app
+from app_support.navigation import build_navigation_context
 from services import setup_wizard
 
 
@@ -90,7 +91,7 @@ def test_setup_component_install_is_allow_listed_and_recorded(isolated_users):
         'message': 'Downloaded 35,000 IEEE OUI entries.',
     }
 
-    with patch('routes.social_auth.setup_wizard_service.install_component', return_value=result), \
+    with patch('routes.setup_wizard.setup_wizard_service.install_component', return_value=result), \
             patch('app.save_runtime_state') as save_state:
         response = client.post('/setup-wizard/install', data={
             'component': 'oui-database',
@@ -132,6 +133,19 @@ def test_setup_catalog_is_platform_aware():
     assert 'python-pywifi' not in linux_components
     assert 'python-pywifi' in windows_components
     assert 'browser-screenshot' not in windows_components
+
+
+def test_setup_wizard_search_item_is_admin_only():
+    common = (None, (), ())
+    admin_context = build_navigation_context(
+        '/', 'Home', *common, {'role': 'admin'}, (), ()
+    )
+    viewer_context = build_navigation_context(
+        '/', 'Home', *common, {'role': 'viewer'}, (), ()
+    )
+
+    assert any(item['url'] == '/setup-wizard' for item in admin_context['search_items'])
+    assert all(item['url'] != '/setup-wizard' for item in viewer_context['search_items'])
 
 
 def test_unknown_setup_components_are_rejected():

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -102,6 +102,10 @@ def test_setup_component_install_is_allow_listed_and_recorded(isolated_users):
         }, headers={'X-Requested-With': 'XMLHttpRequest'})
 
     assert response.status_code == 200
+    response_result = response.get_json()['result']
+    assert response_result['count'] == 35000
+    assert 'output' not in response_result
+    assert 'commands' not in response_result
     recorded = app_module.social_users['setup-admin']['setup_wizard']['components']['oui-database']
     assert recorded['status'] == 'installed'
     assert '35,000' in recorded['message']

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -1,0 +1,139 @@
+from copy import deepcopy
+from unittest.mock import patch
+
+import pytest
+
+import app as app_module
+from app import app
+from services import setup_wizard
+
+
+@pytest.fixture
+def isolated_users():
+    with app_module.social_users_lock:
+        original = deepcopy(app_module.social_users)
+        app_module.social_users.clear()
+    yield
+    with app_module.social_users_lock:
+        app_module.social_users.clear()
+        app_module.social_users.update(original)
+
+
+def authenticated_client(username='setup-admin', role='admin', csrf_token='setup-token'):
+    client = app.test_client()
+    with client.session_transaction() as flask_session:
+        flask_session['social_user'] = {'username': username, 'role': role}
+        flask_session['social_csrf_token'] = csrf_token
+    return client, csrf_token
+
+
+def add_admin(username='setup-admin', enrolled=True):
+    with app_module.social_users_lock:
+        app_module.social_users[username] = {
+            'id': username,
+            'username': username,
+            'display_name': 'Setup Administrator',
+            'email': '',
+            'role': 'admin',
+            'password_hash': 'unused',
+            'preferences': {'default_landing_page': '/'},
+        }
+    if enrolled:
+        setup_wizard.begin_setup(
+            username, app_module.social_users, app_module.social_users_lock
+        )
+
+
+def test_legacy_accounts_are_not_forced_into_new_setup():
+    user = {'username': 'existing-admin', 'role': 'admin'}
+
+    assert setup_wizard.setup_required(user) is False
+    assert setup_wizard.setup_state(user)['completion_mode'] == 'legacy'
+
+
+def test_first_account_creation_redirects_to_setup_wizard(isolated_users):
+    client = app.test_client()
+    with client.session_transaction() as flask_session:
+        flask_session['social_csrf_token'] = 'first-run-token'
+
+    with patch('app.save_runtime_state'):
+        response = client.post('/setup', data={
+            'username': 'first-admin',
+            'password': 'a-secure-first-password',
+            'csrf_token': 'first-run-token',
+        })
+
+    assert response.status_code == 302
+    assert response.location.endswith('/setup-wizard')
+    assert setup_wizard.setup_required(app_module.social_users['first-admin']) is True
+
+
+def test_setup_wizard_page_explains_optional_downloads(isolated_users):
+    add_admin()
+    client, _ = authenticated_client()
+
+    response = client.get('/setup-wizard')
+
+    assert response.status_code == 200
+    assert b'Welcome to Mobile Router' in response.data
+    assert b'Would you like to download the full IEEE OUI database?' in response.data
+    assert b'Nothing on this page is required' in response.data
+    assert b'Skip optional downloads and continue' in response.data
+
+
+def test_setup_component_install_is_allow_listed_and_recorded(isolated_users):
+    add_admin()
+    client, csrf_token = authenticated_client()
+    result = {
+        'component': 'oui-database',
+        'installed': True,
+        'message': 'Downloaded 35,000 IEEE OUI entries.',
+    }
+
+    with patch('routes.social_auth.setup_wizard_service.install_component', return_value=result), \
+            patch('app.save_runtime_state') as save_state:
+        response = client.post('/setup-wizard/install', data={
+            'component': 'oui-database',
+            'csrf_token': csrf_token,
+        }, headers={'X-Requested-With': 'XMLHttpRequest'})
+
+    assert response.status_code == 200
+    recorded = app_module.social_users['setup-admin']['setup_wizard']['components']['oui-database']
+    assert recorded['status'] == 'installed'
+    assert '35,000' in recorded['message']
+    save_state.assert_called_once_with('setup-component-install')
+
+
+def test_setup_completion_persists_and_returns_to_landing_page(isolated_users):
+    add_admin()
+    client, csrf_token = authenticated_client()
+
+    with patch('app.save_runtime_state') as save_state:
+        response = client.post('/setup-wizard/complete', data={
+            'mode': 'skipped',
+            'csrf_token': csrf_token,
+        })
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    state = app_module.social_users['setup-admin']['setup_wizard']
+    assert state['status'] == 'complete'
+    assert state['completion_mode'] == 'skipped'
+    assert setup_wizard.setup_required(app_module.social_users['setup-admin']) is False
+    save_state.assert_called_once_with('setup-wizard-complete')
+
+
+def test_setup_catalog_is_platform_aware():
+    linux_components = {item['id']: item for item in setup_wizard.component_catalog('Linux')}
+    windows_components = {item['id']: item for item in setup_wizard.component_catalog('Windows')}
+
+    assert linux_components['oui-database']['recommended'] is True
+    assert 'browser-screenshot' in linux_components
+    assert 'python-pywifi' not in linux_components
+    assert 'python-pywifi' in windows_components
+    assert 'browser-screenshot' not in windows_components
+
+
+def test_unknown_setup_components_are_rejected():
+    with pytest.raises(ValueError, match='Unsupported setup component'):
+        setup_wizard.install_component('arbitrary-shell-command')

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -136,12 +136,11 @@ def test_setup_catalog_is_platform_aware():
 
 
 def test_setup_wizard_search_item_is_admin_only():
-    common = (None, (), ())
     admin_context = build_navigation_context(
-        '/', 'Home', *common, {'role': 'admin'}, (), ()
+        '/', 'Home', None, {'role': 'admin'}, (), ()
     )
     viewer_context = build_navigation_context(
-        '/', 'Home', *common, {'role': 'viewer'}, (), ()
+        '/', 'Home', None, {'role': 'viewer'}, (), ()
     )
 
     assert any(item['url'] == '/setup-wizard' for item in admin_context['search_items'])

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -89,6 +89,9 @@ def test_setup_component_install_is_allow_listed_and_recorded(isolated_users):
         'component': 'oui-database',
         'installed': True,
         'message': 'Downloaded 35,000 IEEE OUI entries.',
+        'count': 35000,
+        'output': 'verbose installer output that must not enter user state',
+        'commands': [{'command': 'package-manager install'}],
     }
 
     with patch('routes.setup_wizard.setup_wizard_service.install_component', return_value=result), \
@@ -102,6 +105,9 @@ def test_setup_component_install_is_allow_listed_and_recorded(isolated_users):
     recorded = app_module.social_users['setup-admin']['setup_wizard']['components']['oui-database']
     assert recorded['status'] == 'installed'
     assert '35,000' in recorded['message']
+    assert recorded['details']['count'] == 35000
+    assert 'output' not in recorded['details']
+    assert 'commands' not in recorded['details']
     save_state.assert_called_once_with('setup-component-install')
 
 


### PR DESCRIPTION
## Summary

- redirect the first administrator into a guided setup wizard immediately after account creation;
- explain that core operation does not require any optional download;
- offer allow-listed optional components including the full IEEE OUI database, Bleak, Scapy, platform-appropriate PyWiFi, and Linux browser screenshot tooling;
- show installation impact, current status, recommended choices, sequential progress, and per-component errors before finishing;
- persist first-run progress and safe result summaries so interrupted setup resumes after login without storing verbose installer logs;
- allow setup to be skipped, retried after failures, or reopened later by administrators from the System menu;
- treat existing accounts without wizard metadata as already configured, avoiding upgrade lockouts;
- keep the wizard, menu entry, and quick-search result administrator-only;
- retain CSRF, audit, runtime persistence, bounded error messages, and an explicit installer allow-list.

## Validation

- Python compilation passed on Ubuntu and Windows;
- application startup import passed on Ubuntu and Windows;
- 331 tests passed and 1 skipped on Ubuntu;
- 331 tests passed and 1 skipped on Windows;
- duplicate-code audit scanned 89 Python files and 724 non-trivial functions with no exact duplicate bodies;
- changed-file sweep contains nine focused application/test files and no temporary workflows or migration assets.