### PR TITLE
Add bounded deauth Start/Stop controls

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -3,6 +3,7 @@ from .capabilities import create_capabilities_blueprint
 from .minecraft import create_minecraft_blueprint
 from .train_controller import create_train_controller_blueprint
 from .automotive import create_automotive_blueprint
+from .deauth_control import create_deauth_control_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -11,3 +12,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_minecraft_blueprint(context_provider))
     app.register_blueprint(create_train_controller_blueprint(context_provider))
     app.register_blueprint(create_automotive_blueprint(context_provider))
+    app.register_blueprint(create_deauth_control_blueprint(context_provider))

--- a/routes/deauth_control.py
+++ b/routes/deauth_control.py
@@ -1,0 +1,145 @@
+"""Administrator-only routes for bounded deauthentication lab control."""
+
+from functools import wraps
+import secrets
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+from services import deauth_control as deauth_control_service
+
+
+def _admin_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        user = session.get("social_user") or {}
+        if not user:
+            return jsonify({"status": "error", "message": "Administrator login required"}), 401
+        if user.get("role") != "admin":
+            return jsonify({"status": "error", "message": "Administrator role required"}), 403
+        if request.method != "GET":
+            expected = session.get("social_csrf_token") or ""
+            supplied = (
+                request.form.get("csrf_token")
+                or request.headers.get("X-CSRF-Token")
+                or ""
+            )
+            if not expected or not secrets.compare_digest(str(expected), str(supplied)):
+                return jsonify({"status": "error", "message": "Invalid CSRF token"}), 400
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _error(message, status=400):
+    return jsonify({"status": "error", "message": str(message)}), status
+
+
+def create_deauth_control_blueprint(context_provider):
+    del context_provider
+    blueprint = Blueprint("deauth_control", __name__)
+
+    @blueprint.route("/deauth/start", methods=["POST"])
+    @_admin_required
+    def start_deauth():
+        data = request.form
+        selected_interface = (data.get("selectedInterface") or "").strip()
+        if not selected_interface:
+            return _error("Choose a wireless interface")
+
+        try:
+            ap_mac, target_mac = deauth_control_service.validate_start_request(
+                data,
+                _normalize_mac,
+            )
+            operator = (session.get("social_user") or {}).get("username") or "unknown"
+
+            def send_frame():
+                from scripts.wifi.deauth import send_deauth_frame
+
+                send_deauth_frame(ap_mac, target_mac, selected_interface)
+
+            job = deauth_control_service.start_deauth(
+                ap_mac=ap_mac,
+                target_mac=target_mac,
+                interface=selected_interface,
+                operator=operator,
+                send_frame=send_frame,
+            )
+        except ValueError as exc:
+            return _error(exc)
+        except Exception as exc:
+            current_app.logger.exception("Unable to start bounded deauth lab")
+            return _error(f"Deauth start error: {exc}", 500)
+
+        current_app.logger.warning(
+            "Bounded deauth lab started by %s for AP %s target %s on %s; hard deadline %.3f",
+            operator,
+            ap_mac,
+            target_mac,
+            selected_interface,
+            job["hard_deadline"],
+        )
+        return jsonify(
+            {
+                "status": "success",
+                "message": "Bounded deauth lab run started",
+                "job": job,
+            }
+        )
+
+    @blueprint.route("/deauth/heartbeat", methods=["POST"])
+    @_admin_required
+    def heartbeat_deauth():
+        job_id = (request.form.get("jobId") or "").strip()
+        if not job_id:
+            return _error("Missing bounded deauth job ID")
+        try:
+            job = deauth_control_service.heartbeat_deauth(job_id)
+        except ValueError as exc:
+            return _error(exc, 409)
+        return jsonify({"status": "success", "job": job})
+
+    @blueprint.route("/deauth/stop", methods=["POST"])
+    @_admin_required
+    def stop_deauth():
+        job_id = (request.form.get("jobId") or "").strip() or None
+        try:
+            job = deauth_control_service.stop_deauth(job_id, "manual_stop")
+        except ValueError as exc:
+            return _error(exc, 409)
+        current_app.logger.warning(
+            "Bounded deauth lab stop requested by %s",
+            (session.get("social_user") or {}).get("username") or "unknown",
+        )
+        return jsonify({"status": "success", "job": job})
+
+    @blueprint.route("/deauth/emergency-stop", methods=["POST"])
+    @_admin_required
+    def emergency_stop_deauth():
+        job = deauth_control_service.emergency_stop_deauth("web_emergency_stop")
+        current_app.logger.error(
+            "Bounded deauth emergency stop requested by %s",
+            (session.get("social_user") or {}).get("username") or "unknown",
+        )
+        return jsonify({"status": "success", "job": job})
+
+    @blueprint.route("/deauth/status")
+    @_admin_required
+    def deauth_status():
+        return jsonify(
+            {
+                "status": "success",
+                "job": deauth_control_service.deauth_status(),
+                "local_emergency_stop": (
+                    "python -m scripts.wifi.deauth_emergency_stop"
+                ),
+            }
+        )
+
+    return blueprint
+
+
+def _normalize_mac(value):
+    from app_support.identifiers import normalize_mac
+
+    return normalize_mac(value)

