### PR TITLE
Add reusable model port knowledge database

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -5,6 +5,7 @@ from .train_controller import create_train_controller_blueprint
 from .automotive import create_automotive_blueprint
 from .deauth_control import create_deauth_control_blueprint
 from .device_identification import create_device_identification_blueprint
+from .port_knowledge import create_port_knowledge_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -15,3 +16,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_automotive_blueprint(context_provider))
     app.register_blueprint(create_deauth_control_blueprint(context_provider))
     app.register_blueprint(create_device_identification_blueprint(context_provider))
+    app.register_blueprint(create_port_knowledge_blueprint(context_provider))

--- a/routes/device_identification.py
+++ b/routes/device_identification.py
@@ -1,11 +1,12 @@
 """Authenticated routes for explainable passive and active device identification."""
 
 from functools import wraps
+from pathlib import Path
 import secrets
 
 from flask import Blueprint, current_app, jsonify, request, session
 
-from services import device_identification
+from services import device_identification, port_knowledge
 
 
 IDENTIFICATION_STAGES = {"passive", "safe", "deep"}
@@ -71,9 +72,31 @@ def _persist_assessment(app_module, identifier, assessment, stage):
                 item["identity_signature_tokens"] = assessment.get("signature_tokens", [])
                 item["identity_identification_stage"] = stage
                 item["identity_assessed_at"] = now
+                if assessment.get("manufacturer"):
+                    item["manufacturer"] = assessment["manufacturer"]
+                if assessment.get("model"):
+                    item["model"] = assessment["model"]
+                    item["model_source"] = assessment.get("model_source")
                 updated = dict(item)
                 break
     return updated
+
+
+def _persist_device(app_module, identifier, device):
+    with app_module.device_inventory_lock:
+        normalized = app_module.normalize_mac(identifier)
+        for key, item in app_module.device_inventory.items():
+            matches = {
+                str(key),
+                str(item.get("id") or ""),
+                str(item.get("ip") or ""),
+                str(item.get("mac") or ""),
+                str(item.get("address") or ""),
+            }
+            if str(identifier) in matches or (normalized and normalized in matches):
+                app_module.device_inventory[key] = dict(device)
+                return dict(app_module.device_inventory[key])
+    return None
 
 
 def create_device_identification_blueprint(context_provider):
@@ -140,6 +163,14 @@ def create_device_identification_blueprint(context_provider):
                 deep_probe=deep_probe,
                 passive_summary=_passive_summary(device),
             )
+            model_identity = port_knowledge.extract_identity(
+                device,
+                safe_probes=safe_probes,
+                assessment=assessment,
+            )
+            assessment["manufacturer"] = model_identity["manufacturer"]
+            assessment["model"] = model_identity["model"]
+            assessment["model_source"] = model_identity["source"]
         except ValueError as exc:
             return _error(exc)
         except Exception as exc:
@@ -147,12 +178,23 @@ def create_device_identification_blueprint(context_provider):
             return _error(f"Device identification failed: {exc}", 500)
 
         updated = _persist_assessment(app_module, identifier, assessment, stage)
+        knowledge_result = port_knowledge.process(
+            Path(current_app.instance_path) / "device_port_knowledge.sqlite3",
+            updated or device,
+            safe_probes=safe_probes,
+        )
+        updated = _persist_device(
+            app_module,
+            identifier,
+            knowledge_result["device"],
+        ) or knowledge_result["device"]
         app_module.append_client_timeline_event(
             host,
             "Device identified",
             (
                 f"Likely {assessment['likely_device']} with "
-                f"{assessment['confidence']} confidence ({assessment['score']}/100)."
+                f"{assessment['confidence']} confidence ({assessment['score']}/100). "
+                f"Model-port knowledge applied {len(knowledge_result['applied'])} mapping(s)."
             ),
             f"device-identification:{stage}",
         )
@@ -161,18 +203,22 @@ def create_device_identification_blueprint(context_provider):
             profile_id=str(identifier),
             detail=(
                 f"stage={stage}; likely={assessment['likely_device']}; "
+                f"model={assessment.get('model') or 'unknown'}; "
                 f"confidence={assessment['confidence']}; score={assessment['score']}"
             ),
         )
         app_module.save_runtime_state(f"device-identification:{stage}")
-        return jsonify({
-            "status": "success",
-            "stage": stage,
-            "identification": assessment,
-            "safe_probes": safe_probes,
-            "deep_probe": deep_probe,
-            "device": updated or device,
-        })
+        return jsonify(
+            {
+                "status": "success",
+                "stage": stage,
+                "identification": assessment,
+                "safe_probes": safe_probes,
+                "deep_probe": deep_probe,
+                "port_knowledge": knowledge_result,
+                "device": updated,
+            }
+        )
 
     @blueprint.get("/clients/<path:identifier>/identify")
     def saved_identification(identifier):
@@ -183,10 +229,12 @@ def create_device_identification_blueprint(context_provider):
         device = app_module.find_inventory_device(identifier) or {}
         if not device:
             return _error("Device was not found in inventory", 404)
-        return jsonify({
-            "status": "success",
-            "identification": device.get("identity_assessment"),
-            "stage": device.get("identity_identification_stage"),
-        })
+        return jsonify(
+            {
+                "status": "success",
+                "identification": device.get("identity_assessment"),
+                "stage": device.get("identity_identification_stage"),
+            }
+        )
 
     return blueprint