--- a/scripts/wifi/deauth.py
+++ b/scripts/wifi/deauth.py
@@ -23,8 +23,14 @@ def build_deauth_packet(ap_mac: str, target_mac: str):
     return RadioTap() / dot11 / Dot11Deauth(reason=DEFAULT_DEAUTH_REASON)
 
 
+def send_deauth_frame(ap_mac: str, target_mac: str, iface: str) -> None:
+    """Send one frame for the supervised bounded Start/Stop controller."""
+    packet = build_deauth_packet(ap_mac, target_mac)
+    sendp(packet, iface=iface, count=1, inter=0, verbose=False)
+
+
 def deauth(ap_mac: str, target_mac: str, iface: str, frames: int = 10) -> None:
-    """Send 802.11 deauthentication frames.
+    """Send a fixed number of 802.11 deauthentication frames.
 
     Parameters
     ----------

--- a/scripts/wifi/deauth_emergency_stop.py
+++ b/scripts/wifi/deauth_emergency_stop.py
@@ -1,0 +1,14 @@
+"""Create the local emergency-stop flag for a bounded deauth lab run."""
+
+from services.deauth_control import emergency_stop_path, request_emergency_stop
+
+
+def main() -> int:
+    path = request_emergency_stop()
+    print(f"Emergency stop requested via {path}")
+    print(f"Controller flag path: {emergency_stop_path()}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/deauth_control.py
+++ b/services/deauth_control.py
@@ -1,0 +1,329 @@
+"""Bounded, supervised controller for authorized deauthentication lab runs."""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import time
+import uuid
+from pathlib import Path
+from typing import Callable, Optional
+
+DEFAULT_MAX_RUN_SECONDS = 15.0
+DEFAULT_HEARTBEAT_GRACE_SECONDS = 5.0
+DEFAULT_SEND_INTERVAL_SECONDS = 0.1
+_MAX_ERROR_LENGTH = 500
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DEFAULT_STATE_DIR = _REPO_ROOT / "instance"
+_DEFAULT_ACTIVE_MARKER = _DEFAULT_STATE_DIR / "deauth_active.json"
+_DEFAULT_EMERGENCY_FLAG = _DEFAULT_STATE_DIR / "deauth_emergency_stop.flag"
+
+
+def _bounded_error(value: object) -> str:
+    return str(value or "").strip()[:_MAX_ERROR_LENGTH]
+
+
+def validate_start_request(data, normalize_mac):
+    """Validate the bounded Start/Stop controller inputs."""
+    ap_mac = normalize_mac(data.get("ap"))
+    target_mac = normalize_mac(data.get("target") or "ff:ff:ff:ff:ff:ff")
+    if not ap_mac:
+        raise ValueError("Enter a valid lab AP MAC address")
+    if not target_mac:
+        raise ValueError("Enter a valid target MAC address")
+    if ap_mac == "ff:ff:ff:ff:ff:ff":
+        raise ValueError("AP MAC must be a specific lab access point, not broadcast")
+    if data.get("authorized") != "on":
+        raise ValueError(
+            "Confirm this is an authorized isolated lab network before starting deauth"
+        )
+    return ap_mac, target_mac
+
+
+class BoundedDeauthController:
+    """Manage one short-lived deauthentication sender with fail-closed leases."""
+
+    def __init__(
+        self,
+        *,
+        max_run_seconds: float = DEFAULT_MAX_RUN_SECONDS,
+        heartbeat_grace_seconds: float = DEFAULT_HEARTBEAT_GRACE_SECONDS,
+        send_interval_seconds: float = DEFAULT_SEND_INTERVAL_SECONDS,
+        active_marker: Path | str = _DEFAULT_ACTIVE_MARKER,
+        emergency_flag: Path | str = _DEFAULT_EMERGENCY_FLAG,
+        time_fn: Callable[[], float] = time.time,
+    ):
+        self.max_run_seconds = float(max_run_seconds)
+        self.heartbeat_grace_seconds = float(heartbeat_grace_seconds)
+        self.send_interval_seconds = float(send_interval_seconds)
+        if self.max_run_seconds <= 0:
+            raise ValueError("Maximum run time must be greater than zero")
+        if self.heartbeat_grace_seconds <= 0:
+            raise ValueError("Heartbeat grace must be greater than zero")
+        if self.send_interval_seconds <= 0:
+            raise ValueError("Send interval must be greater than zero")
+
+        self.active_marker = Path(active_marker)
+        self.emergency_flag = Path(emergency_flag)
+        self._time = time_fn
+        self._lock = threading.Lock()
+        self._active = None
+        self._last = None
+        self.startup_cleanup()
+
+    def startup_cleanup(self) -> bool:
+        """Fail closed after restart and remove any stale active-job marker."""
+        self.emergency_flag.parent.mkdir(parents=True, exist_ok=True)
+        stale = self.active_marker.exists()
+        self.emergency_flag.write_text(
+            f"startup-cleanup {os.getpid()} {self._time():.6f}\n",
+            encoding="utf-8",
+        )
+        try:
+            self.active_marker.unlink()
+        except FileNotFoundError:
+            pass
+        return stale
+
+    def _write_marker(self, job: dict) -> None:
+        self.active_marker.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "id": job["id"],
+            "pid": os.getpid(),
+            "interface": job["interface"],
+            "ap": job["ap"],
+            "target": job["target"],
+            "operator": job["operator"],
+            "started_at": job["started_at"],
+            "hard_deadline": job["hard_deadline"],
+        }
+        temporary = self.active_marker.with_suffix(".tmp")
+        temporary.write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+        temporary.replace(self.active_marker)
+
+    def _clear_marker(self) -> None:
+        try:
+            self.active_marker.unlink()
+        except FileNotFoundError:
+            pass
+
+    def _public(self, job: Optional[dict]) -> dict:
+        if not job:
+            return {
+                "active": False,
+                "max_run_seconds": self.max_run_seconds,
+                "heartbeat_grace_seconds": self.heartbeat_grace_seconds,
+            }
+        now = self._time()
+        status = job.get("status", "stopped")
+        return {
+            "active": status in {"starting", "running", "stopping"},
+            "id": job["id"],
+            "status": status,
+            "interface": job["interface"],
+            "ap": job["ap"],
+            "target": job["target"],
+            "operator": job["operator"],
+            "started_at": job["started_at"],
+            "stopped_at": job.get("stopped_at"),
+            "hard_deadline": job["hard_deadline"],
+            "heartbeat_deadline": job["heartbeat_deadline"],
+            "remaining_seconds": max(0.0, job["hard_deadline"] - now),
+            "frames_sent": job.get("frames_sent", 0),
+            "stop_reason": job.get("stop_reason"),
+            "error": job.get("error"),
+            "max_run_seconds": self.max_run_seconds,
+            "heartbeat_grace_seconds": self.heartbeat_grace_seconds,
+        }
+
+    def status(self) -> dict:
+        with self._lock:
+            return self._public(self._active or self._last)
+
+    def start(
+        self,
+        *,
+        ap_mac: str,
+        target_mac: str,
+        interface: str,
+        operator: str,
+        send_frame: Callable[[], None],
+    ) -> dict:
+        now = self._time()
+        with self._lock:
+            if self._active and self._active.get("status") in {
+                "starting",
+                "running",
+                "stopping",
+            }:
+                raise ValueError("A bounded deauth lab run is already active")
+
+            try:
+                self.emergency_flag.unlink()
+            except FileNotFoundError:
+                pass
+
+            job = {
+                "id": uuid.uuid4().hex,
+                "status": "starting",
+                "interface": interface,
+                "ap": ap_mac,
+                "target": target_mac,
+                "operator": operator or "unknown",
+                "started_at": now,
+                "hard_deadline": now + self.max_run_seconds,
+                "heartbeat_deadline": min(
+                    now + self.heartbeat_grace_seconds,
+                    now + self.max_run_seconds,
+                ),
+                "frames_sent": 0,
+                "stop_reason": None,
+                "error": None,
+                "_stop_event": threading.Event(),
+            }
+            self._active = job
+            self._write_marker(job)
+            thread = threading.Thread(
+                target=self._worker,
+                args=(job["id"], send_frame),
+                name=f"bounded-deauth-{job['id'][:8]}",
+                daemon=True,
+            )
+            job["_thread"] = thread
+            job["status"] = "running"
+            thread.start()
+            return self._public(job)
+
+    def heartbeat(self, job_id: str) -> dict:
+        now = self._time()
+        with self._lock:
+            job = self._active
+            if not job or job.get("id") != job_id:
+                raise ValueError("The bounded deauth job is not active")
+            if job.get("status") not in {"starting", "running"}:
+                raise ValueError("The bounded deauth job is stopping")
+            if now >= job["hard_deadline"]:
+                job["stop_reason"] = "hard_timeout"
+                job["_stop_event"].set()
+            else:
+                job["heartbeat_deadline"] = min(
+                    now + self.heartbeat_grace_seconds,
+                    job["hard_deadline"],
+                )
+            return self._public(job)
+
+    def stop(self, job_id: Optional[str] = None, reason: str = "manual_stop") -> dict:
+        with self._lock:
+            job = self._active
+            if not job:
+                return self._public(self._last)
+            if job_id and job.get("id") != job_id:
+                raise ValueError("The bounded deauth job ID does not match")
+            job["status"] = "stopping"
+            job["stop_reason"] = reason
+            job["_stop_event"].set()
+            return self._public(job)
+
+    def emergency_stop(self, reason: str = "emergency_stop") -> dict:
+        request_emergency_stop(self.emergency_flag, reason=reason)
+        return self.stop(reason=reason)
+
+    def _worker(self, job_id: str, send_frame: Callable[[], None]) -> None:
+        reason = "completed"
+        error = None
+        while True:
+            with self._lock:
+                job = self._active
+                if not job or job.get("id") != job_id:
+                    return
+                now = self._time()
+                stop_event = job["_stop_event"]
+                explicit_reason = job.get("stop_reason")
+                heartbeat_deadline = job["heartbeat_deadline"]
+                hard_deadline = job["hard_deadline"]
+
+            if stop_event.is_set():
+                reason = explicit_reason or "manual_stop"
+                break
+            if self.emergency_flag.exists():
+                reason = "emergency_stop"
+                break
+            if now >= hard_deadline:
+                reason = "hard_timeout"
+                break
+            if now >= heartbeat_deadline:
+                reason = "heartbeat_timeout"
+                break
+
+            try:
+                send_frame()
+            except Exception as exc:  # pragma: no cover - hardware/runtime specific
+                reason = "sender_error"
+                error = _bounded_error(exc)
+                break
+
+            with self._lock:
+                current = self._active
+                if current and current.get("id") == job_id:
+                    current["frames_sent"] += 1
+
+            stop_event.wait(self.send_interval_seconds)
+
+        self._finish(job_id, reason, error)
+
+    def _finish(self, job_id: str, reason: str, error: Optional[str]) -> None:
+        with self._lock:
+            job = self._active
+            if not job or job.get("id") != job_id:
+                return
+            job["status"] = "failed" if error else "stopped"
+            job["stop_reason"] = reason
+            job["error"] = error
+            job["stopped_at"] = self._time()
+            self._last = job
+            self._active = None
+            self._clear_marker()
+
+
+def request_emergency_stop(
+    path: Path | str = _DEFAULT_EMERGENCY_FLAG,
+    *,
+    reason: str = "local-emergency-stop",
+) -> Path:
+    """Create the filesystem kill flag checked by the active worker."""
+    flag = Path(path)
+    flag.parent.mkdir(parents=True, exist_ok=True)
+    flag.write_text(
+        f"{reason} {os.getpid()} {time.time():.6f}\n",
+        encoding="utf-8",
+    )
+    return flag
+
+
+_controller = BoundedDeauthController()
+
+
+def start_deauth(**kwargs) -> dict:
+    return _controller.start(**kwargs)
+
+
+def heartbeat_deauth(job_id: str) -> dict:
+    return _controller.heartbeat(job_id)
+
+
+def stop_deauth(job_id: Optional[str] = None, reason: str = "manual_stop") -> dict:
+    return _controller.stop(job_id, reason)
+
+
+def emergency_stop_deauth(reason: str = "emergency_stop") -> dict:
+    return _controller.emergency_stop(reason)
+
+
+def deauth_status() -> dict:
+    return _controller.status()
+
+
+def emergency_stop_path() -> str:
+    return str(_controller.emergency_flag)

--- a/services/deauth_control.py
+++ b/services/deauth_control.py
@@ -75,15 +75,18 @@ class BoundedDeauthController:
 
     def startup_cleanup(self) -> bool:
         """Fail closed after restart and remove any stale active-job marker."""
-        self.emergency_flag.parent.mkdir(parents=True, exist_ok=True)
         stale = self.active_marker.exists()
-        self.emergency_flag.write_text(
-            f"startup-cleanup {os.getpid()} {self._time():.6f}\n",
-            encoding="utf-8",
-        )
+        try:
+            self.emergency_flag.parent.mkdir(parents=True, exist_ok=True)
+            self.emergency_flag.write_text(
+                f"startup-cleanup {os.getpid()} {self._time():.6f}\n",
+                encoding="utf-8",
+            )
+        except OSError:
+            pass
         try:
             self.active_marker.unlink()
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             pass
         return stale
 
@@ -106,7 +109,7 @@ class BoundedDeauthController:
     def _clear_marker(self) -> None:
         try:
             self.active_marker.unlink()
-        except FileNotFoundError:
+        except (FileNotFoundError, OSError):
             pass
 
     def _public(self, job: Optional[dict]) -> dict:
@@ -184,16 +187,21 @@ class BoundedDeauthController:
                 "_stop_event": threading.Event(),
             }
             self._active = job