--- a/routes/port_knowledge.py
+++ b/routes/port_knowledge.py
@@ -1,0 +1,387 @@
+"""Authenticated routes for reusable model-specific port knowledge."""
+
+from functools import wraps
+import json
+from pathlib import Path
+import secrets
+
+from flask import Blueprint, Response, current_app, jsonify, request, session
+
+from services import port_knowledge
+
+
+def _error(message, status=400):
+    return jsonify({"status": "error", "message": str(message)}), status
+
+
+def _database_path():
+    return Path(current_app.instance_path) / "device_port_knowledge.sqlite3"
+
+
+def _login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not session.get("social_user"):
+            return _error("Login required", 401)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _write_required(admin=False):
+    def decorator(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            user = session.get("social_user") or {}
+            if not user:
+                return _error("Login required", 401)
+            if admin and user.get("role") != "admin":
+                return _error("Administrator role required", 403)
+            expected = str(session.get("social_csrf_token") or "")
+            supplied = str(
+                request.form.get("csrf_token")
+                or request.headers.get("X-CSRF-Token")
+                or ""
+            )
+            if not expected or not secrets.compare_digest(expected, supplied):
+                return _error("Invalid CSRF token", 400)
+            return view(*args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+def _find_inventory_key(app_module, identifier):
+    normalized = app_module.normalize_mac(identifier)
+    for key, item in app_module.device_inventory.items():
+        values = {
+            str(key),
+            str(item.get("id") or ""),
+            str(item.get("ip") or ""),
+            str(item.get("mac") or ""),
+            str(item.get("address") or ""),
+        }
+        if str(identifier) in values or (normalized and normalized in values):
+            return key
+    return None
+
+
+def _persist_device(app_module, identifier, device):
+    with app_module.device_inventory_lock:
+        key = _find_inventory_key(app_module, identifier)
+        if key is None:
+            return None
+        app_module.device_inventory[key] = dict(device)
+        return dict(app_module.device_inventory[key])
+
+
+def _device_payload(app_module, identifier):
+    device = app_module.find_inventory_device(identifier) or {}
+    if not device:
+        raise ValueError("Device was not found in inventory")
+    if not device.get("ip"):
+        raise ValueError("Port knowledge requires a saved IP device")
+    return device
+
+
+def _knowledge_payload(path, device):
+    ident = port_knowledge.identity(device)
+    approved = port_knowledge.mappings(
+        path,
+        manufacturer=ident["manufacturer"],
+        model=ident["model"],
+    )
+    learned = port_knowledge.candidates(
+        path,
+        manufacturer=ident["manufacturer"],
+        model=ident["model"],
+    )
+    mapping_keys = {
+        (int(item["port"]), item["protocol"]): item
+        for item in approved
+    }
+    needs_application = False
+    for detail in device.get("open_port_details", []):
+        try:
+            key = (
+                int(detail.get("port")),
+                str(detail.get("protocol") or "tcp").casefold(),
+            )
+        except (TypeError, ValueError):
+            continue
+        mapping = mapping_keys.get(key)
+        if mapping and detail.get("knowledge_mapping_id") != mapping["id"]:
+            needs_application = True
+            break
+    application_token = "|".join(
+        [
+            str(device.get("last_port_scan") or ""),
+            *[
+                f"{item['id']}:{item['updated_at']}"
+                for item in approved
+            ],
+        ]
+    )
+    return {
+        "identity": ident,
+        "mappings": approved,
+        "candidates": learned,
+        "open_ports": device.get("open_port_details", []),
+        "needs_application": needs_application,
+        "application_token": application_token,
+        "configured_registry_count": len(port_knowledge.configured_urls()),
+    }
+
+
+def create_port_knowledge_blueprint(context_provider):
+    del context_provider
+    blueprint = Blueprint("port_knowledge", __name__)
+
+    @blueprint.get("/clients/<path:identifier>/port-knowledge")
+    @_login_required
+    def client_port_knowledge(identifier):
+        import app as app_module
+
+        try:
+            device = _device_payload(app_module, identifier)
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify(
+            {
+                "status": "success",
+                "knowledge": _knowledge_payload(_database_path(), device),
+            }
+        )
+
+    @blueprint.post("/clients/<path:identifier>/port-knowledge/learn")
+    @_write_required()
+    def learn_client_ports(identifier):
+        import app as app_module
+        from services import device_identification
+
+        try:
+            device = _device_payload(app_module, identifier)
+            safe_probes = None
+            if request.form.get("activeProbe") == "on":
+                base = app_module.fingerprint_client_services(identifier)
+                safe_probes = device_identification.supplement_service_probes(
+                    device,
+                    device["ip"],
+                    base_fingerprints=base,
+                )
+            result = port_knowledge.process(
+                _database_path(),
+                device,
+                safe_probes=safe_probes,
+            )
+        except ValueError as exc:
+            return _error(exc)
+        except Exception as exc:
+            current_app.logger.exception("Port knowledge learning failed")
+            return _error(f"Port knowledge learning failed: {exc}", 500)
+
+        updated = _persist_device(app_module, identifier, result["device"])
+        user = (session.get("social_user") or {}).get("username") or "unknown"
+        app_module.append_client_timeline_event(
+            device["ip"],
+            "Model port knowledge updated",
+            (
+                f"Applied {len(result['applied'])} mapping(s), recorded "
+                f"{result['learning']['observed']} candidate observation(s), and "
+                f"promoted {len(result['learning']['promoted'])} repeated mapping(s)."
+            ),
+            "port-knowledge",
+        )
+        app_module.record_social_audit(
+            "port-knowledge.learn",
+            profile_id=str(identifier),
+            detail=f"operator={user}; active_probe={bool(safe_probes)}",
+        )
+        app_module.save_runtime_state("port-knowledge-learn")
+        return jsonify(
+            {
+                "status": "success",
+                "result": result,
+                "device": updated or result["device"],
+                "knowledge": _knowledge_payload(_database_path(), updated or result["device"]),
+            }
+        )
+
+    @blueprint.post("/clients/<path:identifier>/port-knowledge/mappings")
+    @_write_required()
+    def add_client_mapping(identifier):
+        import app as app_module
+
+        user = (session.get("social_user") or {}).get("username") or "unknown"
+        try:
+            device = _device_payload(app_module, identifier)
+            ident = port_knowledge.identity(
+                device,
+                manufacturer=request.form.get("manufacturer"),
+                model=request.form.get("model"),
+            )
+            mapping = port_knowledge.add_mapping(
+                _database_path(),
+                manufacturer=ident["manufacturer"],
+                model=ident["model"],
+                port=request.form.get("port"),
+                protocol=request.form.get("protocol") or "tcp",
+                service=request.form.get("service"),
+                description=request.form.get("description"),
+                source_name=request.form.get("sourceName") or "Manual research",
+                source_url=request.form.get("sourceUrl"),
+                confidence="confirmed",
+                verified_by=user,
+            )
+            device["manufacturer"] = ident["manufacturer"] or device.get("manufacturer")
+            device["model"] = ident["model"]
+            applied = port_knowledge.apply(_database_path(), device)
+        except ValueError as exc:
+            return _error(exc)
+
+        updated = _persist_device(app_module, identifier, applied["device"])
+        app_module.append_client_timeline_event(
+            device["ip"],
+            "Port mapping confirmed",
+            (
+                f"{mapping['port']}/{mapping['protocol']} mapped to "
+                f"{mapping['service']} for {mapping['model']}."
+            ),
+            "port-knowledge",
+        )
+        app_module.record_social_audit(
+            "port-knowledge.mapping.add",
+            profile_id=str(identifier),
+            detail=(
+                f"model={mapping['model']}; port={mapping['port']}/"
+                f"{mapping['protocol']}; service={mapping['service']}"
+            ),
+        )
+        app_module.save_runtime_state("port-knowledge-mapping-add")
+        return jsonify(
+            {
+                "status": "success",
+                "mapping": mapping,
+                "device": updated or applied["device"],
+                "knowledge": _knowledge_payload(_database_path(), updated or applied["device"]),
+            }
+        )
+
+    @blueprint.post("/clients/<path:identifier>/port-knowledge/candidates/<int:candidate_id>/approve")
+    @_write_required()
+    def approve_client_candidate(identifier, candidate_id):
+        import app as app_module
+
+        user = (session.get("social_user") or {}).get("username") or "unknown"
+        try:
+            device = _device_payload(app_module, identifier)
+            mapping = port_knowledge.approve(
+                _database_path(),
+                candidate_id,
+                verified_by=user,
+                source_url=request.form.get("sourceUrl"),
+            )
+            applied = port_knowledge.apply(_database_path(), device)
+        except ValueError as exc:
+            return _error(exc, 404)
+
+        updated = _persist_device(app_module, identifier, applied["device"])
+        app_module.record_social_audit(
+            "port-knowledge.candidate.approve",
+            profile_id=str(identifier),
+            detail=f"candidate={candidate_id}; mapping={mapping['id']}",
+        )
+        app_module.save_runtime_state("port-knowledge-candidate-approve")
+        return jsonify(
+            {
+                "status": "success",
+                "mapping": mapping,
+                "device": updated or applied["device"],
+                "knowledge": _knowledge_payload(_database_path(), updated or applied["device"]),
+            }
+        )
+
+    @blueprint.post("/clients/<path:identifier>/port-knowledge/mappings/<int:mapping_id>/delete")
+    @_write_required(admin=True)
+    def delete_client_mapping(identifier, mapping_id):
+        import app as app_module
+
+        if not port_knowledge.delete(_database_path(), mapping_id):
+            return _error("Port mapping was not found", 404)
+        device = _device_payload(app_module, identifier)
+        applied = port_knowledge.apply(_database_path(), device)
+        updated = _persist_device(app_module, identifier, applied["device"])
+        app_module.record_social_audit(
+            "port-knowledge.mapping.delete",
+            profile_id=str(identifier),
+            detail=f"mapping={mapping_id}",
+        )
+        app_module.save_runtime_state("port-knowledge-mapping-delete")
+        return jsonify(
+            {
+                "status": "success",
+                "knowledge": _knowledge_payload(
+                    _database_path(), updated or applied["device"]
+                ),
+            }
+        )
+
+    @blueprint.post("/port-knowledge/import")
+    @_write_required(admin=True)
+    def import_port_registry():
+        user = (session.get("social_user") or {}).get("username") or "unknown"
+        artifact = request.files.get("registryFile")
+        try:
+            if artifact and artifact.filename:
+                payload = json.load(artifact.stream)
+            else:
+                payload = json.loads(request.form.get("registryJson") or "{}")
+            result = port_knowledge.import_registry(
+                _database_path(),
+                payload,
+                source_name=request.form.get("sourceName") or "Imported registry",
+                source_url=request.form.get("sourceUrl"),
+                verified_by=user,
+            )
+        except (json.JSONDecodeError, UnicodeError, ValueError) as exc:
+            return _error(exc)
+        import app as app_module
+        app_module.record_social_audit(
+            "port-knowledge.registry.import",
+            detail=f"imported={result['imported']}; errors={len(result['errors'])}",
+        )
+        return jsonify({"status": "success", "result": result})
+
+    @blueprint.post("/port-knowledge/sync")
+    @_write_required(admin=True)
+    def sync_port_registries():
+        urls = port_knowledge.configured_urls()
+        if not urls:
+            return _error(
+                "No online registries are configured in MOBILE_ROUTER_PORT_REGISTRY_URLS"
+            )
+        results = port_knowledge.sync(
+            _database_path(),
+            urls=urls,
+        )
+        import app as app_module
+        app_module.record_social_audit(
+            "port-knowledge.registry.sync",
+            detail=f"sources={len(urls)}; success={len([item for item in results if item.get('status') == 'success'])}",
+        )
+        return jsonify({"status": "success", "results": results})
+
+    @blueprint.get("/port-knowledge/export.json")
+    @_login_required
+    def export_port_registry():
+        payload = port_knowledge.export_registry(_database_path())
+        return Response(
+            json.dumps(payload, indent=2),
+            mimetype="application/json",
+            headers={
+                "Content-Disposition": "attachment; filename=device-port-knowledge.json"
+            },
+        )
+
+    return blueprint

--- a/services/port_knowledge.py
+++ b/services/port_knowledge.py
@@ -1,0 +1,358 @@
+"""Reusable model-specific port mappings and learned candidates."""
+
+import hashlib
+import ipaddress
+import json
+import os
+import socket
+import sqlite3
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+SCHEMA = "mobile-router-port-knowledge-v1"
+_GENERIC = {"", "unknown", "unknown service", "tcpwrapped", "unassigned", "model-specific service"}
+_MAX_DOWNLOAD = 1_048_576
+
+
+def database_path():
+    return Path(os.environ.get("MOBILE_ROUTER_PORT_KNOWLEDGE_DB") or Path(__file__).resolve().parents[1] / "instance" / "device_port_knowledge.sqlite3")
+
+
+def clean(value, limit=500):
+    return " ".join(str(value or "").strip().split())[:limit]
+
+
+def key(value):
+    return clean(value).casefold()
+
+
+def identity(device, manufacturer=None, model=None):
+    device = device or {}
+    assessment = device.get("identity_assessment") or {}
+    manufacturer = clean(manufacturer or device.get("manufacturer") or assessment.get("manufacturer"), 160)
+    model = clean(model or device.get("model") or assessment.get("model") or assessment.get("likely_device"), 200)
+    if key(manufacturer) == "unknown":
+        manufacturer = ""
+    if key(model) in {"", "unknown", "unidentified network device", "client"}:
+        model = ""
+    return {"manufacturer": manufacturer, "model": model, "manufacturer_key": key(manufacturer), "model_key": key(model)}
+
+
+def extract_identity(device, safe_probes=None, assessment=None):
+    assessment = assessment or {}
+    found = identity(device, model=assessment.get("model"))
+    source = "inventory" if found["model"] else ""
+    for item in (safe_probes or {}).get("upnp") or []:
+        if not isinstance(item, dict) or item.get("error"):
+            continue
+        model = " ".join(filter(None, [clean(item.get("model_name"), 160), clean(item.get("model_number"), 100)]))
+        if model:
+            found = identity(device, manufacturer=item.get("manufacturer") or found["manufacturer"], model=model)
+            source = "UPnP device description"
+            break
+    if not found["model"]:
+        found = identity(device, model=assessment.get("likely_device"))
+        source = "identity fingerprint" if found["model"] else ""
+    found["source"] = source
+    return found
+
+
+def valid_port(value):
+    try:
+        value = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Port must be an integer") from exc
+    if not 1 <= value <= 65535:
+        raise ValueError("Port must be between 1 and 65535")
+    return value
+
+
+def valid_protocol(value):
+    value = key(value or "tcp")
+    if value not in {"tcp", "udp"}:
+        raise ValueError("Protocol must be TCP or UDP")
+    return value
+
+
+def valid_url(value):
+    value = str(value or "").strip()
+    if not value:
+        return ""
+    parsed = urlparse(value)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Source URL must be HTTP or HTTPS")
+    return value[:1000]
+
+
+def connect(path=None):
+    path = Path(path or database_path())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(path, timeout=10)
+    db.row_factory = sqlite3.Row
+    db.executescript("""
+      CREATE TABLE IF NOT EXISTS port_knowledge (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        manufacturer_key TEXT NOT NULL, model_key TEXT NOT NULL,
+        manufacturer TEXT NOT NULL, model TEXT NOT NULL,
+        port INTEGER NOT NULL, protocol TEXT NOT NULL,
+        service TEXT NOT NULL, description TEXT NOT NULL DEFAULT '',
+        source_name TEXT NOT NULL DEFAULT '', source_url TEXT NOT NULL DEFAULT '',
+        confidence TEXT NOT NULL DEFAULT 'candidate', status TEXT NOT NULL DEFAULT 'candidate',
+        verified_by TEXT NOT NULL DEFAULT '', observations INTEGER NOT NULL DEFAULT 1,
+        signatures_json TEXT NOT NULL DEFAULT '[]', evidence_json TEXT NOT NULL DEFAULT '{}',
+        created_at REAL NOT NULL, updated_at REAL NOT NULL,
+        UNIQUE(manufacturer_key, model_key, port, protocol, service, status)
+      );
+      CREATE INDEX IF NOT EXISTS port_knowledge_model
+        ON port_knowledge(manufacturer_key, model_key, status, protocol, port);
+    """)
+    return db
+
+
+def row_dict(row):
+    if not row:
+        return None
+    item = dict(row)
+    item["signatures"] = json.loads(item.pop("signatures_json") or "[]")
+    item["evidence"] = json.loads(item.pop("evidence_json") or "{}")
+    item["distinct_devices"] = len(item["signatures"])
+    return item
+
+
+def mappings(path, manufacturer, model):
+    ident = identity({}, manufacturer, model)
+    if not ident["model_key"]:
+        return []
+    with connect(path) as db:
+        rows = db.execute("SELECT * FROM port_knowledge WHERE manufacturer_key=? AND model_key=? AND status='approved' ORDER BY protocol,port", (ident["manufacturer_key"], ident["model_key"])).fetchall()
+    return [row_dict(row) for row in rows]
+
+
+def candidates(path, manufacturer, model):
+    ident = identity({}, manufacturer, model)
+    if not ident["model_key"]:
+        return []
+    with connect(path) as db:
+        rows = db.execute("SELECT * FROM port_knowledge WHERE manufacturer_key=? AND model_key=? AND status='candidate' ORDER BY observations DESC,protocol,port", (ident["manufacturer_key"], ident["model_key"])).fetchall()
+    return [row_dict(row) for row in rows]
+
+
+def add_mapping(path, *, manufacturer, model, port, service, protocol="tcp", description="", source_name="", source_url="", confidence="confirmed", verified_by="", observations=1, signatures=None):
+    ident = identity({}, manufacturer, model)
+    if not ident["model_key"]:
+        raise ValueError("An exact or reusable device model is required")
+    service = clean(service, 160)
+    if not service:
+        raise ValueError("Service name is required")
+    port, protocol, now = valid_port(port), valid_protocol(protocol), time.time()
+    signatures = sorted(set(signatures or []))
+    with connect(path) as db:
+        db.execute("DELETE FROM port_knowledge WHERE manufacturer_key=? AND model_key=? AND port=? AND protocol=? AND status='approved'", (ident["manufacturer_key"], ident["model_key"], port, protocol))
+        cursor = db.execute("""
+          INSERT INTO port_knowledge (
+            manufacturer_key,model_key,manufacturer,model,port,protocol,service,description,
+            source_name,source_url,confidence,status,verified_by,observations,signatures_json,
+            evidence_json,created_at,updated_at
+          ) VALUES (?,?,?,?,?,?,?,?,?,?,?,'approved',?,?,?,?,?,?)
+        """, (
+            ident["manufacturer_key"], ident["model_key"], ident["manufacturer"], ident["model"],
+            port, protocol, service, clean(description,1000), clean(source_name,200),
+            valid_url(source_url), key(confidence or "confirmed"), clean(verified_by,160),
+            max(1,int(observations)), json.dumps(signatures), "{}", now, now,
+        ))
+        row = db.execute("SELECT * FROM port_knowledge WHERE id=?", (cursor.lastrowid,)).fetchone()
+    return row_dict(row)
+
+
+def _signature(device):
+    value = clean((device or {}).get("identity_signature"))
+    if value:
+        return value
+    raw = "|".join(str((device or {}).get(name) or "") for name in ("mac","serial_number","hostname","id","ip"))
+    return hashlib.sha256(raw.encode()).hexdigest() if raw.strip("|") else ""
+
+
+def _probe(safe_probes, port):
+    for item in (safe_probes or {}).get("services") or []:
+        try:
+            if int(item.get("port")) == port:
+                return item
+        except (TypeError, ValueError):
+            pass
+    return {}
+
+
+def suggestion(detail, probe, protocol):
+    service = clean(detail.get("service"),160)
+    if key(service) not in _GENERIC:
+        return service, clean(detail.get("description"),500), True
+    http = probe.get("http") or {}
+    if http.get("title") or http.get("server"):
+        return "HTTP management service", clean(http.get("title") or http.get("server"),300), True
+    if probe.get("rtsp") and not probe["rtsp"].get("error"):
+        return "RTSP media service", clean(probe["rtsp"].get("server") or probe["rtsp"].get("status"),300), True
+    if probe.get("mqtt") and not probe["mqtt"].get("error"):
+        return "MQTT broker", clean(json.dumps(probe["mqtt"],sort_keys=True),300), True
+    if probe.get("banner"):
+        banner = clean(probe["banner"],300)
+        return f"{banner.split()[0][:80]} service", banner, True
+    try:
+        name = socket.getservbyport(valid_port(detail.get("port")), protocol)
+    except (OSError, ValueError):
+        name = ""
+    return (name, "Suggested by the host services database.", True) if name else ("Model-specific service", "", False)
+
+
+def observe(path, device, safe_probes=None):
+    ident = identity(device)
+    if not ident["model_key"]:
+        return {"observed":0,"promoted":[],"candidates":[]}
+    known = {(item["port"],item["protocol"]) for item in mappings(path,ident["manufacturer"],ident["model"])}
+    signature, now, promote = _signature(device), time.time(), []
+    with connect(path) as db:
+        for detail in (device or {}).get("open_port_details") or []:
+            try:
+                port, protocol = valid_port(detail.get("port")), valid_protocol(detail.get("protocol") or "tcp")
+            except ValueError:
+                continue
+            if (port,protocol) in known:
+                continue
+            service, description, promotable = suggestion(detail,_probe(safe_probes,port),protocol)
+            row = db.execute("SELECT * FROM port_knowledge WHERE manufacturer_key=? AND model_key=? AND port=? AND protocol=? AND service=? AND status='candidate'", (ident["manufacturer_key"],ident["model_key"],port,protocol,service)).fetchone()
+            signatures = set(json.loads(row["signatures_json"] or "[]")) if row else set()
+            if signature:
+                signatures.add(signature)
+            observations = (row["observations"]+1) if row else 1
+            evidence = {"scan":{k:detail.get(k) for k in ("service","description","http_title","http_server") if detail.get(k) not in (None,"")},"probe":_probe(safe_probes,port)}
+            if row:
+                db.execute("UPDATE port_knowledge SET description=?,observations=?,signatures_json=?,evidence_json=?,updated_at=? WHERE id=?", (description or row["description"],observations,json.dumps(sorted(signatures)),json.dumps(evidence,sort_keys=True),now,row["id"]))
+            else:
+                db.execute("""
+                  INSERT INTO port_knowledge (
+                    manufacturer_key,model_key,manufacturer,model,port,protocol,service,description,
+                    source_name,confidence,status,observations,signatures_json,evidence_json,created_at,updated_at
+                  ) VALUES (?,?,?,?,?,?,?,?,?,'candidate','candidate',?,?,?,?,?)
+                """, (ident["manufacturer_key"],ident["model_key"],ident["manufacturer"],ident["model"],port,protocol,service,description,"automatic observation",observations,json.dumps(sorted(signatures)),json.dumps(evidence,sort_keys=True),now,now))
+            if promotable and len(signatures)>=2:
+                promote.append((port,protocol,service,description,observations,sorted(signatures)))
+    promoted=[]
+    for port,protocol,service,description,observations,signatures in promote:
+        promoted.append(add_mapping(path,manufacturer=ident["manufacturer"],model=ident["model"],port=port,protocol=protocol,service=service,description=description,source_name="Automatic repeated observation",confidence="learned",observations=observations,signatures=signatures))
+        with connect(path) as db:
+            db.execute("UPDATE port_knowledge SET status='approved-observation',updated_at=? WHERE manufacturer_key=? AND model_key=? AND port=? AND protocol=? AND service=? AND status='candidate'", (time.time(),ident["manufacturer_key"],ident["model_key"],port,protocol,service))
+    return {"observed":len((device or {}).get("open_port_details") or []),"promoted":promoted,"candidates":candidates(path,ident["manufacturer"],ident["model"])}
+
+
+def apply(path, device):
+    ident = identity(device)
+    known = {(item["port"],item["protocol"]):item for item in mappings(path,ident["manufacturer"],ident["model"])}
+    updated, applied = dict(device or {}), []
+    details=[]
+    for raw in updated.get("open_port_details") or []:
+        detail=dict(raw)
+        for name in list(detail):
+            if name.startswith("knowledge_"):
+                detail.pop(name,None)
+        try:
+            mapping=known.get((valid_port(detail.get("port")),valid_protocol(detail.get("protocol") or "tcp")))
+        except ValueError:
+            mapping=None
+        if mapping:
+            detail.update({
+              "knowledge_mapping_id":mapping["id"],"knowledge_service":mapping["service"],
+              "knowledge_description":mapping["description"],"knowledge_source_name":mapping["source_name"],
+              "knowledge_source_url":mapping["source_url"],"knowledge_confidence":mapping["confidence"],
+              "knowledge_model":mapping["model"],
+            })
+            if key(detail.get("service")) in _GENERIC:
+                detail["service"]=mapping["service"]
+            if not clean(detail.get("description")):
+                detail["description"]=mapping["description"]
+            applied.append(mapping)
+        details.append(detail)
+    updated["open_port_details"]=details
+    if ident["model"]:
+        updated["model"],updated["port_knowledge_applied_at"]=ident["model"],time.time()
+    return {"device":updated,"applied":applied,"identity":ident}
+
+
+def process(path, device, safe_probes=None):
+    applied=apply(path,device)
+    learned=observe(path,applied["device"],safe_probes)
+    if learned["promoted"]:
+        applied=apply(path,applied["device"])
+    return {**applied,"learning":learned}
+
+
+def approve(path, candidate_id, verified_by="", source_url=""):
+    with connect(path) as db:
+        row=db.execute("SELECT * FROM port_knowledge WHERE id=? AND status='candidate'",(int(candidate_id),)).fetchone()
+    if not row:
+        raise ValueError("Port knowledge candidate was not found")
+    return add_mapping(path,manufacturer=row["manufacturer"],model=row["model"],port=row["port"],protocol=row["protocol"],service=row["service"],description=row["description"],source_name=row["source_name"] or "Approved local observation",source_url=source_url or row["source_url"],verified_by=verified_by,observations=row["observations"],signatures=json.loads(row["signatures_json"] or "[]"))
+
+
+def delete(path, mapping_id):
+    with connect(path) as db:
+        return db.execute("DELETE FROM port_knowledge WHERE id=? AND status='approved'",(int(mapping_id),)).rowcount>0
+
+
+def export_registry(path):
+    with connect(path) as db:
+        rows=db.execute("SELECT * FROM port_knowledge WHERE status='approved' ORDER BY manufacturer_key,model_key,protocol,port").fetchall()
+    items=[]
+    for row in rows:
+        item=row_dict(row)
+        for name in ("id","manufacturer_key","model_key","status","evidence","signatures"):
+            item.pop(name,None)
+        items.append(item)
+    return {"schema":SCHEMA,"exported_at":time.time(),"mappings":items}
+
+
+def import_registry(path,payload,source_name="",source_url="",verified_by=""):
+    if not isinstance(payload,dict) or payload.get("schema")!=SCHEMA or not isinstance(payload.get("mappings"),list):
+        raise ValueError(f"Registry must use schema {SCHEMA} and contain a mappings list")
+    imported,errors=0,[]
+    for index,item in enumerate(payload["mappings"][:10000]):
+        try:
+            add_mapping(path,manufacturer=item.get("manufacturer"),model=item.get("model"),port=item.get("port"),protocol=item.get("protocol") or "tcp",service=item.get("service"),description=item.get("description") or "",source_name=item.get("source_name") or source_name,source_url=item.get("source_url") or source_url,confidence=item.get("confidence") or "vendor",verified_by=item.get("verified_by") or verified_by,observations=item.get("observations") or 1,signatures=item.get("signatures") or [])
+            imported+=1
+        except (TypeError,ValueError) as exc:
+            errors.append({"index":index,"message":clean(exc,300)})
+    return {"imported":imported,"errors":errors[:100]}
+
+
+def configured_urls(value=None):
+    return [item.strip() for item in str(value if value is not None else os.environ.get("MOBILE_ROUTER_PORT_REGISTRY_URLS","")).split(",") if item.strip()]
+
+
+def public_https_url(url):
+    parsed=urlparse(str(url or ""))
+    if parsed.scheme!="https" or not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError("Registry URLs must be credential-free HTTPS URLs")
+    try:
+        addresses={item[4][0] for item in socket.getaddrinfo(parsed.hostname,parsed.port or 443)}
+    except OSError as exc:
+        raise ValueError("Registry hostname could not be resolved") from exc
+    if any((lambda ip: ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified)(ipaddress.ip_address(address)) for address in addresses):
+        raise ValueError("Registry URL resolved to a non-public address")
+    return str(url)
+
+
+def sync(path,urls=None,opener=urlopen):
+    results=[]
+    for configured in urls or configured_urls():
+        try:
+            url=public_https_url(configured)
+            with opener(Request(url,headers={"User-Agent":"MobileRouterLab/1.0"}),timeout=10) as response:
+                final=public_https_url(response.geturl())
+                raw=response.read(_MAX_DOWNLOAD+1)
+            if len(raw)>_MAX_DOWNLOAD:
+                raise ValueError("Registry download exceeded 1 MiB")
+            result=import_registry(path,json.loads(raw.decode()),"Configured online registry",final,"registry-sync")
+            results.append({"url":final,"status":"success",**result})
+        except (OSError,UnicodeError,json.JSONDecodeError,ValueError) as exc:
+            results.append({"url":clean(configured,1000),"status":"error","message":clean(exc,500)})
+    return results

--- a/services/port_knowledge.py
+++ b/services/port_knowledge.py
@@ -87,10 +87,20 @@ def valid_url(value):
     return value[:1000]
 
 
+class _ClosingConnection(sqlite3.Connection):
+    """Commit or roll back, then deterministically release the SQLite file."""
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            return super().__exit__(exc_type, exc_value, traceback)
+        finally:
+            self.close()
+
+
 def connect(path=None):
     path = Path(path or database_path())
     path.parent.mkdir(parents=True, exist_ok=True)
-    db = sqlite3.connect(path, timeout=10)
+    db = sqlite3.connect(path, timeout=10, factory=_ClosingConnection)
     db.row_factory = sqlite3.Row
     db.executescript("""
       CREATE TABLE IF NOT EXISTS port_knowledge (

--- a/services/port_knowledge.py
+++ b/services/port_knowledge.py
@@ -13,6 +13,7 @@ from urllib.request import Request, urlopen
 
 SCHEMA = "mobile-router-port-knowledge-v1"
 _GENERIC = {"", "unknown", "unknown service", "tcpwrapped", "unassigned", "model-specific service"}
+_GENERIC_MODELS = {"", "unknown", "unidentified network device", "client", "gateway/router", "network infrastructure", "nas/file server", "media/tv device", "printer", "camera/nvr", "home automation/iot", "windows computer", "linux/unix computer", "mqtt/iot device", "web appliance", "remote admin host", "service endpoint"}
 _MAX_DOWNLOAD = 1_048_576
 
 
@@ -35,7 +36,7 @@ def identity(device, manufacturer=None, model=None):
     model = clean(model or device.get("model") or assessment.get("model") or assessment.get("likely_device"), 200)
     if key(manufacturer) == "unknown":
         manufacturer = ""
-    if key(model) in {"", "unknown", "unidentified network device", "client"}:
+    if key(model) in _GENERIC_MODELS:
         model = ""
     return {"manufacturer": manufacturer, "model": model, "manufacturer_key": key(manufacturer), "model_key": key(model)}
 
@@ -291,7 +292,10 @@ def approve(path, candidate_id, verified_by="", source_url=""):
         row=db.execute("SELECT * FROM port_knowledge WHERE id=? AND status='candidate'",(int(candidate_id),)).fetchone()
     if not row:
         raise ValueError("Port knowledge candidate was not found")
-    return add_mapping(path,manufacturer=row["manufacturer"],model=row["model"],port=row["port"],protocol=row["protocol"],service=row["service"],description=row["description"],source_name=row["source_name"] or "Approved local observation",source_url=source_url or row["source_url"],verified_by=verified_by,observations=row["observations"],signatures=json.loads(row["signatures_json"] or "[]"))
+    mapping = add_mapping(path,manufacturer=row["manufacturer"],model=row["model"],port=row["port"],protocol=row["protocol"],service=row["service"],description=row["description"],source_name=row["source_name"] or "Approved local observation",source_url=source_url or row["source_url"],verified_by=verified_by,observations=row["observations"],signatures=json.loads(row["signatures_json"] or "[]"))
+    with connect(path) as db:
+        db.execute("UPDATE port_knowledge SET status='approved-observation',updated_at=? WHERE id=?", (time.time(), int(candidate_id)))
+    return mapping
 
 
 def delete(path, mapping_id):

--- a/static/js/port-knowledge.js
+++ b/static/js/port-knowledge.js
@@ -1,0 +1,295 @@
+(function () {
+  "use strict";
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function csrfToken() {
+    return String(document.querySelector(".app-navbar")?.dataset.csrfToken || "");
+  }
+
+  function clientHost() {
+    return String(document.querySelector("[data-ip-client-tools]")?.dataset.host || "");
+  }
+
+  function post(url, data) {
+    const body = new URLSearchParams({ csrf_token: csrfToken(), ...data });
+    return fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      body: body.toString()
+    }).then(async function (response) {
+      const payload = await response.json().catch(function () { return {}; });
+      if (!response.ok) throw new Error(payload.message || `Request failed (${response.status})`);
+      return payload;
+    });
+  }
+
+  function status(message, error) {
+    const target = document.querySelector("[data-port-knowledge-status]");
+    if (!target) return;
+    target.className = `alert ${error ? "alert-danger" : "alert-info"} mt-3`;
+    target.textContent = message;
+  }
+
+  function mappingForPort(mappings, port, protocol) {
+    return (mappings || []).find(function (item) {
+      return Number(item.port) === Number(port) && String(item.protocol) === String(protocol || "tcp");
+    });
+  }
+
+  function renderOpenPorts(knowledge) {
+    const identity = knowledge.identity || {};
+    return (knowledge.open_ports || []).map(function (port) {
+      const protocol = port.protocol || "tcp";
+      const mapping = mappingForPort(knowledge.mappings, port.port, protocol);
+      const scannedService = port.service || "Unknown";
+      const mapped = mapping
+        ? `<div><strong>${escapeHtml(mapping.service)}</strong><br><small>${escapeHtml(mapping.description || "")}</small></div>`
+        : `<span class="text-muted">No reusable mapping</span>`;
+      const source = mapping && mapping.source_url
+        ? `<a href="${escapeHtml(mapping.source_url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(mapping.source_name || "Source")}</a>`
+        : escapeHtml(mapping?.source_name || "");
+      return `
+        <tr>
+          <td><strong>${escapeHtml(port.port)}/${escapeHtml(protocol)}</strong></td>
+          <td>${escapeHtml(scannedService)}${port.description ? `<br><small>${escapeHtml(port.description)}</small>` : ""}</td>
+          <td>${mapped}${source ? `<br><small>${source}</small>` : ""}</td>
+          <td>
+            <details>
+              <summary>${mapping ? "Update mapping" : "Add mapping"}</summary>
+              <form data-port-mapping-form data-port="${escapeHtml(port.port)}" data-protocol="${escapeHtml(protocol)}" class="mt-2">
+                <input class="form-control form-control-sm mb-1" name="service" value="${escapeHtml(mapping?.service || (scannedService === "Unknown" ? "" : scannedService))}" placeholder="Service name" required>
+                <input class="form-control form-control-sm mb-1" name="description" value="${escapeHtml(mapping?.description || port.description || "")}" placeholder="What this port does">
+                <input class="form-control form-control-sm mb-1" name="sourceName" value="${escapeHtml(mapping?.source_name || "Manual research")}" placeholder="Source name">
+                <input class="form-control form-control-sm mb-1" name="sourceUrl" value="${escapeHtml(mapping?.source_url || "")}" placeholder="https://source.example/...">
+                <button class="btn btn-primary btn-sm" type="submit">Save for ${escapeHtml(identity.model || "this model")}</button>
+              </form>
+            </details>
+          </td>
+        </tr>`;
+    }).join("") || `<tr><td colspan="4" class="text-muted">Run a port scan first.</td></tr>`;
+  }
+
+  function renderMappings(knowledge) {
+    return (knowledge.mappings || []).map(function (item) {
+      return `<li>
+        <strong>${escapeHtml(item.port)}/${escapeHtml(item.protocol)}</strong>
+        — ${escapeHtml(item.service)}
+        <span class="badge badge-light border">${escapeHtml(item.confidence)}</span>
+        ${item.description ? `<small>${escapeHtml(item.description)}</small>` : ""}
+        <button class="btn btn-link btn-sm text-danger" data-delete-port-mapping="${escapeHtml(item.id)}" type="button">Delete</button>
+      </li>`;
+    }).join("") || `<li class="text-muted">No approved mappings for this model yet.</li>`;
+  }
+
+  function renderCandidates(knowledge) {
+    return (knowledge.candidates || []).map(function (item) {
+      return `<li>
+        <strong>${escapeHtml(item.port)}/${escapeHtml(item.protocol)}</strong>
+        — ${escapeHtml(item.service)}
+        <small>${escapeHtml(item.description || "")}</small>
+        <span class="badge badge-light border">${escapeHtml(item.observations)} observations · ${escapeHtml(item.distinct_devices)} devices</span>
+        <button class="btn btn-outline-success btn-sm" data-approve-port-candidate="${escapeHtml(item.id)}" type="button">Approve</button>
+      </li>`;
+    }).join("") || `<li class="text-muted">No unapproved learned candidates.</li>`;
+  }
+
+  function render(payload) {
+    const knowledge = payload.knowledge || payload;
+    const identity = knowledge.identity || {};
+    const root = document.querySelector("[data-port-knowledge]");
+    if (!root) return;
+    root.innerHTML = `
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-start flex-wrap">
+          <div>
+            <h2 class="theme-section-title">Model Port Knowledge</h2>
+            <p class="text-muted">Save researched port meanings once and reuse them for every device identified as the same model.</p>
+          </div>
+          <a class="btn btn-outline-secondary btn-sm" href="/port-knowledge/export.json">Export registry</a>
+        </div>
+
+        <div class="form-row">
+          <div class="col-md-5">
+            <label>Manufacturer</label>
+            <input class="form-control" data-port-knowledge-manufacturer value="${escapeHtml(identity.manufacturer || "")}" placeholder="Sky, Synology, Ubiquiti">
+          </div>
+          <div class="col-md-7">
+            <label>Exact model</label>
+            <input class="form-control" data-port-knowledge-model value="${escapeHtml(identity.model || "")}" placeholder="SR203, RT6600ax, UDM-Pro">
+          </div>
+        </div>
+        <p class="small text-muted mt-2">Correct these fields before saving a mapping if the automatic model is too broad.</p>
+
+        <div class="theme-actions">
+          <button class="btn btn-outline-primary" type="button" data-port-knowledge-learn>Learn from saved scan</button>
+          <button class="btn btn-outline-info" type="button" data-port-knowledge-probe>Use safe probes and learn</button>
+          ${knowledge.configured_registry_count ? `<button class="btn btn-outline-success" type="button" data-port-knowledge-sync>Sync ${escapeHtml(knowledge.configured_registry_count)} configured registry source(s)</button>` : ""}
+        </div>
+        <div data-port-knowledge-status class="alert alert-light mt-3">Ready.</div>
+
+        <div class="table-responsive">
+          <table class="table table-sm">
+            <thead><tr><th>Port</th><th>Scan result</th><th>Model knowledge</th><th>Research mapping</th></tr></thead>
+            <tbody>${renderOpenPorts(knowledge)}</tbody>
+          </table>
+        </div>
+
+        <div class="row">
+          <div class="col-lg-6">
+            <h3 class="theme-subsection-title">Approved mappings</h3>
+            <ul>${renderMappings(knowledge)}</ul>
+          </div>
+          <div class="col-lg-6">
+            <h3 class="theme-subsection-title">Learned candidates</h3>
+            <ul>${renderCandidates(knowledge)}</ul>
+          </div>
+        </div>
+
+        <details class="mt-3">
+          <summary>Import a structured port registry</summary>
+          <p class="small text-muted mt-2">Use the exported <code>mobile-router-port-knowledge-v1</code> JSON format. Imported entries retain their source URLs.</p>
+          <textarea class="form-control" rows="5" data-port-registry-json placeholder='{"schema":"mobile-router-port-knowledge-v1","mappings":[]}'></textarea>
+          <button class="btn btn-outline-secondary btn-sm mt-2" type="button" data-port-registry-import>Import JSON</button>
+        </details>
+      </div>`;
+  }
+
+  function reload() {
+    const host = clientHost();
+    if (!host) return Promise.resolve();
+    return fetch(`/clients/${encodeURIComponent(host)}/port-knowledge`, {
+      headers: { "X-Requested-With": "XMLHttpRequest" }
+    })
+      .then(async function (response) {
+        const payload = await response.json().catch(function () { return {}; });
+        if (!response.ok) throw new Error(payload.message || "Unable to load port knowledge");
+        render(payload.knowledge);
+        if (payload.knowledge.needs_application) {
+          const key = `mobile-router:port-knowledge:${host}:${payload.knowledge.application_token}`;
+          if (!window.sessionStorage.getItem(key)) {
+            window.sessionStorage.setItem(key, "1");
+            status("Applying reusable mappings for this model…");
+            return post(`/clients/${encodeURIComponent(host)}/port-knowledge/learn`, {})
+              .then(function (learned) {
+                render(learned.knowledge);
+                status("Reusable model mappings applied automatically.");
+              });
+          }
+        }
+        return null;
+      })
+      .catch(function (error) { status(error.message, true); });
+  }
+
+  function inject() {
+    const tools = document.querySelector("[data-ip-client-tools]");
+    if (!tools || document.querySelector("[data-port-knowledge]")) return;
+    const section = document.createElement("section");
+    section.className = "theme-card card";
+    section.setAttribute("data-port-knowledge", "");
+    section.innerHTML = `<div class="card-body"><p class="text-muted mb-0">Loading model port knowledge…</p></div>`;
+    tools.parentNode.insertBefore(section, tools);
+    reload();
+  }
+
+  document.addEventListener("submit", function (event) {
+    const form = event.target.closest("[data-port-mapping-form]");
+    if (!form) return;
+    event.preventDefault();
+    const host = clientHost();
+    const data = new FormData(form);
+    status("Saving reusable model mapping…");
+    post(`/clients/${encodeURIComponent(host)}/port-knowledge/mappings`, {
+      manufacturer: document.querySelector("[data-port-knowledge-manufacturer]")?.value || "",
+      model: document.querySelector("[data-port-knowledge-model]")?.value || "",
+      port: form.dataset.port,
+      protocol: form.dataset.protocol,
+      service: data.get("service") || "",
+      description: data.get("description") || "",
+      sourceName: data.get("sourceName") || "",
+      sourceUrl: data.get("sourceUrl") || ""
+    }).then(function (payload) {
+      render(payload.knowledge);
+      status("Mapping saved and applied to this device.");
+    }).catch(function (error) { status(error.message, true); });
+  });
+
+  document.addEventListener("click", function (event) {
+    const host = clientHost();
+    if (!host) return;
+
+    if (event.target.closest("[data-port-knowledge-learn]")) {
+      status("Recording candidates and applying known mappings…");
+      post(`/clients/${encodeURIComponent(host)}/port-knowledge/learn`, {})
+        .then(function (payload) {
+          render(payload.knowledge);
+          status("Saved scan processed.");
+        }).catch(function (error) { status(error.message, true); });
+    }
+
+    if (event.target.closest("[data-port-knowledge-probe]")) {
+      status("Running bounded safe probes against already-open ports…");
+      post(`/clients/${encodeURIComponent(host)}/port-knowledge/learn`, { activeProbe: "on" })
+        .then(function (payload) {
+          render(payload.knowledge);
+          status("Safe probes completed and candidates updated.");
+        }).catch(function (error) { status(error.message, true); });
+    }
+
+    const approve = event.target.closest("[data-approve-port-candidate]");
+    if (approve) {
+      status("Approving learned mapping…");
+      post(`/clients/${encodeURIComponent(host)}/port-knowledge/candidates/${approve.dataset.approvePortCandidate}/approve`, {})
+        .then(function (payload) {
+          render(payload.knowledge);
+          status("Candidate approved and applied.");
+        }).catch(function (error) { status(error.message, true); });
+    }
+
+    const remove = event.target.closest("[data-delete-port-mapping]");
+    if (remove) {
+      status("Deleting mapping…");
+      post(`/clients/${encodeURIComponent(host)}/port-knowledge/mappings/${remove.dataset.deletePortMapping}/delete`, {})
+        .then(function (payload) {
+          render(payload.knowledge);
+          status("Mapping deleted.");
+        }).catch(function (error) { status(error.message, true); });
+    }
+
+    if (event.target.closest("[data-port-knowledge-sync]")) {
+      status("Synchronising configured registries…");
+      post("/port-knowledge/sync", {})
+        .then(function () {
+          status("Registry synchronisation completed.");
+          return reload();
+        }).catch(function (error) { status(error.message, true); });
+    }
+
+    if (event.target.closest("[data-port-registry-import]")) {
+      const registryJson = document.querySelector("[data-port-registry-json]")?.value || "";
+      status("Importing registry…");
+      post("/port-knowledge/import", { registryJson: registryJson })
+        .then(function () {
+          status("Registry imported.");
+          return reload();
+        }).catch(function (error) { status(error.message, true); });
+    }
+  });
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", inject);
+  } else {
+    inject();
+  }
+}());

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -8,4 +8,5 @@
 
 <script src="/static/js/wireless-deauth-buttons.js"></script>
 <script src="/static/js/device-identification.js"></script>
+<script src="/static/js/port-knowledge.js"></script>
 

--- a/tests/test_port_knowledge.py
+++ b/tests/test_port_knowledge.py
@@ -1,0 +1,331 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import app as app_module
+from app import app
+from services import port_knowledge
+
+
+class PortKnowledgeServiceTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.database = Path(self.tempdir.name) / "knowledge.sqlite3"
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def test_confirmed_mapping_is_reused_for_same_model(self):
+        mapping = port_knowledge.add_mapping(
+            self.database,
+            manufacturer="Sky",
+            model="SR203",
+            port=51000,
+            service="Sky router management service",
+            description="Model-specific management endpoint",
+            source_name="Vendor support page",
+            source_url="https://example.com/sky-sr203",
+            verified_by="admin",
+        )
+        device = {
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "open_port_details": [{"port": 51000, "service": "Unknown"}],
+        }
+
+        result = port_knowledge.apply(self.database, device)
+
+        detail = result["device"]["open_port_details"][0]
+        self.assertEqual(detail["service"], "Sky router management service")
+        self.assertEqual(detail["knowledge_mapping_id"], mapping["id"])
+        self.assertEqual(detail["knowledge_source_url"], "https://example.com/sky-sr203")
+
+    def test_mapping_does_not_cross_models(self):
+        port_knowledge.add_mapping(
+            self.database,
+            manufacturer="Sky",
+            model="SR203",
+            port=51000,
+            service="Sky router management service",
+        )
+        other = {
+            "manufacturer": "Sky",
+            "model": "SR213",
+            "open_port_details": [{"port": 51000, "service": "Unknown"}],
+        }
+
+        result = port_knowledge.apply(self.database, other)
+
+        self.assertFalse(result["applied"])
+        self.assertEqual(result["device"]["open_port_details"][0]["service"], "Unknown")
+
+    def test_two_distinct_devices_promote_consistent_candidate(self):
+        first = {
+            "manufacturer": "Example",
+            "model": "Router X",
+            "identity_signature": "device-one",
+            "open_port_details": [
+                {"port": 49160, "service": "router-control", "description": "Control service"}
+            ],
+        }
+        second = {
+            **first,
+            "identity_signature": "device-two",
+        }
+
+        initial = port_knowledge.observe(self.database, first)
+        learned = port_knowledge.observe(self.database, second)
+
+        self.assertFalse(initial["promoted"])
+        self.assertEqual(len(learned["promoted"]), 1)
+        mapping = port_knowledge.mappings(
+            self.database,
+            manufacturer="Example",
+            model="Router X",
+        )[0]
+        self.assertEqual(mapping["confidence"], "learned")
+        self.assertEqual(mapping["distinct_devices"], 2)
+
+    def test_unidentified_high_port_remains_candidate(self):
+        for signature in ("one", "two"):
+            port_knowledge.observe(
+                self.database,
+                {
+                    "manufacturer": "Sky",
+                    "model": "SR203",
+                    "identity_signature": signature,
+                    "open_port_details": [{"port": 55000, "service": "Unknown"}],
+                },
+            )
+
+        self.assertFalse(
+            port_knowledge.mappings(
+                self.database,
+                manufacturer="Sky",
+                model="SR203",
+            )
+        )
+        candidate = port_knowledge.candidates(
+            self.database,
+            manufacturer="Sky",
+            model="SR203",
+        )[0]
+        self.assertEqual(candidate["service"], "Model-specific service")
+        self.assertEqual(candidate["distinct_devices"], 2)
+
+    def test_upnp_model_becomes_reusable_identity(self):
+        identity = port_knowledge.extract_identity(
+            {"manufacturer": "Unknown"},
+            safe_probes={
+                "upnp": [
+                    {
+                        "manufacturer": "Sky",
+                        "model_name": "Sky Broadband Hub",
+                        "model_number": "SR203",
+                    }
+                ]
+            },
+            assessment={"likely_device": "Gateway/router"},
+        )
+
+        self.assertEqual(identity["manufacturer"], "Sky")
+        self.assertEqual(identity["model"], "Sky Broadband Hub SR203")
+        self.assertEqual(identity["source"], "UPnP device description")
+
+    def test_registry_round_trip(self):
+        port_knowledge.add_mapping(
+            self.database,
+            manufacturer="Example",
+            model="Model A",
+            port=12345,
+            protocol="udp",
+            service="Telemetry",
+        )
+        exported = port_knowledge.export_registry(self.database)
+        other = Path(self.tempdir.name) / "other.sqlite3"
+
+        result = port_knowledge.import_registry(
+            other,
+            exported,
+            source_name="Test registry",
+        )
+
+        self.assertEqual(result["imported"], 1)
+        imported = port_knowledge.mappings(
+            other,
+            manufacturer="Example",
+            model="Model A",
+        )[0]
+        self.assertEqual(imported["protocol"], "udp")
+        self.assertEqual(imported["service"], "Telemetry")
+
+    @patch("services.port_knowledge.socket.getaddrinfo")
+    def test_online_registry_rejects_private_destination(self, getaddrinfo):
+        getaddrinfo.return_value = [(None, None, None, None, ("192.168.1.2", 443))]
+
+        with self.assertRaisesRegex(ValueError, "non-public"):
+            port_knowledge.public_https_url("https://registry.example/ports.json")
+
+
+class PortKnowledgeRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.database = Path(self.tempdir.name) / "route.sqlite3"
+        self.client = app.test_client()
+        app_module.device_inventory.clear()
+        app_module.social_users.clear()
+        app_module.social_audit_log.clear()
+        app_module.social_users["test-admin"] = {
+            "id": "test-admin",
+            "username": "test-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        self.csrf = "port-knowledge-csrf"
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {
+                "username": "test-admin",
+                "role": "admin",
+            }
+            flask_session["social_csrf_token"] = self.csrf
+        app_module.device_inventory["mac:00:11:22:33:44:55"] = {
+            "id": "mac:00:11:22:33:44:55",
+            "ip": "192.0.2.10",
+            "mac": "00:11:22:33:44:55",
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "open_ports": [51000],
+            "open_port_details": [{"port": 51000, "service": "Unknown"}],
+            "sources": ["test"],
+            "interfaces": ["eth0"],
+        }
+        self.path_patch = patch(
+            "routes.port_knowledge._database_path",
+            return_value=self.database,
+        )
+        self.path_patch.start()
+
+    def tearDown(self):
+        self.path_patch.stop()
+        app_module.device_inventory.clear()
+        app_module.social_users.clear()
+        app_module.social_audit_log.clear()
+        self.tempdir.cleanup()
+
+    def test_client_page_loads_model_port_knowledge_script(self):
+        response = self.client.get("/clients/192.0.2.10")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"port-knowledge.js", response.data)
+
+    def test_manual_mapping_is_saved_and_applied(self):
+        response = self.client.post(
+            "/clients/192.0.2.10/port-knowledge/mappings",
+            data={
+                "manufacturer": "Sky",
+                "model": "SR203",
+                "port": "51000",
+                "protocol": "tcp",
+                "service": "Sky router management service",
+                "description": "Documented high-port service",
+                "sourceName": "Research note",
+                "sourceUrl": "https://example.com/sky",
+                "csrf_token": self.csrf,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = response.get_json()
+        self.assertEqual(payload["mapping"]["model"], "SR203")
+        device = app_module.find_inventory_device("192.0.2.10")
+        self.assertEqual(
+            device["open_port_details"][0]["service"],
+            "Sky router management service",
+        )
+        self.assertTrue(
+            any(item["action"] == "port-knowledge.mapping.add" for item in app_module.social_audit_log)
+        )
+
+    def test_mapping_is_reused_on_second_device(self):
+        port_knowledge.add_mapping(
+            self.database,
+            manufacturer="Sky",
+            model="SR203",
+            port=51000,
+            service="Sky router management service",
+        )
+        app_module.device_inventory["mac:00:11:22:33:44:66"] = {
+            "id": "mac:00:11:22:33:44:66",
+            "ip": "192.0.2.11",
+            "mac": "00:11:22:33:44:66",
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "open_ports": [51000],
+            "open_port_details": [{"port": 51000, "service": "Unknown"}],
+            "sources": ["test"],
+            "interfaces": ["eth0"],
+        }
+
+        overview = self.client.get("/clients/192.0.2.11/port-knowledge")
+        self.assertTrue(overview.get_json()["knowledge"]["needs_application"])
+        response = self.client.post(
+            "/clients/192.0.2.11/port-knowledge/learn",
+            data={"csrf_token": self.csrf},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        device = app_module.find_inventory_device("192.0.2.11")
+        self.assertEqual(
+            device["open_port_details"][0]["service"],
+            "Sky router management service",
+        )
+
+    def test_write_routes_require_csrf(self):
+        response = self.client.post(
+            "/clients/192.0.2.10/port-knowledge/learn",
+            data={"csrf_token": "wrong"},
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("CSRF", response.get_json()["message"])
+
+    def test_structured_registry_import(self):
+        payload = {
+            "schema": port_knowledge.SCHEMA,
+            "mappings": [
+                {
+                    "manufacturer": "Example",
+                    "model": "Router Z",
+                    "port": 45000,
+                    "protocol": "tcp",
+                    "service": "Vendor telemetry",
+                }
+            ],
+        }
+
+        response = self.client.post(
+            "/port-knowledge/import",
+            data={
+                "registryJson": json.dumps(payload),
+                "csrf_token": self.csrf,
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.get_json()["result"]["imported"], 1)
+
+    def test_sync_requires_configured_allowlist(self):
+        with patch.dict("os.environ", {}, clear=True):
+            response = self.client.post(
+                "/port-knowledge/sync",
+                data={"csrf_token": self.csrf},
+            )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("MOBILE_ROUTER_PORT_REGISTRY_URLS", response.get_json()["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds a SQLite-backed database for model-specific TCP and UDP port mappings
- lets a user research an unknown port once, record the exact manufacturer/model, service meaning, description, and source URL, then reuse it on another device of the same model
- automatically applies approved mappings when a matching device page is opened or device identification is rerun
- records unknown ports as learned candidates after saved scans or bounded safe service probes
- automatically promotes a consistent candidate only after the same service is observed on at least two distinct device signatures of the same exact model
- requires manual approval for unidentified model-specific high ports
- extracts exact reusable model names from UPnP descriptions when available
- adds JSON import/export using the `mobile-router-port-knowledge-v1` schema
- supports optional online registry synchronisation through administrator-configured `MOBILE_ROUTER_PORT_REGISTRY_URLS`

## Trust and safety

- broad labels such as `Gateway/router` cannot become reusable model mappings
- online sync accepts only explicitly configured, credential-free HTTPS URLs resolving to public addresses
- registry downloads are limited to 1 MiB and validated before import
- arbitrary webpages are retained only as source links; they are not silently scraped into trusted mappings
- imported, learned, and manually confirmed mappings retain confidence and provenance
- all writes are authenticated and CSRF-protected; registry sync/import and deletion require an administrator
- SQLite handles are deterministically closed after commit or rollback on both Windows and Linux

## Validation

Final GitHub Actions run `30770022873` passed on both platforms:

- Ubuntu: compile, application import, duplicate-code report, `368 passed, 1 skipped`
- Windows: compile, application import, duplicate-code report, `368 passed, 1 skipped`
- duplicate-code scan: 96 Python files, 808 non-trivial functions, no exact duplicate function bodies

Tests cover exact-model reuse, model isolation, repeated-observation promotion, unknown high-port candidates, UPnP model extraction, registry round trips, private-address sync rejection, CSRF protection, UI loading, persistence, deterministic SQLite closure, and reuse on a second device.