-            self._write_marker(job)
-            thread = threading.Thread(
-                target=self._worker,
-                args=(job["id"], send_frame),
-                name=f"bounded-deauth-{job['id'][:8]}",
-                daemon=True,
-            )
-            job["_thread"] = thread
-            job["status"] = "running"
-            thread.start()
+            try:
+                self._write_marker(job)
+                thread = threading.Thread(
+                    target=self._worker,
+                    args=(job["id"], send_frame),
+                    name=f"bounded-deauth-{job['id'][:8]}",
+                    daemon=True,
+                )
+                job["_thread"] = thread
+                job["status"] = "running"
+                thread.start()
+            except Exception:
+                self._active = None
+                self._clear_marker()
+                raise
             return self._public(job)
 
     def heartbeat(self, job_id: str) -> dict:

--- a/static/js/deauth-control.js
+++ b/static/js/deauth-control.js
@@ -1,0 +1,195 @@
+(function () {
+    "use strict";
+
+    var jobId = null;
+    var heartbeatTimer = null;
+    var statusTimer = null;
+
+    function csrfToken() {
+        return $("#Deauth-CSRF").val() || "";
+    }
+
+    function setStatus(message, isError) {
+        $("#Deauth-Status")
+            .toggleClass("text-danger", Boolean(isError))
+            .toggleClass("text-success", !isError)
+            .text(message || "");
+    }
+
+    function setActive(active) {
+        $("#Deauth-Start").prop("disabled", active);
+        $("#Deauth-Stop").prop("disabled", !active);
+        $("#Deauth-AP, #Deauth-Target, #Deauth-Authorized, #interface-select-Deauth")
+            .prop("disabled", active);
+    }
+
+    function stopTimers() {
+        if (heartbeatTimer) {
+            window.clearInterval(heartbeatTimer);
+            heartbeatTimer = null;
+        }
+        if (statusTimer) {
+            window.clearInterval(statusTimer);
+            statusTimer = null;
+        }
+    }
+
+    function renderJob(job) {
+        if (!job || !job.id) {
+            jobId = null;
+            setActive(false);
+            $("#Deauth-Progress").val(0);
+            return;
+        }
+
+        jobId = job.active ? job.id : null;
+        setActive(Boolean(job.active));
+        var maximum = Number(job.max_run_seconds || 15);
+        var remaining = Math.max(0, Number(job.remaining_seconds || 0));
+        $("#Deauth-Progress").attr("max", maximum).val(maximum - remaining);
+
+        var message = job.active
+            ? "Active on " + job.interface + ": " + job.frames_sent +
+              " frame(s) sent; automatic stop in " + remaining.toFixed(1) + "s."
+            : "Stopped: " + (job.stop_reason || job.status || "complete") +
+              ". " + (job.frames_sent || 0) + " frame(s) sent.";
+
+        setStatus(message, job.status === "failed");
+        if (!job.active) {
+            stopTimers();
+        }
+    }
+
+    function statusPoll() {
+        $.ajax({
+            url: "/deauth/status",
+            type: "GET",
+            success: function (response) {
+                renderJob(response.job);
+            },
+            error: function () {
+                stopTimers();
+                setActive(false);
+                setStatus("Unable to confirm bounded deauth job status.", true);
+            }
+        });
+    }
+
+    function heartbeat() {
+        if (!jobId) {
+            return;
+        }
+        $.ajax({
+            url: "/deauth/heartbeat",
+            type: "POST",
+            data: {jobId: jobId, csrf_token: csrfToken()},
+            success: function (response) {
+                renderJob(response.job);
+            },
+            error: function () {
+                stopTimers();
+                statusPoll();
+            }
+        });
+    }
+
+    function beginMonitoring() {
+        stopTimers();
+        heartbeatTimer = window.setInterval(heartbeat, 2000);
+        statusTimer = window.setInterval(statusPoll, 1000);
+    }
+
+    $("#Deauth-Start").on("click", function (event) {
+        event.preventDefault();
+        var ap = $("#Deauth-AP").val();
+        var authorized = $("#Deauth-Authorized").is(":checked");
+        if (!ap || !authorized) {
+            if (!ap) {
+                $("#Deauth-AP").addClass("input-error");
+            }
+            if (!authorized) {
+                $("#Deauth-Authorized").addClass("input-error");
+            }
+            setStatus("Enter the lab AP and confirm the isolated authorized scope.", true);
+            return;
+        }
+
+        $.ajax({
+            url: "/deauth/start",
+            type: "POST",
+            data: {
+                ap: ap,
+                target: $("#Deauth-Target").val() || "ff:ff:ff:ff:ff:ff",
+                authorized: "on",
+                selectedInterface: $("#interface-select-Deauth").val(),
+                csrf_token: csrfToken()
+            },
+            beforeSend: function () {
+                $("#Deauth-Start").prop("disabled", true);
+                $("#Deauth-AP, #Deauth-Authorized").removeClass("input-error");
+                setStatus("Starting bounded lab transmission…", false);
+            },
+            success: function (response) {
+                renderJob(response.job);
+                beginMonitoring();
+            },
+            error: function (error) {
+                setActive(false);
+                var message = error.responseJSON && error.responseJSON.message
+                    ? error.responseJSON.message
+                    : "Unable to start bounded deauth lab run.";
+                setStatus(message, true);
+            }
+        });
+    });
+
+    $("#Deauth-Stop").on("click", function (event) {
+        event.preventDefault();
+        $.ajax({
+            url: "/deauth/stop",
+            type: "POST",
+            data: {jobId: jobId || "", csrf_token: csrfToken()},
+            success: function (response) {
+                renderJob(response.job);
+                statusPoll();
+            },
+            error: function (error) {
+                var message = error.responseJSON && error.responseJSON.message
+                    ? error.responseJSON.message
+                    : "Unable to stop the bounded deauth lab run.";
+                setStatus(message, true);
+            }
+        });
+    });
+
+    $("#Deauth-Emergency-Stop").on("click", function (event) {
+        event.preventDefault();
+        $.ajax({
+            url: "/deauth/emergency-stop",
+            type: "POST",
+            data: {csrf_token: csrfToken()},
+            success: function (response) {
+                renderJob(response.job);
+                statusPoll();
+            },
+            error: function () {
+                setStatus("Emergency-stop request failed. Use the local stop command.", true);
+            }
+        });
+    });
+
+    window.addEventListener("beforeunload", function () {
+        if (!jobId || !navigator.sendBeacon) {
+            return;
+        }
+        var data = new FormData();
+        data.append("jobId", jobId);
+        data.append("csrf_token", csrfToken());
+        navigator.sendBeacon("/deauth/stop", data);
+    });
+
+    $(document).ready(function () {
+        setActive(false);
+        statusPoll();
+    });
+}());

--- a/templates/attacks/_deauth.html
+++ b/templates/attacks/_deauth.html
@@ -1,5 +1,5 @@
 <div class="card m-3 deauth-control-card" style="width: 18rem;">
-  <h5 class="card-title">Bounded Deauth Lab</h5>
+  <h5 class="card-title">Student Deauth Lab — Bounded Start/Stop</h5>
   <p class="card-text">
     Start a supervised 802.11 deauthentication stream only on an isolated network you are authorized to test.
     The server stops it after 15 seconds, if the browser heartbeat is lost, or when an emergency stop is requested.

--- a/templates/attacks/_deauth.html
+++ b/templates/attacks/_deauth.html
@@ -1,16 +1,28 @@
-<div class="card m-3" style="width: 18rem;">
-  <h5 class="card-title">Student Deauth Lab</h5>
-  <p class="card-text">Send a small, rate-limited 802.11 deauth burst only on an isolated network you are authorized to test.</p>
-  <form class="form-inline" method="post" action="/deauth">
+<div class="card m-3 deauth-control-card" style="width: 18rem;">
+  <h5 class="card-title">Bounded Deauth Lab</h5>
+  <p class="card-text">
+    Start a supervised 802.11 deauthentication stream only on an isolated network you are authorized to test.
+    The server stops it after 15 seconds, if the browser heartbeat is lost, or when an emergency stop is requested.
+  </p>
+  <form class="form-inline" id="Deauth-Control-Form">
+      <input type="hidden" id="Deauth-CSRF" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
       <input type="text" class="form-control mb-2" id="Deauth-AP" placeholder="Lab AP MAC (aa:bb:cc:dd:ee:ff)" name="ap">
       <input type="text" class="form-control mb-2" id="Deauth-Target" placeholder="Client MAC or broadcast" name="target">
-      <input type="number" class="form-control mb-2" id="Deauth-Frames" placeholder="1-5" min="1" max="5" name="frames">
       <label class="form-check deauth-lab-confirm">
         <input class="form-check-input" type="checkbox" id="Deauth-Authorized" name="authorized">
         <span class="form-check-label">I confirm this is an authorized isolated class lab.</span>
       </label>
       {% set selectId = 'Deauth' %}
       {% include '_adapters-list.html' %}
-      <button id="Deauth-Submit" class="btn btn-primary mb-2">Run Lab Burst</button>
+      <div class="btn-group mb-2" role="group" aria-label="Bounded deauth controls">
+        <button id="Deauth-Start" type="button" class="btn btn-primary">Start</button>
+        <button id="Deauth-Stop" type="button" class="btn btn-secondary" disabled>Stop</button>
+      </div>
+      <button id="Deauth-Emergency-Stop" type="button" class="btn btn-danger mb-2">Emergency Stop</button>
   </form>
+  <progress id="Deauth-Progress" max="15" value="0" class="w-100"></progress>
+  <p id="Deauth-Status" class="small mt-2" role="status" aria-live="polite">No bounded lab run is active.</p>
+  <p class="small text-muted">
+    Local kill command: <code>python -m scripts.wifi.deauth_emergency_stop</code>
+  </p>
 </div>

--- a/templates/red-team.html
+++ b/templates/red-team.html
@@ -24,4 +24,5 @@
 </body>
 {% include '_footer.html' %}
 <script src="/static/js/red-team-scripts.js"></script>
+<script src="/static/js/deauth-control.js"></script>
 </html>

--- a/tests/test_deauth_control.py
+++ b/tests/test_deauth_control.py
@@ -1,0 +1,231 @@
+import tempfile
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import app as app_module
+from app import app
+from services.deauth_control import (
+    BoundedDeauthController,
+    validate_start_request,
+)
+
+
+class BoundedDeauthControllerTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        root = Path(self.tempdir.name)
+        self.marker = root / "active.json"
+        self.flag = root / "stop.flag"
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def make_controller(self, **overrides):
+        options = {
+            "max_run_seconds": 0.25,
+            "heartbeat_grace_seconds": 0.08,
+            "send_interval_seconds": 0.01,
+            "active_marker": self.marker,
+            "emergency_flag": self.flag,
+        }
+        options.update(overrides)
+        return BoundedDeauthController(**options)
+
+    def wait_inactive(self, controller, timeout=1.0):
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            status = controller.status()
+            if not status["active"]:
+                return status
+            time.sleep(0.01)
+        self.fail("Bounded deauth controller did not stop")
+
+    def test_startup_cleanup_fails_closed_and_removes_stale_marker(self):
+        self.marker.parent.mkdir(parents=True)
+        self.marker.write_text('{"id": "stale"}', encoding="utf-8")
+        controller = self.make_controller()
+
+        self.assertFalse(self.marker.exists())
+        self.assertTrue(self.flag.exists())
+        self.assertFalse(controller.status()["active"])
+
+    def test_manual_stop_ends_active_job(self):
+        controller = self.make_controller()
+        sent = []
+        job = controller.start(
+            ap_mac="aa:bb:cc:dd:ee:ff",
+            target_mac="11:22:33:44:55:66",
+            interface="wlan0mon",
+            operator="admin",
+            send_frame=lambda: sent.append(time.time()),
+        )
+        self.assertTrue(job["active"])
+        deadline = time.time() + 0.1
+        while time.time() < deadline and not sent:
+            time.sleep(0.005)
+        controller.stop(job["id"], "manual_stop")
+        stopped = self.wait_inactive(controller)
+
+        self.assertEqual(stopped["stop_reason"], "manual_stop")
+        self.assertGreaterEqual(stopped["frames_sent"], 1)
+        self.assertFalse(self.marker.exists())
+
+    def test_missing_heartbeat_stops_job(self):
+        controller = self.make_controller()
+        controller.start(
+            ap_mac="aa:bb:cc:dd:ee:ff",
+            target_mac="11:22:33:44:55:66",
+            interface="wlan0mon",
+            operator="admin",
+            send_frame=lambda: None,
+        )
+
+        stopped = self.wait_inactive(controller)
+        self.assertEqual(stopped["stop_reason"], "heartbeat_timeout")
+
+    def test_hard_deadline_cannot_be_renewed_by_heartbeats(self):
+        controller = self.make_controller(
+            max_run_seconds=0.12,
+            heartbeat_grace_seconds=0.06,
+        )
+        job = controller.start(
+            ap_mac="aa:bb:cc:dd:ee:ff",
+            target_mac="11:22:33:44:55:66",
+            interface="wlan0mon",
+            operator="admin",
+            send_frame=lambda: None,
+        )
+
+        deadline = time.time() + 0.3
+        while time.time() < deadline and controller.status()["active"]:
+            try:
+                controller.heartbeat(job["id"])
+            except ValueError:
+                break
+            time.sleep(0.02)
+
+        stopped = self.wait_inactive(controller)
+        self.assertEqual(stopped["stop_reason"], "hard_timeout")
+
+    def test_emergency_stop_flag_ends_job(self):
+        controller = self.make_controller()
+        controller.start(
+            ap_mac="aa:bb:cc:dd:ee:ff",
+            target_mac="11:22:33:44:55:66",
+            interface="wlan0mon",
+            operator="admin",
+            send_frame=lambda: None,
+        )
+        controller.emergency_stop()
+
+        stopped = self.wait_inactive(controller)
+        self.assertEqual(stopped["stop_reason"], "emergency_stop")
+        self.assertTrue(self.flag.exists())
+
+    def test_start_request_keeps_authorization_and_ap_checks(self):
+        normalize = lambda value: str(value or "").lower() or None
+        ap, target = validate_start_request(
+            {
+                "ap": "AA:BB:CC:DD:EE:FF",
+                "target": "",
+                "authorized": "on",
+            },
+            normalize,
+        )
+        self.assertEqual(ap, "aa:bb:cc:dd:ee:ff")
+        self.assertEqual(target, "ff:ff:ff:ff:ff:ff")
+
+        with self.assertRaisesRegex(ValueError, "authorized isolated"):
+            validate_start_request(
+                {"ap": "aa:bb:cc:dd:ee:ff", "authorized": ""},
+                normalize,
+            )
+
+
+class DeauthControlRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        app_module.social_users.clear()
+        app_module.social_users["test-admin"] = {
+            "id": "test-admin",
+            "username": "test-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        self.csrf = "deauth-test-csrf"
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {
+                "username": "test-admin",
+                "role": "admin",
+            }
+            flask_session["social_csrf_token"] = self.csrf
+
+    def test_red_team_uses_start_stop_controller_not_frame_input(self):
+        response = self.client.get("/red-team")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'id="Deauth-Start"', response.data)
+        self.assertIn(b'id="Deauth-Stop"', response.data)
+        self.assertIn(b"deauth-control.js", response.data)
+        self.assertNotIn(b'id="Deauth-Frames"', response.data)
+
+    @patch("services.deauth_control.start_deauth")
+    def test_start_route_is_admin_csrf_protected_and_returns_job(self, start):
+        start.return_value = {
+            "active": True,
+            "id": "job-1",
+            "status": "running",
+            "hard_deadline": time.time() + 15,
+        }
+
+        response = self.client.post(
+            "/deauth/start",
+            data={
+                "ap": "aa:bb:cc:dd:ee:ff",
+                "target": "11:22:33:44:55:66",
+                "authorized": "on",
+                "selectedInterface": "wlan0mon",
+                "csrf_token": self.csrf,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["job"]["id"], "job-1")
+        start.assert_called_once()
+
+        bad_csrf = self.client.post(
+            "/deauth/start",
+            data={
+                "ap": "aa:bb:cc:dd:ee:ff",
+                "authorized": "on",
+                "selectedInterface": "wlan0mon",
+                "csrf_token": "wrong",
+            },
+        )
+        self.assertEqual(bad_csrf.status_code, 400)
+
+    @patch("services.deauth_control.emergency_stop_deauth")
+    def test_emergency_stop_route(self, emergency_stop):
+        emergency_stop.return_value = {
+            "active": False,
+            "id": "job-1",
+            "status": "stopped",
+            "stop_reason": "web_emergency_stop",
+        }
+
+        response = self.client.post(
+            "/deauth/emergency-stop",
+            data={"csrf_token": self.csrf},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            response.get_json()["job"]["stop_reason"],
+            "web_emergency_stop",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_deauth_control.py
+++ b/tests/test_deauth_control.py
@@ -43,7 +43,7 @@ class BoundedDeauthControllerTest(unittest.TestCase):
         self.fail("Bounded deauth controller did not stop")
 
     def test_startup_cleanup_fails_closed_and_removes_stale_marker(self):
-        self.marker.parent.mkdir(parents=True)
+        self.marker.parent.mkdir(parents=True, exist_ok=True)
         self.marker.write_text('{"id": "stale"}', encoding="utf-8")
         controller = self.make_controller()
 


### PR DESCRIPTION
## What changed

- replaces the Red Team deauth frame-count field with Start, Stop, and Emergency Stop controls
- adds an administrator-only bounded deauth controller with one active job at a time
- enforces a non-renewable 15-second hard deadline and a five-second heartbeat lease
- stops automatically when the browser heartbeat disappears
- records an active-job marker and performs fail-closed stale-state cleanup at application startup
- adds a local emergency-stop command: `python -m scripts.wifi.deauth_emergency_stop`
- keeps the existing fixed-frame `/deauth` endpoint for compatibility while the UI uses the bounded controller

## Safety and failure handling

- AP MAC must identify a specific access point
- the isolated-authorized-lab confirmation remains mandatory
- Start/Stop routes require an administrator session and CSRF token
- heartbeat renewal can never extend the hard deadline
- the worker stops on manual Stop, heartbeat timeout, hard timeout, emergency flag, or sender failure
- filesystem startup cleanup fails closed without preventing application import on a read-only installation

## Validation

Added tests for:

- stale active-marker startup cleanup
- manual Stop
- missing-heartbeat expiry
- hard deadline despite repeated heartbeats
- emergency-stop flag handling
- authorization and AP validation
- administrator/CSRF route protection
- Start/Stop UI replacing the frame field

Final GitHub Actions run `30758933337` passed on both platforms:

- Ubuntu: compile, application import, duplicate-code report, `340 passed, 1 skipped`
- Windows: compile, application import, duplicate-code report, `340 passed, 1 skipped`
- duplicate-code scan: 92 Python files, 745 non-trivial functions, no exact duplicate function bodies
