### PR TITLE
Add full device model profile system

### DIFF
--- a/build_model_registry.py
+++ b/build_model_registry.py
@@ -1,0 +1,7 @@
+"""Repository-root entry point for the device model registry builder."""
+
+from tools.build_model_registry import main
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/DEVICE_MODEL_PROFILES.md
+++ b/docs/DEVICE_MODEL_PROFILES.md
@@ -1,0 +1,108 @@
+# Device Model Profiles
+
+Device Model Profiles extend the original model-port knowledge database into a reusable device-intelligence library.
+
+## Matching hierarchy
+
+Rules are combined from least to most specific:
+
+1. manufacturer defaults;
+2. model-family profiles;
+3. exact model profiles;
+4. hardware and firmware constrained exact profiles;
+5. a manually assigned profile;
+6. device-specific local overrides.
+
+The most specific applicable rule wins for the same port and protocol.
+
+## Port classifications
+
+- `expected`: normally present and reported as missing when absent;
+- `optional`: accepted when present but not reported missing;
+- `firmware-specific`: valid only for the configured firmware range;
+- `local-configuration`: a known local addition rather than standard model behaviour;
+- `investigate`: meaning is not yet sufficiently established;
+- `deprecated`: known legacy service that should usually be removed or disabled;
+- `unexpected`: explicitly documented as abnormal for the model.
+
+Each rule can include exposure expectations, authentication and encryption expectations, risk, remediation, hardware/firmware applicability, source provenance, reliability, and confidence.
+
+## Model library
+
+Open `/models` to:
+
+- create exact, family, or manufacturer profiles;
+- add aliases and canonical identities;
+- constrain profiles and rules to hardware revisions or firmware ranges;
+- add and classify port rules;
+- compare matching inventory devices;
+- review common ports and firmware distributions;
+- resolve conflicting source claims;
+- inspect revision history and roll back;
+- export privacy-clean community contributions.
+
+## Client drift
+
+IP client pages automatically show a Device Model Profile card. Drift compares observed ports with applicable profile rules and reports:
+
+- unexpected ports;
+- missing expected ports;
+- deprecated services;
+- remediation tasks;
+- overall severity and score.
+
+An unexpected service can be investigated with bounded safe probes or approved as a device-specific local override.
+
+## Signed registries
+
+Registries use schema `mobile-router-model-profiles-v2` and always contain a SHA-256 manifest digest. They can additionally be authenticated with HMAC-SHA256.
+
+Configure a publisher and signing secret when exporting:
+
+```powershell
+$env:MOBILE_ROUTER_MODEL_REGISTRY_PUBLISHER = "my-lab"
+$env:MOBILE_ROUTER_MODEL_REGISTRY_SIGNING_KEY = "replace-with-a-long-random-secret"
+```
+
+Configure trusted publisher keys for import and sync:
+
+```powershell
+$env:MOBILE_ROUTER_MODEL_REGISTRY_KEYS = '{"my-lab":"replace-with-a-long-random-secret"}'
+```
+
+Configure one or more HTTPS registry locations:
+
+```powershell
+$env:MOBILE_ROUTER_MODEL_REGISTRY_URLS = "https://example.org/device-model-registry.json"
+```
+
+Automatic sync requires trusted signatures unless the administrator explicitly selects unsigned import.
+
+## Registry build pipeline
+
+Build a release from contribution and registry JSON files:
+
+```powershell
+python build_model_registry.py `
+  contributions\sky-sr203.json `
+  contributions\synology.json `
+  --output releases\device-model-registry.json `
+  --publisher my-lab `
+  --version 2026.08.1
+```
+
+The builder:
+
+- validates input schemas;
+- merges aliases;
+- deduplicates identical profiles and rules;
+- writes a separate conflict report;
+- refuses conflicting releases by default;
+- validates the completed registry;
+- signs it when the configured signing key is present.
+
+Use `--allow-conflicts` only when the generated conflict report has been reviewed and retaining the current preferred entries is intentional.
+
+## Privacy-clean contributions
+
+Contribution exports intentionally exclude IP addresses, MAC addresses, hostnames, serial numbers, credentials, and private device URLs. They contain only the reusable model profile, port rules, and aggregate observation counts.

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -6,6 +6,7 @@ from .automotive import create_automotive_blueprint
 from .deauth_control import create_deauth_control_blueprint
 from .device_identification import create_device_identification_blueprint
 from .port_knowledge import create_port_knowledge_blueprint
+from .model_profiles import create_model_profiles_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -17,3 +18,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_deauth_control_blueprint(context_provider))
     app.register_blueprint(create_device_identification_blueprint(context_provider))
     app.register_blueprint(create_port_knowledge_blueprint(context_provider))
+    app.register_blueprint(create_model_profiles_blueprint(context_provider))

--- a/routes/model_profiles.py
+++ b/routes/model_profiles.py
@@ -1,0 +1,596 @@
+"""Device model profile library, drift analysis, and registry routes."""
+
+from functools import wraps
+import json
+import os
+from pathlib import Path
+import secrets
+
+from flask import Blueprint, Response, current_app, jsonify, render_template, request, session
+
+from services import model_profiles
+
+
+def _error(message, status=400):
+    return jsonify({"status": "error", "message": str(message)}), status
+
+
+def _database_path():
+    return Path(current_app.instance_path) / "device_port_knowledge.sqlite3"
+
+
+def _login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not session.get("social_user"):
+            return _error("Login required", 401)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _write_required(admin=False):
+    def decorator(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            user = session.get("social_user") or {}
+            if not user:
+                return _error("Login required", 401)
+            if admin and user.get("role") != "admin":
+                return _error("Administrator role required", 403)
+            expected = str(session.get("social_csrf_token") or "")
+            supplied = str(
+                request.form.get("csrf_token")
+                or request.headers.get("X-CSRF-Token")
+                or ""
+            )
+            if not expected or not secrets.compare_digest(expected, supplied):
+                return _error("Invalid CSRF token", 400)
+            return view(*args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+def _actor():
+    return (session.get("social_user") or {}).get("username") or "unknown"
+
+
+def _inventory_records(app_module):
+    if hasattr(app_module, "inventory_records"):
+        return app_module.inventory_records()
+    with app_module.device_inventory_lock:
+        return [dict(item) for item in app_module.device_inventory.values()]
+
+
+def _find_inventory_key(app_module, identifier):
+    normalized = app_module.normalize_mac(identifier)
+    for item_key, item in app_module.device_inventory.items():
+        values = {
+            str(item_key),
+            str(item.get("id") or ""),
+            str(item.get("ip") or ""),
+            str(item.get("mac") or ""),
+            str(item.get("address") or ""),
+        }
+        if str(identifier) in values or (normalized and normalized in values):
+            return item_key
+    return None
+
+
+def _device(app_module, identifier):
+    device = app_module.find_inventory_device(identifier) or {}
+    if not device:
+        raise ValueError("Device was not found in inventory")
+    if not device.get("ip"):
+        raise ValueError("Device model profiles require a saved IP device")
+    return device
+
+
+def _persist_device(app_module, identifier, device):
+    with app_module.device_inventory_lock:
+        item_key = _find_inventory_key(app_module, identifier)
+        if item_key is None:
+            return None
+        app_module.device_inventory[item_key] = dict(device)
+        return dict(app_module.device_inventory[item_key])
+
+
+def _apply_and_persist(app_module, identifier, device, alert=True):
+    before = (device.get("model_port_drift") or {}).get("digest")
+    result = model_profiles.apply_device_profile(_database_path(), device)
+    updated = result["device"]
+    drift = result["drift"]
+    if (
+        alert
+        and drift["severity"] in {"high", "critical"}
+        and drift["digest"] != before
+        and drift["digest"] != device.get("model_drift_alert_digest")
+    ):
+        alert_device = dict(updated)
+        alert_device["name"] = (
+            alert_device.get("display_name")
+            or alert_device.get("name")
+            or alert_device.get("ip")
+        )
+        alert_device["model_drift_summary"] = (
+            f"{len(drift['unexpected'])} unexpected, "
+            f"{len(drift['missing_expected'])} missing expected, "
+            f"{len(drift['deprecated'])} deprecated service(s)"
+        )
+        try:
+            app_module.create_new_device_alert(
+                alert_device,
+                "model-profile-drift",
+                next(iter(alert_device.get("interfaces") or []), None),
+            )
+        except Exception:
+            current_app.logger.exception("Unable to create model drift alert")
+        updated["model_drift_alert_digest"] = drift["digest"]
+    persisted = _persist_device(app_module, identifier, updated) or updated
+    return result, persisted
+
+
+def _profile_from_form(existing=None):
+    existing = existing or {}
+    return {
+        "manufacturer": request.form.get("manufacturer") or existing.get("manufacturer"),
+        "model": request.form.get("model") if "model" in request.form else existing.get("model"),
+        "family": request.form.get("family") if "family" in request.form else existing.get("family"),
+        "scope": request.form.get("scope") or existing.get("scope") or "exact",
+        "hardware_revision": request.form.get("hardwareRevision") if "hardwareRevision" in request.form else existing.get("hardware_revision"),
+        "firmware_min": request.form.get("firmwareMin") if "firmwareMin" in request.form else existing.get("firmware_min"),
+        "firmware_max": request.form.get("firmwareMax") if "firmwareMax" in request.form else existing.get("firmware_max"),
+        "aliases": request.form.get("aliases") if "aliases" in request.form else existing.get("aliases"),
+        "manufacturer_aliases": request.form.get("manufacturerAliases") if "manufacturerAliases" in request.form else existing.get("manufacturer_aliases"),
+        "notes": request.form.get("notes") if "notes" in request.form else existing.get("notes"),
+        "risk_notes": request.form.get("riskNotes") if "riskNotes" in request.form else existing.get("risk_notes"),
+        "actor": _actor(),
+    }
+
+
+def _port_rule_from_form(profile_id):
+    return {
+        "profile_id": profile_id,
+        "port": request.form.get("port"),
+        "protocol": request.form.get("protocol") or "tcp",
+        "service": request.form.get("service"),
+        "description": request.form.get("description"),
+        "classification": request.form.get("classification") or "expected",
+        "exposure": request.form.get("exposure") or "unknown",
+        "authentication_expected": request.form.get("authenticationExpected"),
+        "encryption_expected": request.form.get("encryptionExpected"),
+        "risk": request.form.get("risk") or "info",
+        "remediation": request.form.get("remediation"),
+        "hardware_revision": request.form.get("hardwareRevision"),
+        "firmware_min": request.form.get("firmwareMin"),
+        "firmware_max": request.form.get("firmwareMax"),
+        "source_name": request.form.get("sourceName"),
+        "source_url": request.form.get("sourceUrl"),
+        "source_reliability": request.form.get("sourceReliability") or 50,
+        "confidence": request.form.get("confidence") or "confirmed",
+        "actor": _actor(),
+        "allow_replace": request.form.get("replace") == "on",
+    }
+
+
+def create_model_profiles_blueprint(context_provider):
+    blueprint = Blueprint("model_profiles", __name__)
+
+    @blueprint.get("/models")
+    def model_library_page():
+        return render_template(
+            "model_profiles.html",
+            title="Device Model Library",
+            **context_provider(),
+        )
+
+    @blueprint.get("/models/<int:profile_id>")
+    def model_profile_page(profile_id):
+        try:
+            profile = model_profiles.profile_detail(_database_path(), profile_id)
+        except ValueError:
+            profile = None
+        return render_template(
+            "model_profile_detail.html",
+            title=(
+                f"Model {profile['manufacturer']} {profile['model'] or profile['family']}"
+                if profile
+                else "Model Profile Not Found"
+            ),
+            profile_id=profile_id,
+            profile=profile,
+            **context_provider(),
+        ), (200 if profile else 404)
+
+    @blueprint.get("/api/model-profiles")
+    @_login_required
+    def list_model_profiles():
+        profiles = model_profiles.list_profiles(
+            _database_path(),
+            query=request.args.get("q") or "",
+            scope=request.args.get("scope") or "",
+        )
+        return jsonify({"status": "success", "profiles": profiles})
+
+    @blueprint.post("/api/model-profiles")
+    @_write_required()
+    def create_model_profile():
+        try:
+            profile = model_profiles.upsert_profile(
+                _database_path(), **_profile_from_form()
+            )
+        except ValueError as exc:
+            return _error(exc)
+        import app as app_module
+        app_module.record_social_audit(
+            "model-profile.create",
+            detail=f"profile={profile['id']}; manufacturer={profile['manufacturer']}; model={profile['model']}",
+        )
+        return jsonify({"status": "success", "profile": profile})
+
+    @blueprint.get("/api/model-profiles/<int:profile_id>")
+    @_login_required
+    def get_model_profile(profile_id):
+        try:
+            profile = model_profiles.profile_detail(_database_path(), profile_id)
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify(
+            {
+                "status": "success",
+                "profile": profile,
+                "history": model_profiles.revision_history(_database_path(), profile_id),
+            }
+        )
+
+    @blueprint.post("/api/model-profiles/<int:profile_id>")
+    @_write_required()
+    def update_model_profile(profile_id):
+        try:
+            existing = model_profiles.profile_detail(_database_path(), profile_id)
+            profile = model_profiles.upsert_profile(
+                _database_path(), **_profile_from_form(existing)
+            )
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify({"status": "success", "profile": profile})
+
+    @blueprint.post("/api/model-profiles/<int:profile_id>/ports")
+    @_write_required()
+    def add_model_port_rule(profile_id):
+        try:
+            result = model_profiles.add_port_rule(
+                _database_path(), **_port_rule_from_form(profile_id)
+            )
+            profile = model_profiles.profile_detail(_database_path(), profile_id)
+        except ValueError as exc:
+            return _error(exc)
+        return jsonify(
+            {
+                "status": "conflict" if result.get("status") == "conflict" else "success",
+                "result": result,
+                "profile": profile,
+            }
+        ), (409 if result.get("status") == "conflict" else 200)
+
+    @blueprint.post("/api/model-profiles/<int:profile_id>/ports/<int:rule_id>/delete")
+    @_write_required(admin=True)
+    def delete_model_port_rule(profile_id, rule_id):
+        if not model_profiles.delete_port_rule(
+            _database_path(), profile_id, rule_id, actor=_actor()
+        ):
+            return _error("Model port rule was not found", 404)
+        return jsonify(
+            {
+                "status": "success",
+                "profile": model_profiles.profile_detail(_database_path(), profile_id),
+            }
+        )
+
+    @blueprint.get("/api/model-profiles/<int:profile_id>/fleet")
+    @_login_required
+    def model_profile_fleet(profile_id):
+        import app as app_module
+        try:
+            fleet = model_profiles.fleet_summary(
+                _database_path(), _inventory_records(app_module), profile_id
+            )
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify({"status": "success", "fleet": fleet})
+
+    @blueprint.get("/api/model-profiles/<int:profile_id>/history")
+    @_login_required
+    def model_profile_history(profile_id):
+        return jsonify(
+            {
+                "status": "success",
+                "history": model_profiles.revision_history(_database_path(), profile_id),
+            }
+        )
+
+    @blueprint.post("/api/model-profiles/<int:profile_id>/rollback/<int:revision>")
+    @_write_required(admin=True)
+    def rollback_model_profile(profile_id, revision):
+        try:
+            profile = model_profiles.rollback(
+                _database_path(),
+                profile_id,
+                revision,
+                actor=_actor(),
+                note=request.form.get("note"),
+            )
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify({"status": "success", "profile": profile})
+
+    @blueprint.get("/api/model-profile-conflicts")
+    @_login_required
+    def list_model_profile_conflicts():
+        return jsonify(
+            {
+                "status": "success",
+                "conflicts": model_profiles.conflicts(
+                    _database_path(),
+                    profile_id=request.args.get("profileId"),
+                    status=request.args.get("status") or "open",
+                ),
+            }
+        )
+
+    @blueprint.post("/api/model-profile-conflicts/<int:conflict_id>/resolve")
+    @_write_required(admin=True)
+    def resolve_model_profile_conflict(conflict_id):
+        try:
+            profile = model_profiles.resolve_conflict(
+                _database_path(),
+                conflict_id,
+                request.form.get("choice"),
+                actor=_actor(),
+                note=request.form.get("note"),
+            )
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify({"status": "success", "profile": profile})
+
+    @blueprint.get("/api/model-profiles/<int:profile_id>/contribution.json")
+    @_login_required
+    def export_model_contribution(profile_id):
+        import app as app_module
+        try:
+            payload = model_profiles.contribution_payload(
+                _database_path(), profile_id, _inventory_records(app_module)
+            )
+        except ValueError as exc:
+            return _error(exc, 404)
+        return Response(
+            json.dumps(payload, indent=2),
+            mimetype="application/json",
+            headers={
+                "Content-Disposition": f"attachment; filename=model-profile-{profile_id}-contribution.json"
+            },
+        )
+
+    @blueprint.get("/api/model-registry/export.json")
+    @_login_required
+    def export_model_registry():
+        signing_key = os.environ.get("MOBILE_ROUTER_MODEL_REGISTRY_SIGNING_KEY")
+        payload = model_profiles.export_registry(
+            _database_path(),
+            publisher=os.environ.get("MOBILE_ROUTER_MODEL_REGISTRY_PUBLISHER") or _actor(),
+            version=request.args.get("version") or "",
+            signing_key=signing_key,
+        )
+        return Response(
+            json.dumps(payload, indent=2),
+            mimetype="application/json",
+            headers={
+                "Content-Disposition": "attachment; filename=device-model-registry.json"
+            },
+        )
+
+    @blueprint.post("/api/model-registry/preview")
+    @_write_required(admin=True)
+    def preview_model_registry():
+        try:
+            payload = json.loads(request.form.get("registryJson") or "{}")
+            verification = model_profiles.verify_registry(
+                payload,
+                require_signature=request.form.get("requireSignature") == "on",
+            )
+        except (json.JSONDecodeError, ValueError) as exc:
+            return _error(exc)
+        return jsonify(
+            {
+                "status": "success",
+                "verification": verification,
+                "profiles": [
+                    {
+                        "manufacturer": item.get("manufacturer"),
+                        "model": item.get("model"),
+                        "family": item.get("family"),
+                        "scope": item.get("scope"),
+                        "port_count": len(item.get("ports") or []),
+                    }
+                    for item in payload.get("profiles") or []
+                ],
+            }
+        )
+
+    @blueprint.post("/api/model-registry/import")
+    @_write_required(admin=True)
+    def import_model_registry():
+        artifact = request.files.get("registryFile")
+        try:
+            if artifact and artifact.filename:
+                payload = json.load(artifact.stream)
+            else:
+                payload = json.loads(request.form.get("registryJson") or "{}")
+            result = model_profiles.import_registry(
+                _database_path(),
+                payload,
+                actor=_actor(),
+                source_url=request.form.get("sourceUrl"),
+                require_signature=request.form.get("requireSignature") == "on",
+            )
+        except (json.JSONDecodeError, UnicodeError, ValueError) as exc:
+            return _error(exc)
+        return jsonify({"status": "success", "result": result})
+
+    @blueprint.post("/api/model-registry/sync")
+    @_write_required(admin=True)
+    def sync_model_registries():
+        urls = model_profiles.configured_registry_urls()
+        if not urls:
+            return _error(
+                "No model registries are configured in MOBILE_ROUTER_MODEL_REGISTRY_URLS"
+            )
+        results = model_profiles.sync_registries(
+            _database_path(),
+            urls=urls,
+            require_signature=request.form.get("allowUnsigned") != "on",
+        )
+        return jsonify({"status": "success", "results": results})
+
+    @blueprint.get("/api/model-registry/history")
+    @_login_required
+    def model_registry_history():
+        return jsonify(
+            {
+                "status": "success",
+                "imports": model_profiles.registry_import_history(_database_path()),
+            }
+        )
+
+    @blueprint.get("/clients/<path:identifier>/model-profile")
+    @_login_required
+    def client_model_profile(identifier):
+        import app as app_module
+        try:
+            device = _device(app_module, identifier)
+            result, persisted = _apply_and_persist(
+                app_module, identifier, device, alert=False
+            )
+            model_profiles.record_observations(_database_path(), persisted)
+        except ValueError as exc:
+            return _error(exc, 404)
+        return jsonify(
+            {
+                "status": "success",
+                "result": result,
+                "device": persisted,
+            }
+        )
+
+    @blueprint.post("/clients/<path:identifier>/model-profile/apply")
+    @_write_required()
+    def apply_client_model_profile(identifier):
+        import app as app_module
+        try:
+            device = _device(app_module, identifier)
+            result, persisted = _apply_and_persist(
+                app_module, identifier, device, alert=True
+            )
+            observations = model_profiles.record_observations(
+                _database_path(), persisted
+            )
+        except ValueError as exc:
+            return _error(exc, 404)
+        app_module.append_client_timeline_event(
+            device["ip"],
+            "Model profile assessed",
+            (
+                f"Matched {len(result['profiles'])} profile layer(s); "
+                f"drift severity {result['drift']['severity']} "
+                f"({result['drift']['score']}/100)."
+            ),
+            "model-profile",
+        )
+        app_module.save_runtime_state("model-profile-apply")
+        return jsonify(
+            {
+                "status": "success",
+                "result": result,
+                "device": persisted,
+                "observations": observations,
+            }
+        )
+
+    @blueprint.post("/clients/<path:identifier>/model-profile/assign")
+    @_write_required()
+    def assign_client_model_profile(identifier):
+        import app as app_module
+        try:
+            device = _device(app_module, identifier)
+            profile_id = int(request.form.get("profileId"))
+            model_profiles.profile_detail(_database_path(), profile_id)
+        except (TypeError, ValueError) as exc:
+            return _error(exc)
+        device["model_profile_manual_id"] = profile_id
+        result, persisted = _apply_and_persist(
+            app_module, identifier, device, alert=False
+        )
+        app_module.save_runtime_state("model-profile-assignment")
+        return jsonify({"status": "success", "result": result, "device": persisted})
+
+    @blueprint.post("/clients/<path:identifier>/model-profile/override")
+    @_write_required()
+    def override_client_port(identifier):
+        import app as app_module
+        try:
+            device = _device(app_module, identifier)
+            updated = model_profiles.set_device_override(
+                device,
+                port=request.form.get("port"),
+                protocol=request.form.get("protocol") or "tcp",
+                service=request.form.get("service"),
+                classification=request.form.get("classification") or "local-configuration",
+                description=request.form.get("description"),
+                risk=request.form.get("risk") or "info",
+                remediation=request.form.get("remediation"),
+            )
+            result, persisted = _apply_and_persist(
+                app_module, identifier, updated, alert=False
+            )
+        except ValueError as exc:
+            return _error(exc)
+        app_module.save_runtime_state("model-profile-device-override")
+        return jsonify({"status": "success", "result": result, "device": persisted})
+
+    @blueprint.post("/clients/<path:identifier>/model-profile/investigate")
+    @_write_required()
+    def investigate_client_port(identifier):
+        import app as app_module
+        from services import device_identification
+
+        try:
+            device = _device(app_module, identifier)
+            safe_probes = None
+            if request.form.get("activeProbe") == "on":
+                base = app_module.fingerprint_client_services(identifier)
+                safe_probes = device_identification.supplement_service_probes(
+                    device,
+                    device["ip"],
+                    base_fingerprints=base,
+                )
+            peers = [
+                item
+                for item in _inventory_records(app_module)
+                if item.get("model") == device.get("model")
+                and item.get("id") != device.get("id")
+            ]
+            investigation = model_profiles.investigate_port(
+                _database_path(),
+                device,
+                request.form.get("port"),
+                request.form.get("protocol") or "tcp",
+                safe_probes=safe_probes,
+                peers=peers,
+            )
+        except ValueError as exc:
+            return _error(exc)
+        return jsonify({"status": "success", "investigation": investigation})
+
+    return blueprint

--- a/services/model_profiles.py
+++ b/services/model_profiles.py
@@ -1,0 +1,1447 @@
+"""Device model profiles, applicability rules, drift analysis, and registries."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+import re
+import socket
+import sqlite3
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+SCHEMA = "mobile-router-model-profiles-v2"
+CLASSIFICATIONS = {
+    "expected", "optional", "firmware-specific", "local-configuration",
+    "unexpected", "investigate", "deprecated",
+}
+RISK_LEVELS = {"info", "low", "medium", "high", "critical"}
+EXPOSURES = {"unknown", "lan-only", "management", "local-host", "wan-optional", "wan"}
+SCOPES = {"exact", "family", "manufacturer"}
+_MAX_DOWNLOAD = 2_097_152
+_GENERIC_MODELS = {
+    "", "unknown", "unidentified network device", "client", "gateway/router",
+    "network infrastructure", "nas/file server", "media/tv device", "printer",
+    "camera/nvr", "home automation/iot", "windows computer",
+    "linux/unix computer", "mqtt/iot device", "web appliance",
+    "remote admin host", "service endpoint",
+}
+
+
+class _ClosingConnection(sqlite3.Connection):
+    """Commit or roll back and then release the database handle."""
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        try:
+            return super().__exit__(exc_type, exc_value, traceback)
+        finally:
+            self.close()
+
+
+def database_path():
+    configured = os.environ.get("MOBILE_ROUTER_PORT_KNOWLEDGE_DB")
+    return Path(
+        configured
+        or Path(__file__).resolve().parents[1]
+        / "instance"
+        / "device_port_knowledge.sqlite3"
+    )
+
+
+def clean(value, limit=1000):
+    return " ".join(str(value or "").strip().split())[:limit]
+
+
+def key(value):
+    return clean(value).casefold()
+
+
+def json_list(value):
+    if value in (None, ""):
+        return []
+    if isinstance(value, str):
+        try:
+            decoded = json.loads(value)
+        except json.JSONDecodeError:
+            decoded = [part.strip() for part in value.split(",")]
+    else:
+        decoded = value
+    if not isinstance(decoded, (list, tuple, set)):
+        decoded = [decoded]
+    return sorted({clean(item, 200) for item in decoded if clean(item, 200)})
+
+
+def bool_value(value, default=False):
+    if value is None:
+        return bool(default)
+    if isinstance(value, bool):
+        return value
+    return key(value) in {"1", "true", "yes", "on", "required"}
+
+
+def valid_port(value):
+    try:
+        result = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Port must be an integer") from exc
+    if not 1 <= result <= 65535:
+        raise ValueError("Port must be between 1 and 65535")
+    return result
+
+
+def valid_protocol(value):
+    result = key(value or "tcp")
+    if result not in {"tcp", "udp"}:
+        raise ValueError("Protocol must be TCP or UDP")
+    return result
+
+
+def valid_choice(value, choices, label, default):
+    result = key(value or default)
+    if result not in choices:
+        raise ValueError(f"{label} must be one of: {', '.join(sorted(choices))}")
+    return result
+
+
+def valid_url(value):
+    result = str(value or "").strip()
+    if not result:
+        return ""
+    parsed = urlparse(result)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Source URL must be HTTP or HTTPS")
+    return result[:1200]
+
+
+def _version_tokens(value):
+    value = clean(value, 120)
+    if not value:
+        return ()
+    tokens = re.findall(r"\d+|[A-Za-z]+", value)
+    return tuple(int(token) if token.isdigit() else token.casefold() for token in tokens)
+
+
+def compare_versions(left, right):
+    left_tokens = list(_version_tokens(left))
+    right_tokens = list(_version_tokens(right))
+    length = max(len(left_tokens), len(right_tokens))
+    left_tokens.extend([0] * (length - len(left_tokens)))
+    right_tokens.extend([0] * (length - len(right_tokens)))
+    for left_value, right_value in zip(left_tokens, right_tokens):
+        if type(left_value) is type(right_value):
+            if left_value < right_value:
+                return -1
+            if left_value > right_value:
+                return 1
+        else:
+            left_text, right_text = str(left_value), str(right_value)
+            if left_text < right_text:
+                return -1
+            if left_text > right_text:
+                return 1
+    return 0
+
+
+def version_matches(value, minimum="", maximum=""):
+    value, minimum, maximum = clean(value, 120), clean(minimum, 120), clean(maximum, 120)
+    if not minimum and not maximum:
+        return True
+    if not value:
+        return False
+    if minimum and compare_versions(value, minimum) < 0:
+        return False
+    if maximum and compare_versions(value, maximum) > 0:
+        return False
+    return True
+
+
+def _json(value, fallback):
+    try:
+        return json.loads(value or "")
+    except (TypeError, json.JSONDecodeError):
+        return copy.deepcopy(fallback)
+
+
+def connect(path=None):
+    path = Path(path or database_path())
+    path.parent.mkdir(parents=True, exist_ok=True)
+    db = sqlite3.connect(path, timeout=15, factory=_ClosingConnection)
+    db.row_factory = sqlite3.Row
+    db.execute("PRAGMA foreign_keys = ON")
+    db.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS model_profiles (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          scope TEXT NOT NULL DEFAULT 'exact',
+          manufacturer_key TEXT NOT NULL,
+          model_key TEXT NOT NULL DEFAULT '',
+          family_key TEXT NOT NULL DEFAULT '',
+          manufacturer TEXT NOT NULL,
+          model TEXT NOT NULL DEFAULT '',
+          family TEXT NOT NULL DEFAULT '',
+          hardware_revision TEXT NOT NULL DEFAULT '',
+          firmware_min TEXT NOT NULL DEFAULT '',
+          firmware_max TEXT NOT NULL DEFAULT '',
+          aliases_json TEXT NOT NULL DEFAULT '[]',
+          manufacturer_aliases_json TEXT NOT NULL DEFAULT '[]',
+          notes TEXT NOT NULL DEFAULT '',
+          risk_notes TEXT NOT NULL DEFAULT '',
+          status TEXT NOT NULL DEFAULT 'active',
+          created_at REAL NOT NULL,
+          updated_at REAL NOT NULL,
+          UNIQUE(
+            scope, manufacturer_key, model_key, family_key,
+            hardware_revision, firmware_min, firmware_max
+          )
+        );
+        CREATE INDEX IF NOT EXISTS model_profiles_lookup
+          ON model_profiles(manufacturer_key, model_key, family_key, scope, status);
+
+        CREATE TABLE IF NOT EXISTS model_profile_ports (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile_id INTEGER NOT NULL REFERENCES model_profiles(id) ON DELETE CASCADE,
+          port INTEGER NOT NULL,
+          protocol TEXT NOT NULL DEFAULT 'tcp',
+          service TEXT NOT NULL,
+          description TEXT NOT NULL DEFAULT '',
+          classification TEXT NOT NULL DEFAULT 'expected',
+          exposure TEXT NOT NULL DEFAULT 'unknown',
+          authentication_expected INTEGER NOT NULL DEFAULT 0,
+          encryption_expected INTEGER NOT NULL DEFAULT 0,
+          risk TEXT NOT NULL DEFAULT 'info',
+          remediation TEXT NOT NULL DEFAULT '',
+          hardware_revision TEXT NOT NULL DEFAULT '',
+          firmware_min TEXT NOT NULL DEFAULT '',
+          firmware_max TEXT NOT NULL DEFAULT '',
+          source_name TEXT NOT NULL DEFAULT '',
+          source_url TEXT NOT NULL DEFAULT '',
+          source_reliability INTEGER NOT NULL DEFAULT 50,
+          confidence TEXT NOT NULL DEFAULT 'confirmed',
+          status TEXT NOT NULL DEFAULT 'active',
+          last_verified_at REAL,
+          expires_at REAL,
+          created_at REAL NOT NULL,
+          updated_at REAL NOT NULL,
+          UNIQUE(
+            profile_id, port, protocol, hardware_revision,
+            firmware_min, firmware_max, status
+          )
+        );
+        CREATE INDEX IF NOT EXISTS model_profile_ports_lookup
+          ON model_profile_ports(profile_id, protocol, port, status);
+
+        CREATE TABLE IF NOT EXISTS model_profile_revisions (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile_id INTEGER NOT NULL,
+          revision INTEGER NOT NULL,
+          action TEXT NOT NULL,
+          actor TEXT NOT NULL DEFAULT '',
+          note TEXT NOT NULL DEFAULT '',
+          snapshot_json TEXT NOT NULL,
+          created_at REAL NOT NULL,
+          UNIQUE(profile_id, revision)
+        );
+
+        CREATE TABLE IF NOT EXISTS model_profile_conflicts (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile_id INTEGER NOT NULL,
+          port INTEGER NOT NULL,
+          protocol TEXT NOT NULL,
+          current_json TEXT NOT NULL,
+          incoming_json TEXT NOT NULL,
+          source_name TEXT NOT NULL DEFAULT '',
+          source_url TEXT NOT NULL DEFAULT '',
+          status TEXT NOT NULL DEFAULT 'open',
+          resolution_note TEXT NOT NULL DEFAULT '',
+          created_at REAL NOT NULL,
+          resolved_at REAL
+        );
+
+        CREATE TABLE IF NOT EXISTS model_profile_observations (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile_id INTEGER NOT NULL,
+          device_signature TEXT NOT NULL,
+          port INTEGER NOT NULL,
+          protocol TEXT NOT NULL,
+          service TEXT NOT NULL DEFAULT '',
+          firmware TEXT NOT NULL DEFAULT '',
+          hardware_revision TEXT NOT NULL DEFAULT '',
+          evidence_json TEXT NOT NULL DEFAULT '{}',
+          observations INTEGER NOT NULL DEFAULT 1,
+          first_seen REAL NOT NULL,
+          last_seen REAL NOT NULL,
+          UNIQUE(profile_id, device_signature, port, protocol)
+        );
+
+        CREATE TABLE IF NOT EXISTS model_registry_imports (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          publisher TEXT NOT NULL DEFAULT '',
+          version TEXT NOT NULL DEFAULT '',
+          digest TEXT NOT NULL DEFAULT '',
+          signature_status TEXT NOT NULL DEFAULT '',
+          source_url TEXT NOT NULL DEFAULT '',
+          imported INTEGER NOT NULL DEFAULT 0,
+          conflicts INTEGER NOT NULL DEFAULT 0,
+          errors_json TEXT NOT NULL DEFAULT '[]',
+          created_at REAL NOT NULL
+        );
+        """
+    )
+    _migrate_legacy(db)
+    return db
+
+
+def _row(row):
+    if not row:
+        return None
+    item = dict(row)
+    for field, fallback in (
+        ("aliases_json", []),
+        ("manufacturer_aliases_json", []),
+        ("evidence_json", {}),
+        ("current_json", {}),
+        ("incoming_json", {}),
+        ("snapshot_json", {}),
+        ("errors_json", []),
+    ):
+        if field in item:
+            item[field[:-5] if field.endswith("_json") else field] = _json(item.pop(field), fallback)
+    for name in ("authentication_expected", "encryption_expected"):
+        if name in item:
+            item[name] = bool(item[name])
+    return item
+
+
+def _migrate_legacy(db):
+    table = db.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='port_knowledge'"
+    ).fetchone()
+    if not table:
+        return
+    rows = db.execute(
+        """
+        SELECT * FROM port_knowledge
+        WHERE status='approved' AND model_key != ''
+        ORDER BY manufacturer_key, model_key, protocol, port
+        """
+    ).fetchall()
+    now = time.time()
+    for legacy in rows:
+        profile = db.execute(
+            """
+            SELECT * FROM model_profiles
+            WHERE scope='exact' AND manufacturer_key=? AND model_key=?
+              AND hardware_revision='' AND firmware_min='' AND firmware_max=''
+            """,
+            (legacy["manufacturer_key"], legacy["model_key"]),
+        ).fetchone()
+        if profile:
+            profile_id = profile["id"]
+        else:
+            cursor = db.execute(
+                """
+                INSERT INTO model_profiles (
+                  scope, manufacturer_key, model_key, family_key,
+                  manufacturer, model, family, hardware_revision,
+                  firmware_min, firmware_max, aliases_json,
+                  manufacturer_aliases_json, notes, risk_notes,
+                  status, created_at, updated_at
+                ) VALUES (
+                  'exact', ?, ?, '', ?, ?, '', '', '', '',
+                  '[]', '[]', 'Migrated from model port knowledge', '',
+                  'active', ?, ?
+                )
+                """,
+                (
+                    legacy["manufacturer_key"], legacy["model_key"],
+                    legacy["manufacturer"], legacy["model"], now, now,
+                ),
+            )
+            profile_id = cursor.lastrowid
+        db.execute(
+            """
+            INSERT OR IGNORE INTO model_profile_ports (
+              profile_id, port, protocol, service, description,
+              classification, exposure, authentication_expected,
+              encryption_expected, risk, remediation, hardware_revision,
+              firmware_min, firmware_max, source_name, source_url,
+              source_reliability, confidence, status, last_verified_at,
+              expires_at, created_at, updated_at
+            ) VALUES (
+              ?, ?, ?, ?, ?, 'expected', 'unknown', 0, 0, 'info', '',
+              '', '', '', ?, ?, 60, ?, 'active', ?, NULL, ?, ?
+            )
+            """,
+            (
+                profile_id, legacy["port"], legacy["protocol"], legacy["service"],
+                legacy["description"], legacy["source_name"], legacy["source_url"],
+                legacy["confidence"], legacy["updated_at"], legacy["created_at"],
+                legacy["updated_at"],
+            ),
+        )
+
+
+def _profile_snapshot(db, profile_id):
+    profile = _row(db.execute("SELECT * FROM model_profiles WHERE id=?", (profile_id,)).fetchone())
+    if not profile:
+        return {}
+    ports = [
+        _row(row)
+        for row in db.execute(
+            "SELECT * FROM model_profile_ports WHERE profile_id=? AND status='active' ORDER BY protocol, port",
+            (profile_id,),
+        ).fetchall()
+    ]
+    return {"profile": profile, "ports": ports}
+
+
+def _record_revision(db, profile_id, action, actor="", note=""):
+    current = db.execute(
+        "SELECT COALESCE(MAX(revision), 0) FROM model_profile_revisions WHERE profile_id=?",
+        (profile_id,),
+    ).fetchone()[0]
+    revision = int(current) + 1
+    db.execute(
+        """
+        INSERT INTO model_profile_revisions (
+          profile_id, revision, action, actor, note, snapshot_json, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            profile_id, revision, clean(action, 100), clean(actor, 160),
+            clean(note, 1000), json.dumps(_profile_snapshot(db, profile_id), sort_keys=True),
+            time.time(),
+        ),
+    )
+    return revision
+
+
+def identity(device):
+    device = device or {}
+    assessment = device.get("identity_assessment") or {}
+    manufacturer = clean(device.get("manufacturer") or assessment.get("manufacturer") or device.get("vendor"), 200)
+    model = clean(device.get("model") or assessment.get("model") or device.get("model_name"), 240)
+    family = clean(device.get("model_family") or assessment.get("family"), 200)
+    hardware_revision = clean(
+        device.get("hardware_revision") or device.get("hardware_version") or assessment.get("hardware_revision"), 120
+    )
+    firmware = clean(
+        device.get("firmware") or device.get("firmware_version")
+        or device.get("software_version") or assessment.get("firmware"), 160
+    )
+    if key(manufacturer) == "unknown":
+        manufacturer = ""
+    if key(model) in _GENERIC_MODELS:
+        model = ""
+    return {
+        "manufacturer": manufacturer, "manufacturer_key": key(manufacturer),
+        "model": model, "model_key": key(model),
+        "family": family, "family_key": key(family),
+        "hardware_revision": hardware_revision, "firmware": firmware,
+    }
+
+
+def upsert_profile(
+    path, *, manufacturer, model="", family="", scope="exact",
+    hardware_revision="", firmware_min="", firmware_max="", aliases=None,
+    manufacturer_aliases=None, notes="", risk_notes="", actor="",
+):
+    scope = valid_choice(scope, SCOPES, "Profile scope", "exact")
+    manufacturer = clean(manufacturer, 200)
+    model, family = clean(model, 240), clean(family, 200)
+    hardware_revision = clean(hardware_revision, 120)
+    firmware_min, firmware_max = clean(firmware_min, 160), clean(firmware_max, 160)
+    if not manufacturer:
+        raise ValueError("Manufacturer is required")
+    if scope == "exact" and (not model or key(model) in _GENERIC_MODELS):
+        raise ValueError("An exact reusable model is required")
+    if scope == "family" and not family:
+        raise ValueError("A model family is required")
+    if scope == "manufacturer":
+        model, family = "", ""
+    now = time.time()
+    with connect(path) as db:
+        existing = db.execute(
+            """
+            SELECT * FROM model_profiles
+            WHERE scope=? AND manufacturer_key=? AND model_key=?
+              AND family_key=? AND hardware_revision=?
+              AND firmware_min=? AND firmware_max=?
+            """,
+            (scope, key(manufacturer), key(model), key(family), hardware_revision, firmware_min, firmware_max),
+        ).fetchone()
+        if existing:
+            profile_id = existing["id"]
+            db.execute(
+                """
+                UPDATE model_profiles SET
+                  manufacturer=?, model=?, family=?, aliases_json=?,
+                  manufacturer_aliases_json=?, notes=?, risk_notes=?,
+                  status='active', updated_at=? WHERE id=?
+                """,
+                (
+                    manufacturer, model, family, json.dumps(json_list(aliases)),
+                    json.dumps(json_list(manufacturer_aliases)), clean(notes, 4000),
+                    clean(risk_notes, 4000), now, profile_id,
+                ),
+            )
+            _record_revision(db, profile_id, "profile-updated", actor)
+        else:
+            cursor = db.execute(
+                """
+                INSERT INTO model_profiles (
+                  scope, manufacturer_key, model_key, family_key,
+                  manufacturer, model, family, hardware_revision,
+                  firmware_min, firmware_max, aliases_json,
+                  manufacturer_aliases_json, notes, risk_notes,
+                  status, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?)
+                """,
+                (
+                    scope, key(manufacturer), key(model), key(family), manufacturer,
+                    model, family, hardware_revision, firmware_min, firmware_max,
+                    json.dumps(json_list(aliases)), json.dumps(json_list(manufacturer_aliases)),
+                    clean(notes, 4000), clean(risk_notes, 4000), now, now,
+                ),
+            )
+            profile_id = cursor.lastrowid
+            _record_revision(db, profile_id, "profile-created", actor)
+    return profile_detail(path, profile_id)
+
+
+def profile_detail(path, profile_id):
+    with connect(path) as db:
+        profile = _row(db.execute(
+            "SELECT * FROM model_profiles WHERE id=? AND status='active'", (int(profile_id),)
+        ).fetchone())
+        if not profile:
+            raise ValueError("Device model profile was not found")
+        ports = [_row(row) for row in db.execute(
+            "SELECT * FROM model_profile_ports WHERE profile_id=? AND status='active' ORDER BY protocol, port",
+            (profile["id"],),
+        ).fetchall()]
+        open_conflicts = [_row(row) for row in db.execute(
+            "SELECT * FROM model_profile_conflicts WHERE profile_id=? AND status='open' ORDER BY created_at DESC",
+            (profile["id"],),
+        ).fetchall()]
+    profile["ports"] = ports
+    profile["conflicts"] = open_conflicts
+    return profile
+
+
+def list_profiles(path, query="", scope=""):
+    query_key = key(query)
+    with connect(path) as db:
+        rows = db.execute(
+            "SELECT * FROM model_profiles WHERE status='active' ORDER BY manufacturer, model, family"
+        ).fetchall()
+        counts = {row["profile_id"]: row["count"] for row in db.execute(
+            "SELECT profile_id, COUNT(*) AS count FROM model_profile_ports WHERE status='active' GROUP BY profile_id"
+        ).fetchall()}
+    results = []
+    for row in rows:
+        item = _row(row)
+        if scope and item["scope"] != scope:
+            continue
+        searchable = " ".join([
+            item["manufacturer"], item["model"], item["family"],
+            " ".join(item.get("aliases") or []),
+            " ".join(item.get("manufacturer_aliases") or []),
+        ]).casefold()
+        if query_key and query_key not in searchable:
+            continue
+        item["port_count"] = counts.get(item["id"], 0)
+        results.append(item)
+    return results
+
+
+def _manufacturer_match(profile, found):
+    aliases = {key(value) for value in profile.get("manufacturer_aliases") or []}
+    if found["manufacturer_key"] == profile["manufacturer_key"]:
+        return 30
+    if found["manufacturer_key"] and found["manufacturer_key"] in aliases:
+        return 20
+    return 0
+
+
+def _profile_match(profile, found):
+    manufacturer_score = _manufacturer_match(profile, found)
+    if not manufacturer_score:
+        return None
+    if profile["hardware_revision"]:
+        if key(profile["hardware_revision"]) != key(found["hardware_revision"]):
+            return None
+        hardware_score = 20
+    else:
+        hardware_score = 4
+    if not version_matches(found["firmware"], profile["firmware_min"], profile["firmware_max"]):
+        return None
+    firmware_score = 16 if (profile["firmware_min"] or profile["firmware_max"]) else 4
+    if profile["scope"] == "exact":
+        aliases = {key(value) for value in profile.get("aliases") or []}
+        if found["model_key"] == profile["model_key"]:
+            scope_score, level = 60, "exact"
+        elif found["model_key"] and found["model_key"] in aliases:
+            scope_score, level = 50, "alias"
+        else:
+            return None
+    elif profile["scope"] == "family":
+        if found["family_key"] == profile["family_key"]:
+            scope_score, level = 35, "family"
+        elif profile["family_key"] and profile["family_key"] in found["model_key"]:
+            scope_score, level = 28, "family-inferred"
+        else:
+            return None
+    else:
+        scope_score, level = 10, "manufacturer"
+    return {
+        "profile": profile,
+        "score": manufacturer_score + scope_score + hardware_score + firmware_score,
+        "level": level,
+    }
+
+
+def resolve_profile_stack(path, device):
+    found = identity(device)
+    candidates = []
+    manual_id = device.get("model_profile_manual_id")
+    if manual_id:
+        try:
+            manual = profile_detail(path, manual_id)
+            candidates.append({"profile": manual, "score": 1000, "level": "manual"})
+        except ValueError:
+            pass
+    for profile in list_profiles(path):
+        if manual_id and int(profile["id"]) == int(manual_id):
+            continue
+        matched = _profile_match(profile, found)
+        if matched:
+            candidates.append(matched)
+    candidates.sort(key=lambda item: (item["score"], item["profile"]["id"]))
+    return {"identity": found, "matches": candidates}
+
+
+def _rule_applicable(rule, found):
+    if rule["hardware_revision"] and key(rule["hardware_revision"]) != key(found["hardware_revision"]):
+        return False
+    return version_matches(found["firmware"], rule["firmware_min"], rule["firmware_max"])
+
+
+def combined_rules(path, device):
+    stack = resolve_profile_stack(path, device)
+    combined, applied_profiles = {}, []
+    for match in stack["matches"]:
+        profile = profile_detail(path, match["profile"]["id"])
+        applied_profiles.append({
+            "id": profile["id"], "manufacturer": profile["manufacturer"],
+            "model": profile["model"], "family": profile["family"],
+            "scope": profile["scope"], "match_level": match["level"],
+            "score": match["score"],
+        })
+        for rule in profile["ports"]:
+            if _rule_applicable(rule, stack["identity"]):
+                combined[(rule["port"], rule["protocol"])] = rule
+    return {
+        "identity": stack["identity"], "rules": combined,
+        "profiles": applied_profiles,
+        "primary_profile": applied_profiles[-1] if applied_profiles else None,
+    }
+
+
+def add_port_rule(
+    path, *, profile_id, port, protocol="tcp", service, description="",
+    classification="expected", exposure="unknown", authentication_expected=False,
+    encryption_expected=False, risk="info", remediation="", hardware_revision="",
+    firmware_min="", firmware_max="", source_name="", source_url="",
+    source_reliability=50, confidence="confirmed", actor="", allow_replace=False,
+):
+    profile_id, port, protocol = int(profile_id), valid_port(port), valid_protocol(protocol)
+    service = clean(service, 200)
+    if not service:
+        raise ValueError("Service name is required")
+    classification = valid_choice(classification, CLASSIFICATIONS, "Classification", "expected")
+    exposure = valid_choice(exposure, EXPOSURES, "Exposure", "unknown")
+    risk = valid_choice(risk, RISK_LEVELS, "Risk", "info")
+    hardware_revision = clean(hardware_revision, 120)
+    firmware_min, firmware_max = clean(firmware_min, 160), clean(firmware_max, 160)
+    try:
+        source_reliability = max(0, min(100, int(source_reliability)))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Source reliability must be from 0 to 100") from exc
+    incoming = {
+        "profile_id": profile_id, "port": port, "protocol": protocol,
+        "service": service, "description": clean(description, 2000),
+        "classification": classification, "exposure": exposure,
+        "authentication_expected": bool_value(authentication_expected),
+        "encryption_expected": bool_value(encryption_expected), "risk": risk,
+        "remediation": clean(remediation, 2000),
+        "hardware_revision": hardware_revision, "firmware_min": firmware_min,
+        "firmware_max": firmware_max, "source_name": clean(source_name, 240),
+        "source_url": valid_url(source_url), "source_reliability": source_reliability,
+        "confidence": clean(confidence or "confirmed", 80),
+    }
+    now = time.time()
+    with connect(path) as db:
+        profile = db.execute(
+            "SELECT * FROM model_profiles WHERE id=? AND status='active'", (profile_id,)
+        ).fetchone()
+        if not profile:
+            raise ValueError("Device model profile was not found")
+        existing = db.execute(
+            """
+            SELECT * FROM model_profile_ports
+            WHERE profile_id=? AND port=? AND protocol=?
+              AND hardware_revision=? AND firmware_min=? AND firmware_max=?
+              AND status='active'
+            """,
+            (profile_id, port, protocol, hardware_revision, firmware_min, firmware_max),
+        ).fetchone()
+        if existing:
+            current = _row(existing)
+            material = (
+                "service", "description", "classification", "exposure", "risk",
+                "remediation", "authentication_expected", "encryption_expected",
+            )
+            if any(current.get(name) != incoming.get(name) for name in material) and not allow_replace:
+                cursor = db.execute(
+                    """
+                    INSERT INTO model_profile_conflicts (
+                      profile_id, port, protocol, current_json, incoming_json,
+                      source_name, source_url, status, resolution_note,
+                      created_at, resolved_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, 'open', '', ?, NULL)
+                    """,
+                    (
+                        profile_id, port, protocol, json.dumps(current, sort_keys=True),
+                        json.dumps(incoming, sort_keys=True), incoming["source_name"],
+                        incoming["source_url"], now,
+                    ),
+                )
+                _record_revision(db, profile_id, "port-conflict-recorded", actor, f"Conflict {cursor.lastrowid} for {port}/{protocol}")
+                return {"status": "conflict", "conflict_id": cursor.lastrowid, "current": current, "incoming": incoming}
+            db.execute(
+                """
+                UPDATE model_profile_ports SET
+                  service=?, description=?, classification=?, exposure=?,
+                  authentication_expected=?, encryption_expected=?, risk=?,
+                  remediation=?, source_name=?, source_url=?, source_reliability=?,
+                  confidence=?, last_verified_at=?, updated_at=? WHERE id=?
+                """,
+                (
+                    incoming["service"], incoming["description"], incoming["classification"],
+                    incoming["exposure"], int(incoming["authentication_expected"]),
+                    int(incoming["encryption_expected"]), incoming["risk"],
+                    incoming["remediation"], incoming["source_name"], incoming["source_url"],
+                    incoming["source_reliability"], incoming["confidence"], now, now,
+                    existing["id"],
+                ),
+            )
+            rule_id, action = existing["id"], "port-rule-updated"
+        else:
+            cursor = db.execute(
+                """
+                INSERT INTO model_profile_ports (
+                  profile_id, port, protocol, service, description,
+                  classification, exposure, authentication_expected,
+                  encryption_expected, risk, remediation, hardware_revision,
+                  firmware_min, firmware_max, source_name, source_url,
+                  source_reliability, confidence, status, last_verified_at,
+                  expires_at, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, NULL, ?, ?)
+                """,
+                (
+                    profile_id, port, protocol, incoming["service"], incoming["description"],
+                    incoming["classification"], incoming["exposure"],
+                    int(incoming["authentication_expected"]), int(incoming["encryption_expected"]),
+                    incoming["risk"], incoming["remediation"], hardware_revision,
+                    firmware_min, firmware_max, incoming["source_name"], incoming["source_url"],
+                    incoming["source_reliability"], incoming["confidence"], now, now, now,
+                ),
+            )
+            rule_id, action = cursor.lastrowid, "port-rule-created"
+        db.execute("UPDATE model_profiles SET updated_at=? WHERE id=?", (now, profile_id))
+        _record_revision(db, profile_id, action, actor, f"{port}/{protocol} {service}")
+        return _row(db.execute("SELECT * FROM model_profile_ports WHERE id=?", (rule_id,)).fetchone())
+
+
+def delete_port_rule(path, profile_id, rule_id, actor=""):
+    with connect(path) as db:
+        row = db.execute(
+            "SELECT * FROM model_profile_ports WHERE id=? AND profile_id=? AND status='active'",
+            (int(rule_id), int(profile_id)),
+        ).fetchone()
+        if not row:
+            return False
+        db.execute(
+            "UPDATE model_profile_ports SET status='deleted', updated_at=? WHERE id=?",
+            (time.time(), int(rule_id)),
+        )
+        _record_revision(db, int(profile_id), "port-rule-deleted", actor, f"{row['port']}/{row['protocol']} {row['service']}")
+        return True
+
+
+def set_device_override(
+    device, *, port, protocol="tcp", service="",
+    classification="local-configuration", description="", risk="info", remediation="",
+):
+    updated = copy.deepcopy(device or {})
+    override = {
+        "port": valid_port(port), "protocol": valid_protocol(protocol),
+        "service": clean(service, 200),
+        "classification": valid_choice(classification, CLASSIFICATIONS, "Classification", "local-configuration"),
+        "description": clean(description, 1000),
+        "risk": valid_choice(risk, RISK_LEVELS, "Risk", "info"),
+        "remediation": clean(remediation, 1000), "updated_at": time.time(),
+    }
+    overrides = [
+        item for item in updated.get("model_port_overrides") or []
+        if not (
+            int(item.get("port") or 0) == override["port"]
+            and key(item.get("protocol") or "tcp") == override["protocol"]
+        )
+    ]
+    overrides.append(override)
+    updated["model_port_overrides"] = sorted(overrides, key=lambda item: (item["protocol"], item["port"]))
+    return updated
+
+
+def _drift_severity(unexpected, missing, deprecated):
+    score = 0
+    for item in unexpected:
+        score += {"critical": 40, "high": 25, "medium": 12, "low": 5}.get(item.get("risk"), 4)
+    score += len(missing) * 8 + len(deprecated) * 10
+    if score >= 50:
+        return "critical", min(100, score)
+    if score >= 25:
+        return "high", min(100, score)
+    if score >= 10:
+        return "medium", min(100, score)
+    if score:
+        return "low", min(100, score)
+    return "none", 0
+
+
+def apply_device_profile(path, device):
+    result = combined_rules(path, device)
+    rules = dict(result["rules"])
+    for override in device.get("model_port_overrides") or []:
+        try:
+            rules[(valid_port(override.get("port")), valid_protocol(override.get("protocol")))] = {
+                **override, "id": None, "profile_id": None,
+                "source_name": "Device-specific override", "source_url": "",
+                "confidence": "local", "exposure": "unknown",
+                "authentication_expected": False, "encryption_expected": False,
+            }
+        except ValueError:
+            continue
+    observed, open_details = set(), []
+    unexpected, deprecated, remediation = [], [], []
+    for raw in device.get("open_port_details") or []:
+        detail = dict(raw)
+        try:
+            item_key = (valid_port(detail.get("port")), valid_protocol(detail.get("protocol") or "tcp"))
+        except ValueError:
+            open_details.append(detail)
+            continue
+        observed.add(item_key)
+        rule = rules.get(item_key)
+        if rule:
+            detail.update({
+                "model_profile_rule_id": rule.get("id"),
+                "model_profile_id": rule.get("profile_id"),
+                "model_profile_service": rule.get("service"),
+                "model_profile_description": rule.get("description"),
+                "model_profile_classification": rule.get("classification"),
+                "model_profile_exposure": rule.get("exposure"),
+                "model_profile_risk": rule.get("risk"),
+                "model_profile_remediation": rule.get("remediation"),
+                "model_profile_source_name": rule.get("source_name"),
+                "model_profile_source_url": rule.get("source_url"),
+            })
+            if key(detail.get("service")) in {"", "unknown", "unknown service", "unassigned"}:
+                detail["service"] = rule.get("service") or detail.get("service")
+            if not detail.get("description") and rule.get("description"):
+                detail["description"] = rule["description"]
+            if rule.get("classification") == "deprecated":
+                deprecated.append(detail)
+            if rule.get("remediation"):
+                remediation.append({
+                    "port": item_key[0], "protocol": item_key[1],
+                    "severity": rule.get("risk") or "info",
+                    "task": rule["remediation"], "reason": rule.get("classification"),
+                })
+        else:
+            unknown = {
+                "port": item_key[0], "protocol": item_key[1],
+                "service": detail.get("service") or "Unknown",
+                "risk": "medium" if item_key[0] >= 1024 else "high",
+                "reason": "No applicable model-profile rule",
+            }
+            unexpected.append(unknown)
+            detail["model_profile_classification"] = "unexpected"
+            detail["model_profile_risk"] = unknown["risk"]
+            remediation.append({
+                "port": item_key[0], "protocol": item_key[1], "severity": unknown["risk"],
+                "task": "Identify the service and either approve it for this model, mark it as a local override, or restrict/disable it.",
+                "reason": "unexpected",
+            })
+        open_details.append(detail)
+    missing = []
+    for item_key, rule in rules.items():
+        if rule.get("classification") == "expected" and item_key not in observed:
+            missing.append({
+                "port": item_key[0], "protocol": item_key[1],
+                "service": rule.get("service"), "risk": rule.get("risk") or "info",
+                "reason": "Expected model service was not observed",
+            })
+            remediation.append({
+                "port": item_key[0], "protocol": item_key[1], "severity": "low",
+                "task": "Confirm whether the feature is disabled, the firmware differs, or the scan missed the expected service.",
+                "reason": "missing-expected",
+            })
+    severity, score = _drift_severity(unexpected, missing, deprecated)
+    drift = {
+        "severity": severity, "score": score, "unexpected": unexpected,
+        "missing_expected": missing, "deprecated": deprecated,
+        "matches_profile": not unexpected and not missing and not deprecated,
+        "observed_count": len(observed), "applicable_rule_count": len(rules),
+        "digest": hashlib.sha256(json.dumps({
+            "unexpected": unexpected, "missing": missing,
+            "deprecated": [(item.get("port"), item.get("protocol")) for item in deprecated],
+        }, sort_keys=True).encode()).hexdigest(),
+    }
+    updated = copy.deepcopy(device or {})
+    updated["open_port_details"] = open_details
+    updated["model_profile_matches"] = result["profiles"]
+    updated["model_profile_id"] = result["primary_profile"]["id"] if result["primary_profile"] else None
+    updated["model_profile_match_level"] = result["primary_profile"]["match_level"] if result["primary_profile"] else None
+    updated["model_port_drift"] = drift
+    updated["model_remediation_tasks"] = remediation
+    updated["model_profile_applied_at"] = time.time()
+    return {
+        "device": updated, "identity": result["identity"],
+        "profiles": result["profiles"], "primary_profile": result["primary_profile"],
+        "rules": list(rules.values()), "drift": drift, "remediation": remediation,
+    }
+
+
+def record_observations(path, device, profile_id=None):
+    applied = apply_device_profile(path, device)
+    profile_id = int(profile_id or applied["device"].get("model_profile_id") or 0)
+    if not profile_id:
+        return {"recorded": 0}
+    signature = clean(device.get("identity_signature"), 160)
+    if not signature:
+        raw = "|".join(str(device.get(name) or "") for name in ("mac", "serial_number", "hostname", "id", "ip"))
+        if raw.strip("|"):
+            signature = hashlib.sha256(raw.encode()).hexdigest()
+    if not signature:
+        return {"recorded": 0}
+    now, recorded = time.time(), 0
+    with connect(path) as db:
+        for detail in device.get("open_port_details") or []:
+            try:
+                port, protocol = valid_port(detail.get("port")), valid_protocol(detail.get("protocol") or "tcp")
+            except ValueError:
+                continue
+            evidence = {name: detail.get(name) for name in (
+                "service", "description", "http_title", "http_server", "tls_certificate"
+            ) if detail.get(name) not in (None, "")}
+            existing = db.execute(
+                "SELECT * FROM model_profile_observations WHERE profile_id=? AND device_signature=? AND port=? AND protocol=?",
+                (profile_id, signature, port, protocol),
+            ).fetchone()
+            if existing:
+                db.execute(
+                    """
+                    UPDATE model_profile_observations SET service=?, firmware=?,
+                      hardware_revision=?, evidence_json=?, observations=observations+1,
+                      last_seen=? WHERE id=?
+                    """,
+                    (
+                        clean(detail.get("service"), 200), applied["identity"]["firmware"],
+                        applied["identity"]["hardware_revision"], json.dumps(evidence, sort_keys=True),
+                        now, existing["id"],
+                    ),
+                )
+            else:
+                db.execute(
+                    """
+                    INSERT INTO model_profile_observations (
+                      profile_id, device_signature, port, protocol, service,
+                      firmware, hardware_revision, evidence_json,
+                      observations, first_seen, last_seen
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)
+                    """,
+                    (
+                        profile_id, signature, port, protocol, clean(detail.get("service"), 200),
+                        applied["identity"]["firmware"], applied["identity"]["hardware_revision"],
+                        json.dumps(evidence, sort_keys=True), now, now,
+                    ),
+                )
+            recorded += 1
+    return {"recorded": recorded, "profile_id": profile_id}
+
+
+def fleet_summary(path, inventory, profile_id):
+    profile = profile_detail(path, profile_id)
+    devices, port_counts, firmware_counts = [], {}, {}
+    for raw in inventory or []:
+        result = apply_device_profile(path, raw)
+        if profile["id"] not in {item["id"] for item in result["profiles"]}:
+            continue
+        device = result["device"]
+        firmware = result["identity"]["firmware"] or "Unknown"
+        firmware_counts[firmware] = firmware_counts.get(firmware, 0) + 1
+        observed = sorted({
+            (int(item.get("port")), key(item.get("protocol") or "tcp"))
+            for item in device.get("open_port_details") or [] if item.get("port")
+        })
+        for item in observed:
+            port_counts[item] = port_counts.get(item, 0) + 1
+        devices.append({
+            "id": device.get("id"), "ip": device.get("ip"),
+            "display_name": device.get("display_name") or device.get("name")
+            or device.get("hostname") or device.get("ip") or "Unknown device",
+            "firmware": firmware,
+            "hardware_revision": result["identity"]["hardware_revision"],
+            "drift": result["drift"],
+            "observed_ports": [{"port": item[0], "protocol": item[1]} for item in observed],
+        })
+    common = [
+        {"port": item[0], "protocol": item[1], "devices": count}
+        for item, count in sorted(port_counts.items(), key=lambda entry: (-entry[1], entry[0][1], entry[0][0]))
+    ]
+    return {
+        "profile": profile, "device_count": len(devices), "devices": devices,
+        "common_ports": common, "firmware_counts": firmware_counts,
+        "drifted_devices": len([item for item in devices if not item["drift"]["matches_profile"]]),
+    }
+
+
+def investigate_port(path, device, port, protocol="tcp", safe_probes=None, peers=None):
+    port, protocol = valid_port(port), valid_protocol(protocol)
+    detail = next((item for item in device.get("open_port_details") or []
+                   if int(item.get("port") or 0) == port
+                   and key(item.get("protocol") or "tcp") == protocol), {})
+    service_probe = next((item for item in (safe_probes or {}).get("services") or []
+                          if int(item.get("port") or 0) == port), {})
+    evidence, suggestions = [], []
+    http = service_probe.get("http") or {}
+    if http.get("title") or http.get("server"):
+        evidence.append(f"HTTP response: {clean(http.get('title') or http.get('server'), 300)}")
+        suggestions.append("HTTP management or diagnostic service")
+    if service_probe.get("banner"):
+        evidence.append(f"Banner: {clean(service_probe['banner'], 300)}")
+        suggestions.append(f"{clean(service_probe['banner'], 120).split()[0]} service")
+    if service_probe.get("rtsp") and not service_probe["rtsp"].get("error"):
+        evidence.append("RTSP protocol response")
+        suggestions.append("RTSP media service")
+    if service_probe.get("mqtt") and not service_probe["mqtt"].get("error"):
+        evidence.append("MQTT protocol response")
+        suggestions.append("MQTT broker")
+    if detail.get("service") and key(detail.get("service")) not in {"unknown", "unknown service", "unassigned"}:
+        evidence.append(f"Scanner identified {detail['service']}")
+        suggestions.append(detail["service"])
+    peer_matches = []
+    for peer in peers or []:
+        peer_detail = next((item for item in peer.get("open_port_details") or []
+                            if int(item.get("port") or 0) == port
+                            and key(item.get("protocol") or "tcp") == protocol), None)
+        if peer_detail:
+            peer_matches.append({
+                "model": peer.get("model"),
+                "firmware": peer.get("firmware") or peer.get("firmware_version"),
+                "service": peer_detail.get("service"),
+            })
+    if peer_matches:
+        evidence.append(f"Observed on {len(peer_matches)} peer device(s)")
+    found = identity(device)
+    suggested = suggestions[0] if suggestions else "Model-specific service"
+    confidence = "high" if len(evidence) >= 3 else "medium" if evidence else "low"
+    query = " ".join(filter(None, [
+        found["manufacturer"], found["model"], found["firmware"],
+        f"port {port}", protocol, "service",
+    ]))
+    return {
+        "port": port, "protocol": protocol, "identity": found,
+        "suggested_service": suggested, "confidence": confidence,
+        "evidence": evidence, "peer_observations": peer_matches,
+        "research_query": query,
+        "recommended_actions": [
+            "Check vendor manuals and support documentation.",
+            "Confirm whether the service is LAN-only and authenticated.",
+            "Save a model rule when the meaning and applicability are verified.",
+            "Use a device-specific override when this is local configuration rather than model behaviour.",
+        ],
+    }
+
+
+def conflicts(path, profile_id=None, status="open"):
+    with connect(path) as db:
+        if profile_id:
+            rows = db.execute(
+                "SELECT * FROM model_profile_conflicts WHERE profile_id=? AND status=? ORDER BY created_at DESC",
+                (int(profile_id), status),
+            ).fetchall()
+        else:
+            rows = db.execute(
+                "SELECT * FROM model_profile_conflicts WHERE status=? ORDER BY created_at DESC",
+                (status,),
+            ).fetchall()
+    return [_row(row) for row in rows]
+
+
+def resolve_conflict(path, conflict_id, choice, actor="", note=""):
+    choice = key(choice)
+    if choice not in {"current", "incoming"}:
+        raise ValueError("Conflict resolution must keep current or accept incoming")
+    with connect(path) as db:
+        conflict = db.execute(
+            "SELECT * FROM model_profile_conflicts WHERE id=? AND status='open'",
+            (int(conflict_id),),
+        ).fetchone()
+        if not conflict:
+            raise ValueError("Profile conflict was not found")
+        current = _json(conflict["current_json"], {})
+        incoming = _json(conflict["incoming_json"], {})
+        profile_id = conflict["profile_id"]
+        if choice == "incoming":
+            db.execute(
+                """
+                UPDATE model_profile_ports SET
+                  service=?, description=?, classification=?, exposure=?,
+                  authentication_expected=?, encryption_expected=?, risk=?,
+                  remediation=?, source_name=?, source_url=?, source_reliability=?,
+                  confidence=?, updated_at=? WHERE id=?
+                """,
+                (
+                    incoming.get("service", ""), incoming.get("description", ""),
+                    incoming.get("classification", "expected"), incoming.get("exposure", "unknown"),
+                    int(bool(incoming.get("authentication_expected"))),
+                    int(bool(incoming.get("encryption_expected"))), incoming.get("risk", "info"),
+                    incoming.get("remediation", ""), incoming.get("source_name", ""),
+                    incoming.get("source_url", ""), int(incoming.get("source_reliability") or 50),
+                    incoming.get("confidence", "confirmed"), time.time(), current["id"],
+                ),
+            )
+        db.execute(
+            "UPDATE model_profile_conflicts SET status='resolved', resolution_note=?, resolved_at=? WHERE id=?",
+            (clean(note or f"{choice} selected by {actor}", 1000), time.time(), int(conflict_id)),
+        )
+        _record_revision(db, profile_id, "conflict-resolved", actor, f"Conflict {conflict_id}: {choice}")
+    return profile_detail(path, profile_id)
+
+
+def revision_history(path, profile_id):
+    with connect(path) as db:
+        rows = db.execute(
+            "SELECT * FROM model_profile_revisions WHERE profile_id=? ORDER BY revision DESC",
+            (int(profile_id),),
+        ).fetchall()
+    return [_row(row) for row in rows]
+
+
+def rollback(path, profile_id, revision, actor="", note=""):
+    with connect(path) as db:
+        row = db.execute(
+            "SELECT * FROM model_profile_revisions WHERE profile_id=? AND revision=?",
+            (int(profile_id), int(revision)),
+        ).fetchone()
+        if not row:
+            raise ValueError("Profile revision was not found")
+        snapshot = _json(row["snapshot_json"], {})
+        profile, ports = snapshot.get("profile") or {}, snapshot.get("ports") or []
+        if not profile:
+            raise ValueError("Profile revision snapshot is incomplete")
+        db.execute(
+            """
+            UPDATE model_profiles SET
+              scope=?, manufacturer_key=?, model_key=?, family_key=?,
+              manufacturer=?, model=?, family=?, hardware_revision=?,
+              firmware_min=?, firmware_max=?, aliases_json=?,
+              manufacturer_aliases_json=?, notes=?, risk_notes=?,
+              status='active', updated_at=? WHERE id=?
+            """,
+            (
+                profile["scope"], profile["manufacturer_key"], profile["model_key"],
+                profile["family_key"], profile["manufacturer"], profile["model"],
+                profile["family"], profile["hardware_revision"], profile["firmware_min"],
+                profile["firmware_max"], json.dumps(profile.get("aliases") or []),
+                json.dumps(profile.get("manufacturer_aliases") or []), profile.get("notes") or "",
+                profile.get("risk_notes") or "", time.time(), int(profile_id),
+            ),
+        )
+        db.execute(
+            "UPDATE model_profile_ports SET status='rollback-replaced', updated_at=? WHERE profile_id=? AND status='active'",
+            (time.time(), int(profile_id)),
+        )
+        for item in ports:
+            db.execute(
+                """
+                INSERT INTO model_profile_ports (
+                  profile_id, port, protocol, service, description,
+                  classification, exposure, authentication_expected,
+                  encryption_expected, risk, remediation, hardware_revision,
+                  firmware_min, firmware_max, source_name, source_url,
+                  source_reliability, confidence, status, last_verified_at,
+                  expires_at, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'active', ?, ?, ?, ?)
+                """,
+                (
+                    int(profile_id), item["port"], item["protocol"], item["service"],
+                    item.get("description") or "", item.get("classification") or "expected",
+                    item.get("exposure") or "unknown", int(bool(item.get("authentication_expected"))),
+                    int(bool(item.get("encryption_expected"))), item.get("risk") or "info",
+                    item.get("remediation") or "", item.get("hardware_revision") or "",
+                    item.get("firmware_min") or "", item.get("firmware_max") or "",
+                    item.get("source_name") or "", item.get("source_url") or "",
+                    int(item.get("source_reliability") or 50), item.get("confidence") or "confirmed",
+                    item.get("last_verified_at"), item.get("expires_at"),
+                    item.get("created_at") or time.time(), time.time(),
+                ),
+            )
+        _record_revision(db, int(profile_id), "profile-rollback", actor, note or f"Rolled back to revision {revision}")
+    return profile_detail(path, profile_id)
+
+
+def _canonical_registry_content(payload):
+    content = copy.deepcopy(payload)
+    manifest = content.setdefault("manifest", {})
+    manifest.pop("digest", None)
+    manifest.pop("signature", None)
+    return json.dumps(content, sort_keys=True, separators=(",", ":")).encode()
+
+
+def trusted_keys(value=None):
+    raw = value if value is not None else os.environ.get("MOBILE_ROUTER_MODEL_REGISTRY_KEYS", "")
+    if not raw:
+        return {}
+    if isinstance(raw, dict):
+        return {str(name): str(secret) for name, secret in raw.items()}
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError("MOBILE_ROUTER_MODEL_REGISTRY_KEYS must be JSON") from exc
+    if not isinstance(parsed, dict):
+        raise ValueError("MOBILE_ROUTER_MODEL_REGISTRY_KEYS must be an object")
+    return {str(name): str(secret) for name, secret in parsed.items()}
+
+
+def export_registry(path, *, publisher="local", version="", signing_key=None):
+    profiles = []
+    for summary in list_profiles(path):
+        detail = profile_detail(path, summary["id"])
+        detail.pop("conflicts", None)
+        profiles.append(detail)
+    payload = {
+        "schema": SCHEMA,
+        "manifest": {
+            "publisher": clean(publisher, 200) or "local",
+            "version": clean(version, 120) or time.strftime("%Y.%m.%d.%H%M"),
+            "published_at": time.time(),
+            "algorithm": "hmac-sha256" if signing_key else "sha256",
+        },
+        "profiles": profiles,
+    }
+    canonical = _canonical_registry_content(payload)
+    payload["manifest"]["digest"] = hashlib.sha256(canonical).hexdigest()
+    if signing_key:
+        payload["manifest"]["signature"] = hmac.new(
+            str(signing_key).encode(), canonical, hashlib.sha256
+        ).hexdigest()
+    return payload
+
+
+def verify_registry(payload, trusted=None, require_signature=False):
+    if not isinstance(payload, dict) or payload.get("schema") != SCHEMA:
+        raise ValueError(f"Registry must use schema {SCHEMA}")
+    if not isinstance(payload.get("profiles"), list):
+        raise ValueError("Registry must contain a profiles list")
+    manifest = payload.get("manifest") or {}
+    expected_digest = clean(manifest.get("digest"), 128)
+    canonical = _canonical_registry_content(payload)
+    actual_digest = hashlib.sha256(canonical).hexdigest()
+    if not expected_digest or not hmac.compare_digest(expected_digest, actual_digest):
+        raise ValueError("Registry digest verification failed")
+    signature = clean(manifest.get("signature"), 256)
+    publisher = clean(manifest.get("publisher"), 200)
+    keys = trusted_keys(trusted)
+    if signature:
+        secret = keys.get(publisher)
+        if not secret:
+            raise ValueError(f"No trusted signing key is configured for {publisher}")
+        expected = hmac.new(secret.encode(), canonical, hashlib.sha256).hexdigest()
+        if not hmac.compare_digest(signature, expected):
+            raise ValueError("Registry signature verification failed")
+        signature_status = "verified"
+    elif require_signature:
+        raise ValueError("A signed registry is required")
+    else:
+        signature_status = "unsigned"
+    return {
+        "publisher": publisher,
+        "version": clean(manifest.get("version"), 120),
+        "digest": actual_digest, "signature_status": signature_status,
+        "profile_count": len(payload["profiles"]),
+    }
+
+
+def import_registry(
+    path, payload, *, actor="registry-import", source_url="", trusted=None,
+    require_signature=False, preview=False,
+):
+    verification = verify_registry(payload, trusted, require_signature)
+    imported, conflict_count, errors = 0, 0, []
+    for index, raw_profile in enumerate(payload["profiles"][:5000]):
+        try:
+            profile = upsert_profile(
+                path, manufacturer=raw_profile.get("manufacturer"),
+                model=raw_profile.get("model"), family=raw_profile.get("family"),
+                scope=raw_profile.get("scope") or "exact",
+                hardware_revision=raw_profile.get("hardware_revision"),
+                firmware_min=raw_profile.get("firmware_min"),
+                firmware_max=raw_profile.get("firmware_max"),
+                aliases=raw_profile.get("aliases"),
+                manufacturer_aliases=raw_profile.get("manufacturer_aliases"),
+                notes=raw_profile.get("notes"), risk_notes=raw_profile.get("risk_notes"),
+                actor=actor,
+            )
+            for rule in raw_profile.get("ports") or []:
+                result = add_port_rule(
+                    path, profile_id=profile["id"], port=rule.get("port"),
+                    protocol=rule.get("protocol") or "tcp", service=rule.get("service"),
+                    description=rule.get("description"),
+                    classification=rule.get("classification") or "expected",
+                    exposure=rule.get("exposure") or "unknown",
+                    authentication_expected=rule.get("authentication_expected"),
+                    encryption_expected=rule.get("encryption_expected"),
+                    risk=rule.get("risk") or "info", remediation=rule.get("remediation"),
+                    hardware_revision=rule.get("hardware_revision"),
+                    firmware_min=rule.get("firmware_min"), firmware_max=rule.get("firmware_max"),
+                    source_name=rule.get("source_name") or verification["publisher"],
+                    source_url=rule.get("source_url") or source_url,
+                    source_reliability=rule.get("source_reliability") or 60,
+                    confidence=rule.get("confidence") or "registry", actor=actor,
+                    allow_replace=False,
+                )
+                if result.get("status") == "conflict":
+                    conflict_count += 1
+            imported += 1
+        except (TypeError, ValueError, KeyError) as exc:
+            errors.append({"index": index, "message": clean(exc, 500)})
+    result = {
+        "verification": verification, "imported": imported,
+        "conflicts": conflict_count, "errors": errors[:100],
+    }
+    if preview:
+        result["would_import"] = result.pop("imported")
+        result["would_conflict"] = result.pop("conflicts")
+        return result
+    with connect(path) as db:
+        db.execute(
+            """
+            INSERT INTO model_registry_imports (
+              publisher, version, digest, signature_status, source_url,
+              imported, conflicts, errors_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                verification["publisher"], verification["version"], verification["digest"],
+                verification["signature_status"], clean(source_url, 1200), imported,
+                conflict_count, json.dumps(errors[:100]), time.time(),
+            ),
+        )
+    return result
+
+
+def public_https_url(url):
+    parsed = urlparse(str(url or ""))
+    if parsed.scheme != "https" or not parsed.hostname or parsed.username or parsed.password:
+        raise ValueError("Registry URLs must be credential-free HTTPS URLs")
+    try:
+        addresses = {item[4][0] for item in socket.getaddrinfo(parsed.hostname, parsed.port or 443)}
+    except OSError as exc:
+        raise ValueError("Registry hostname could not be resolved") from exc
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved or ip.is_multicast or ip.is_unspecified:
+            raise ValueError("Registry URL resolved to a non-public address")
+    return str(url)
+
+
+def configured_registry_urls(value=None):
+    raw = value if value is not None else os.environ.get(
+        "MOBILE_ROUTER_MODEL_REGISTRY_URLS",
+        os.environ.get("MOBILE_ROUTER_PORT_REGISTRY_URLS", ""),
+    )
+    return [part.strip() for part in str(raw).split(",") if part.strip()]
+
+
+def sync_registries(
+    path, *, urls=None, opener=urlopen, trusted=None, require_signature=True,
+):
+    results = []
+    for configured in urls or configured_registry_urls():
+        try:
+            url = public_https_url(configured)
+            with opener(Request(url, headers={"User-Agent": "MobileRouterLab/2.0"}), timeout=12) as response:
+                final_url = public_https_url(response.geturl())
+                raw = response.read(_MAX_DOWNLOAD + 1)
+            if len(raw) > _MAX_DOWNLOAD:
+                raise ValueError("Registry download exceeded 2 MiB")
+            payload = json.loads(raw.decode("utf-8"))
+            imported = import_registry(
+                path, payload, actor="registry-sync", source_url=final_url,
+                trusted=trusted, require_signature=require_signature,
+            )
+            results.append({"url": final_url, "status": "success", **imported})
+        except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+            results.append({
+                "url": clean(configured, 1200), "status": "error",
+                "message": clean(exc, 500),
+            })
+    return results
+
+
+def contribution_payload(path, profile_id, inventory=None):
+    profile = profile_detail(path, profile_id)
+    fleet = fleet_summary(path, inventory or [], profile_id)
+    safe_profile = {name: profile.get(name) for name in (
+        "scope", "manufacturer", "model", "family", "hardware_revision",
+        "firmware_min", "firmware_max", "aliases", "manufacturer_aliases",
+        "notes", "risk_notes",
+    )}
+    safe_ports = [{name: rule.get(name) for name in (
+        "port", "protocol", "service", "description", "classification", "exposure",
+        "authentication_expected", "encryption_expected", "risk", "remediation",
+        "hardware_revision", "firmware_min", "firmware_max", "source_name",
+        "source_url", "source_reliability", "confidence",
+    )} for rule in profile["ports"]]
+    return {
+        "schema": "mobile-router-model-contribution-v1", "created_at": time.time(),
+        "privacy": {"excluded": [
+            "IP addresses", "MAC addresses", "serial numbers", "hostnames",
+            "credentials", "private URLs",
+        ]},
+        "profile": safe_profile, "ports": safe_ports,
+        "aggregate": {
+            "observed_devices": fleet["device_count"],
+            "firmware_counts": fleet["firmware_counts"],
+            "common_ports": fleet["common_ports"],
+        },
+    }
+
+
+def registry_import_history(path):
+    with connect(path) as db:
+        rows = db.execute(
+            "SELECT * FROM model_registry_imports ORDER BY created_at DESC LIMIT 100"
+        ).fetchall()
+    return [_row(row) for row in rows]

--- a/static/js/model-profiles.js
+++ b/static/js/model-profiles.js
@@ -1,0 +1,490 @@
+(function () {
+  "use strict";
+
+  function escapeHtml(value) {
+    return String(value ?? "")
+      .replace(/&/g, "&amp;")
+      .replace(/</g, "&lt;")
+      .replace(/>/g, "&gt;")
+      .replace(/"/g, "&quot;")
+      .replace(/'/g, "&#039;");
+  }
+
+  function csrfToken() {
+    return String(document.querySelector(".app-navbar")?.dataset.csrfToken || "");
+  }
+
+  function clientHost() {
+    return String(document.querySelector("[data-ip-client-tools]")?.dataset.host || "");
+  }
+
+  async function jsonRequest(url, options) {
+    const response = await fetch(url, options || {});
+    const payload = await response.json().catch(function () { return {}; });
+    if (!response.ok) {
+      const error = new Error(payload.message || `Request failed (${response.status})`);
+      error.payload = payload;
+      throw error;
+    }
+    return payload;
+  }
+
+  function post(url, data) {
+    const body = new URLSearchParams({ csrf_token: csrfToken(), ...(data || {}) });
+    return jsonRequest(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/x-www-form-urlencoded;charset=UTF-8",
+        "X-Requested-With": "XMLHttpRequest"
+      },
+      body: body.toString()
+    });
+  }
+
+  function formDataObject(form) {
+    const result = {};
+    new FormData(form).forEach(function (value, name) {
+      if (form.elements[name]?.type === "checkbox") {
+        result[name] = form.elements[name].checked ? "on" : "";
+      } else {
+        result[name] = value;
+      }
+    });
+    return result;
+  }
+
+  function status(target, message, error) {
+    if (!target) return;
+    target.className = `alert ${error ? "alert-danger" : "alert-info"} mt-3`;
+    target.textContent = message;
+  }
+
+  function badge(value, style) {
+    return `<span class="badge badge-${style || "light"} border">${escapeHtml(value)}</span>`;
+  }
+
+  function riskBadge(risk) {
+    const style = {
+      critical: "danger", high: "danger", medium: "warning",
+      low: "info", info: "light", none: "success"
+    }[risk] || "secondary";
+    return badge(risk || "info", style);
+  }
+
+  function profileName(profile) {
+    if (profile.scope === "manufacturer") return `${profile.manufacturer} defaults`;
+    if (profile.scope === "family") return `${profile.manufacturer} ${profile.family} family`;
+    return `${profile.manufacturer} ${profile.model}`;
+  }
+
+  async function loadLibrary() {
+    const root = document.querySelector("[data-model-library]");
+    if (!root) return;
+    const output = root.querySelector("[data-model-profile-list]");
+    const state = root.querySelector("[data-model-library-status]");
+    const query = root.querySelector("[data-model-search]")?.value || "";
+    const scope = root.querySelector("[data-model-scope-filter]")?.value || "";
+    status(state, "Loading profiles…");
+    try {
+      const payload = await jsonRequest(`/api/model-profiles?q=${encodeURIComponent(query)}&scope=${encodeURIComponent(scope)}`);
+      output.innerHTML = payload.profiles.map(function (profile) {
+        const applicability = [
+          profile.hardware_revision ? `HW ${profile.hardware_revision}` : "All hardware",
+          profile.firmware_min || profile.firmware_max
+            ? `FW ${profile.firmware_min || "*"}–${profile.firmware_max || "*"}`
+            : "All firmware"
+        ].join(" · ");
+        return `<article class="port-service-card">
+          <div class="d-flex justify-content-between align-items-start">
+            <div>
+              <strong>${escapeHtml(profileName(profile))}</strong>
+              <small>${escapeHtml(applicability)}</small>
+            </div>
+            ${badge(profile.scope, "info")}
+          </div>
+          <p class="mb-1">${escapeHtml(profile.notes || "No profile notes yet.")}</p>
+          <small>${escapeHtml(profile.port_count)} port rule(s) · ${escapeHtml((profile.aliases || []).join(", ") || "No aliases")}</small>
+          <a class="btn btn-outline-primary btn-sm mt-2" href="/models/${profile.id}">Open Profile</a>
+        </article>`;
+      }).join("") || `<p class="text-muted">No matching model profiles.</p>`;
+      status(state, `${payload.profiles.length} profile(s) loaded.`);
+    } catch (error) {
+      status(state, error.message, true);
+    }
+  }
+
+  function setupLibrary() {
+    const root = document.querySelector("[data-model-library]");
+    if (!root) return;
+    root.querySelector("[data-model-search]")?.addEventListener("input", function () {
+      window.clearTimeout(root._modelSearchTimer);
+      root._modelSearchTimer = window.setTimeout(loadLibrary, 180);
+    });
+    root.querySelector("[data-model-scope-filter]")?.addEventListener("change", loadLibrary);
+    root.querySelector("[data-model-new-toggle]")?.addEventListener("click", function () {
+      root.querySelector("[data-model-new-panel]")?.classList.toggle("d-none");
+    });
+    root.querySelector("[data-model-profile-create]")?.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      const state = root.querySelector("[data-model-library-status]");
+      status(state, "Creating profile…");
+      try {
+        const payload = await post("/api/model-profiles", formDataObject(event.target));
+        window.location.href = `/models/${payload.profile.id}`;
+      } catch (error) {
+        status(state, error.message, true);
+      }
+    });
+    root.querySelector("[data-model-registry-preview]")?.addEventListener("click", async function () {
+      const registryJson = root.querySelector("[data-model-registry-json]")?.value || "";
+      const output = root.querySelector("[data-model-registry-output]");
+      try {
+        const payload = await post("/api/model-registry/preview", {
+          registryJson: registryJson,
+          requireSignature: root.querySelector("[data-model-registry-require-signature]")?.checked ? "on" : ""
+        });
+        output.textContent = JSON.stringify(payload, null, 2);
+      } catch (error) {
+        output.textContent = error.message;
+      }
+    });
+    root.querySelector("[data-model-registry-import]")?.addEventListener("click", async function () {
+      const registryJson = root.querySelector("[data-model-registry-json]")?.value || "";
+      const output = root.querySelector("[data-model-registry-output]");
+      try {
+        const payload = await post("/api/model-registry/import", {
+          registryJson: registryJson,
+          requireSignature: root.querySelector("[data-model-registry-require-signature]")?.checked ? "on" : ""
+        });
+        output.textContent = JSON.stringify(payload, null, 2);
+        await loadLibrary();
+      } catch (error) {
+        output.textContent = error.message;
+      }
+    });
+    root.querySelector("[data-model-registry-sync]")?.addEventListener("click", async function () {
+      const output = root.querySelector("[data-model-registry-output]");
+      try {
+        const payload = await post("/api/model-registry/sync", {});
+        output.textContent = JSON.stringify(payload, null, 2);
+        await loadLibrary();
+      } catch (error) {
+        output.textContent = error.message;
+      }
+    });
+    loadLibrary();
+  }
+
+  function populateProfileForm(root, profile) {
+    const form = root.querySelector("[data-model-profile-update]");
+    if (!form) return;
+    const values = {
+      scope: profile.scope,
+      manufacturer: profile.manufacturer,
+      model: profile.model,
+      family: profile.family,
+      hardwareRevision: profile.hardware_revision,
+      firmwareMin: profile.firmware_min,
+      firmwareMax: profile.firmware_max,
+      aliases: (profile.aliases || []).join(", "),
+      manufacturerAliases: (profile.manufacturer_aliases || []).join(", "),
+      notes: profile.notes,
+      riskNotes: profile.risk_notes
+    };
+    Object.keys(values).forEach(function (name) {
+      if (form.elements[name]) form.elements[name].value = values[name] || "";
+    });
+  }
+
+  function renderPortRules(root, profile) {
+    const target = root.querySelector("[data-model-port-list]");
+    if (!target) return;
+    target.innerHTML = (profile.ports || []).map(function (rule) {
+      const applicability = [
+        rule.hardware_revision ? `HW ${rule.hardware_revision}` : "all hardware",
+        rule.firmware_min || rule.firmware_max
+          ? `FW ${rule.firmware_min || "*"}–${rule.firmware_max || "*"}`
+          : "all firmware"
+      ].join(" · ");
+      const source = rule.source_url
+        ? `<a href="${escapeHtml(rule.source_url)}" target="_blank" rel="noopener noreferrer">${escapeHtml(rule.source_name || "Source")}</a>`
+        : escapeHtml(rule.source_name || "Local");
+      return `<tr>
+        <td><strong>${escapeHtml(rule.port)}/${escapeHtml(rule.protocol)}</strong></td>
+        <td><strong>${escapeHtml(rule.service)}</strong><br><small>${escapeHtml(rule.description || "")}</small></td>
+        <td>${badge(rule.classification, rule.classification === "deprecated" ? "danger" : "info")}<br><small>${escapeHtml(rule.exposure)}</small></td>
+        <td><small>${escapeHtml(applicability)}</small></td>
+        <td>${riskBadge(rule.risk)}<br><small>${escapeHtml(rule.remediation || "")}</small></td>
+        <td><small>${source}<br>Reliability ${escapeHtml(rule.source_reliability)}/100</small></td>
+        <td><button class="btn btn-link btn-sm text-danger" type="button" data-model-rule-delete="${rule.id}">Delete</button></td>
+      </tr>`;
+    }).join("") || `<tr><td colspan="7" class="text-muted">No port rules yet.</td></tr>`;
+  }
+
+  function renderConflicts(root, profile) {
+    const target = root.querySelector("[data-model-conflicts]");
+    if (!target) return;
+    target.innerHTML = (profile.conflicts || []).map(function (conflict) {
+      const current = conflict.current || {};
+      const incoming = conflict.incoming || {};
+      return `<article class="alert alert-warning">
+        <strong>${escapeHtml(conflict.port)}/${escapeHtml(conflict.protocol)} conflict</strong>
+        <p class="mb-1">Current: ${escapeHtml(current.service)} · ${escapeHtml(current.classification)}</p>
+        <p class="mb-1">Incoming: ${escapeHtml(incoming.service)} · ${escapeHtml(incoming.classification)}</p>
+        <textarea class="form-control form-control-sm mb-2" data-conflict-note="${conflict.id}" placeholder="Resolution note"></textarea>
+        <button class="btn btn-outline-secondary btn-sm" type="button" data-conflict-resolve="${conflict.id}" data-choice="current">Keep Current</button>
+        <button class="btn btn-outline-primary btn-sm" type="button" data-conflict-resolve="${conflict.id}" data-choice="incoming">Accept Incoming</button>
+      </article>`;
+    }).join("") || `<p class="text-muted">No unresolved conflicts.</p>`;
+  }
+
+  function renderHistory(root, history) {
+    const target = root.querySelector("[data-model-history]");
+    if (!target) return;
+    target.innerHTML = (history || []).map(function (item) {
+      return `<div class="d-flex justify-content-between align-items-start border-bottom py-2">
+        <div><strong>Revision ${escapeHtml(item.revision)} · ${escapeHtml(item.action)}</strong><br><small>${escapeHtml(item.actor || "system")} · ${escapeHtml(new Date(item.created_at * 1000).toLocaleString())} · ${escapeHtml(item.note || "")}</small></div>
+        <button class="btn btn-outline-warning btn-sm" type="button" data-model-rollback="${item.revision}">Rollback</button>
+      </div>`;
+    }).join("") || `<p class="text-muted">No revision history.</p>`;
+  }
+
+  function renderFleet(root, fleet) {
+    const target = root.querySelector("[data-model-fleet]");
+    if (!target) return;
+    const devices = (fleet.devices || []).map(function (device) {
+      return `<tr>
+        <td>${device.ip ? `<a href="/clients/${encodeURIComponent(device.ip)}">${escapeHtml(device.display_name)}</a>` : escapeHtml(device.display_name)}</td>
+        <td>${escapeHtml(device.firmware)}</td>
+        <td>${escapeHtml(device.hardware_revision || "Unknown")}</td>
+        <td>${riskBadge(device.drift.severity)} ${escapeHtml(device.drift.score)}/100</td>
+        <td>${escapeHtml(device.drift.unexpected.length)} unexpected · ${escapeHtml(device.drift.missing_expected.length)} missing</td>
+      </tr>`;
+    }).join("") || `<tr><td colspan="5" class="text-muted">No matching inventory devices.</td></tr>`;
+    const common = (fleet.common_ports || []).slice(0, 20).map(function (item) {
+      return `<li>${escapeHtml(item.port)}/${escapeHtml(item.protocol)} · ${escapeHtml(item.devices)} device(s)</li>`;
+    }).join("") || `<li class="text-muted">No common ports yet.</li>`;
+    target.innerHTML = `
+      <div class="alert alert-info">${escapeHtml(fleet.device_count)} matching device(s); ${escapeHtml(fleet.drifted_devices)} with profile drift.</div>
+      <div class="row"><div class="col-lg-8"><div class="table-responsive"><table class="table table-sm"><thead><tr><th>Device</th><th>Firmware</th><th>Hardware</th><th>Drift</th><th>Summary</th></tr></thead><tbody>${devices}</tbody></table></div></div><div class="col-lg-4"><h3 class="theme-subsection-title">Common Ports</h3><ul>${common}</ul><h3 class="theme-subsection-title">Firmware Distribution</h3><pre>${escapeHtml(JSON.stringify(fleet.firmware_counts || {}, null, 2))}</pre></div></div>`;
+  }
+
+  async function loadProfileDetail() {
+    const root = document.querySelector("[data-model-profile-detail]");
+    if (!root) return;
+    const profileId = root.dataset.profileId;
+    const state = root.querySelector("[data-model-profile-status]");
+    try {
+      const [profilePayload, fleetPayload] = await Promise.all([
+        jsonRequest(`/api/model-profiles/${profileId}`),
+        jsonRequest(`/api/model-profiles/${profileId}/fleet`)
+      ]);
+      root._profile = profilePayload.profile;
+      populateProfileForm(root, profilePayload.profile);
+      renderPortRules(root, profilePayload.profile);
+      renderConflicts(root, profilePayload.profile);
+      renderHistory(root, profilePayload.history);
+      renderFleet(root, fleetPayload.fleet);
+      status(state, `Profile loaded with ${profilePayload.profile.ports.length} rule(s).`);
+    } catch (error) {
+      status(state, error.message, true);
+    }
+  }
+
+  function setupProfileDetail() {
+    const root = document.querySelector("[data-model-profile-detail]");
+    if (!root) return;
+    const profileId = root.dataset.profileId;
+    root.querySelector("[data-model-port-toggle]")?.addEventListener("click", function () {
+      root.querySelector("[data-model-port-panel]")?.classList.toggle("d-none");
+    });
+    root.querySelector("[data-model-profile-update]")?.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      const state = root.querySelector("[data-model-profile-status]");
+      try {
+        await post(`/api/model-profiles/${profileId}`, formDataObject(event.target));
+        status(state, "Profile saved.");
+        await loadProfileDetail();
+      } catch (error) {
+        status(state, error.message, true);
+      }
+    });
+    root.querySelector("[data-model-port-form]")?.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      const state = root.querySelector("[data-model-profile-status]");
+      try {
+        await post(`/api/model-profiles/${profileId}/ports`, formDataObject(event.target));
+        event.target.reset();
+        status(state, "Port rule saved.");
+        await loadProfileDetail();
+      } catch (error) {
+        const conflict = error.payload?.result?.conflict_id;
+        status(state, conflict ? `A conflict was recorded as #${conflict}. Review it below.` : error.message, true);
+        await loadProfileDetail();
+      }
+    });
+    root.addEventListener("click", async function (event) {
+      const state = root.querySelector("[data-model-profile-status]");
+      const remove = event.target.closest("[data-model-rule-delete]");
+      if (remove) {
+        try {
+          await post(`/api/model-profiles/${profileId}/ports/${remove.dataset.modelRuleDelete}/delete`, {});
+          status(state, "Port rule deleted.");
+          await loadProfileDetail();
+        } catch (error) { status(state, error.message, true); }
+      }
+      const conflict = event.target.closest("[data-conflict-resolve]");
+      if (conflict) {
+        try {
+          const note = root.querySelector(`[data-conflict-note="${conflict.dataset.conflictResolve}"]`)?.value || "";
+          await post(`/api/model-profile-conflicts/${conflict.dataset.conflictResolve}/resolve`, {
+            choice: conflict.dataset.choice,
+            note: note
+          });
+          status(state, "Conflict resolved.");
+          await loadProfileDetail();
+        } catch (error) { status(state, error.message, true); }
+      }
+      const rollback = event.target.closest("[data-model-rollback]");
+      if (rollback) {
+        try {
+          await post(`/api/model-profiles/${profileId}/rollback/${rollback.dataset.modelRollback}`, {
+            note: "Rollback requested from the model library"
+          });
+          status(state, `Rolled back to revision ${rollback.dataset.modelRollback}.`);
+          await loadProfileDetail();
+        } catch (error) { status(state, error.message, true); }
+      }
+    });
+    loadProfileDetail();
+  }
+
+  function renderDriftList(items, empty) {
+    return (items || []).map(function (item) {
+      return `<li><strong>${escapeHtml(item.port)}/${escapeHtml(item.protocol)}</strong> — ${escapeHtml(item.service || item.reason || "Unknown")}${item.risk ? ` ${riskBadge(item.risk)}` : ""}</li>`;
+    }).join("") || `<li class="text-muted">${escapeHtml(empty)}</li>`;
+  }
+
+  async function loadProfileOptions(select) {
+    const payload = await jsonRequest("/api/model-profiles");
+    select.innerHTML = `<option value="">Choose a profile…</option>` + payload.profiles.map(function (profile) {
+      return `<option value="${profile.id}">${escapeHtml(profileName(profile))}</option>`;
+    }).join("");
+  }
+
+  function renderClientProfile(root, payload) {
+    const result = payload.result || {};
+    const device = payload.device || result.device || {};
+    const drift = result.drift || device.model_port_drift || {
+      severity: "none", score: 0, unexpected: [], missing_expected: [], deprecated: []
+    };
+    const profiles = result.profiles || device.model_profile_matches || [];
+    const primary = result.primary_profile || profiles[profiles.length - 1];
+    const layers = profiles.map(function (profile) {
+      return `<li><a href="/models/${profile.id}">${escapeHtml(profile.manufacturer)} ${escapeHtml(profile.model || profile.family || "defaults")}</a> ${badge(profile.match_level, "info")}</li>`;
+    }).join("") || `<li class="text-muted">No matching profile. Create or manually assign one.</li>`;
+    const tasks = (result.remediation || device.model_remediation_tasks || []).map(function (item) {
+      return `<li>${riskBadge(item.severity)} ${escapeHtml(item.task)}${item.port ? ` (${escapeHtml(item.port)}/${escapeHtml(item.protocol)})` : ""}</li>`;
+    }).join("") || `<li class="text-muted">No remediation tasks.</li>`;
+    const unexpectedRows = (drift.unexpected || []).map(function (item) {
+      return `<tr>
+        <td>${escapeHtml(item.port)}/${escapeHtml(item.protocol)}</td>
+        <td>${escapeHtml(item.service || "Unknown")}</td>
+        <td>${riskBadge(item.risk)}</td>
+        <td><button class="btn btn-outline-info btn-sm" type="button" data-model-investigate="${item.port}" data-protocol="${item.protocol}">Investigate</button> <button class="btn btn-outline-secondary btn-sm" type="button" data-model-local-override="${item.port}" data-protocol="${item.protocol}" data-service="${escapeHtml(item.service || "")}">Mark Local</button></td>
+      </tr>`;
+    }).join("") || `<tr><td colspan="4" class="text-muted">No unexpected services.</td></tr>`;
+    root.innerHTML = `<div class="card-body">
+      <div class="d-flex justify-content-between align-items-start flex-wrap">
+        <div><h2 class="theme-section-title">Device Model Profile</h2><p class="text-muted">Inherited model knowledge, firmware/hardware applicability, fleet comparison, drift, and remediation.</p></div>
+        ${primary ? `<a class="btn btn-outline-primary btn-sm" href="/models/${primary.id}">Open ${escapeHtml(primary.model || primary.family || "Profile")}</a>` : `<a class="btn btn-outline-primary btn-sm" href="/models">Open Model Library</a>`}
+      </div>
+      <div class="alert alert-${drift.severity === "critical" || drift.severity === "high" ? "danger" : drift.severity === "medium" ? "warning" : "success"}">
+        Drift: <strong>${escapeHtml(drift.severity)}</strong> · ${escapeHtml(drift.score)}/100 · ${escapeHtml((drift.unexpected || []).length)} unexpected · ${escapeHtml((drift.missing_expected || []).length)} missing expected · ${escapeHtml((drift.deprecated || []).length)} deprecated
+      </div>
+      <div class="row"><div class="col-lg-6"><h3 class="theme-subsection-title">Profile Layers</h3><ul>${layers}</ul></div><div class="col-lg-6"><h3 class="theme-subsection-title">Manual Assignment</h3><div class="input-group"><select class="form-control" data-client-profile-select></select><div class="input-group-append"><button class="btn btn-outline-primary" type="button" data-client-profile-assign>Assign</button></div></div></div></div>
+      <div class="theme-actions"><button class="btn btn-primary" type="button" data-client-profile-apply>Reassess Model Drift</button></div>
+      <h3 class="theme-subsection-title mt-3">Unexpected Services</h3>
+      <div class="table-responsive"><table class="table table-sm"><thead><tr><th>Port</th><th>Observed</th><th>Risk</th><th>Action</th></tr></thead><tbody>${unexpectedRows}</tbody></table></div>
+      <div class="row"><div class="col-lg-6"><h3 class="theme-subsection-title">Missing Expected</h3><ul>${renderDriftList(drift.missing_expected, "No expected services missing.")}</ul></div><div class="col-lg-6"><h3 class="theme-subsection-title">Remediation Checklist</h3><ul>${tasks}</ul></div></div>
+      <pre class="theme-results mt-3" data-client-profile-output>Ready.</pre>
+    </div>`;
+    const select = root.querySelector("[data-client-profile-select]");
+    if (select) loadProfileOptions(select).catch(function () {});
+  }
+
+  async function loadClientProfile(root) {
+    const host = clientHost();
+    if (!host) return;
+    try {
+      const payload = await jsonRequest(`/clients/${encodeURIComponent(host)}/model-profile`);
+      renderClientProfile(root, payload);
+    } catch (error) {
+      root.innerHTML = `<div class="card-body"><h2 class="theme-section-title">Device Model Profile</h2><div class="alert alert-danger">${escapeHtml(error.message)}</div></div>`;
+    }
+  }
+
+  function setupClientProfile() {
+    const tools = document.querySelector("[data-ip-client-tools]");
+    if (!tools || document.querySelector("[data-client-model-profile]")) return;
+    const root = document.createElement("section");
+    root.className = "theme-card card";
+    root.setAttribute("data-client-model-profile", "");
+    root.innerHTML = `<div class="card-body"><p class="text-muted">Loading device model profile…</p></div>`;
+    tools.parentNode.insertBefore(root, tools);
+    root.addEventListener("click", async function (event) {
+      const host = clientHost();
+      const output = root.querySelector("[data-client-profile-output]");
+      try {
+        if (event.target.closest("[data-client-profile-apply]")) {
+          output.textContent = "Applying profile hierarchy and checking drift…";
+          const payload = await post(`/clients/${encodeURIComponent(host)}/model-profile/apply`, {});
+          renderClientProfile(root, payload);
+        }
+        if (event.target.closest("[data-client-profile-assign]")) {
+          const profileId = root.querySelector("[data-client-profile-select]")?.value || "";
+          if (!profileId) throw new Error("Choose a profile first.");
+          const payload = await post(`/clients/${encodeURIComponent(host)}/model-profile/assign`, { profileId: profileId });
+          renderClientProfile(root, payload);
+        }
+        const investigate = event.target.closest("[data-model-investigate]");
+        if (investigate) {
+          output.textContent = "Running the bounded unknown-port investigation…";
+          const payload = await post(`/clients/${encodeURIComponent(host)}/model-profile/investigate`, {
+            port: investigate.dataset.modelInvestigate,
+            protocol: investigate.dataset.protocol,
+            activeProbe: "on"
+          });
+          output.textContent = JSON.stringify(payload.investigation, null, 2);
+        }
+        const local = event.target.closest("[data-model-local-override]");
+        if (local) {
+          const payload = await post(`/clients/${encodeURIComponent(host)}/model-profile/override`, {
+            port: local.dataset.modelLocalOverride,
+            protocol: local.dataset.protocol,
+            service: local.dataset.service,
+            classification: "local-configuration",
+            description: "Approved as a device-specific local configuration.",
+            risk: "info"
+          });
+          renderClientProfile(root, payload);
+        }
+      } catch (error) {
+        if (output) output.textContent = error.message;
+      }
+    });
+    loadClientProfile(root);
+  }
+
+  function start() {
+    setupLibrary();
+    setupProfileDetail();
+    setupClientProfile();
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start);
+  } else {
+    start();
+  }
+}());

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -9,4 +9,5 @@
 <script src="/static/js/wireless-deauth-buttons.js"></script>
 <script src="/static/js/device-identification.js"></script>
 <script src="/static/js/port-knowledge.js"></script>
+<script src="/static/js/model-profiles.js"></script>
 

--- a/templates/_primary-nav-links.html
+++ b/templates/_primary-nav-links.html
@@ -67,7 +67,7 @@
 <div class="nav-item dropdown nav-compact-group">
   <button type="button"
           id="records-menu"
-          class="nav-link dropdown-toggle {% if title in ['Device Inventory', 'Alerts', 'Reports', 'Evidence Vault', 'Social Engineering'] or title[:7] == 'Client ' %}active{% endif %}"
+          class="nav-link dropdown-toggle {% if title in ['Device Inventory', 'Device Model Library', 'Alerts', 'Reports', 'Evidence Vault', 'Social Engineering'] or title[:7] == 'Client ' or title[:6] == 'Model ' %}active{% endif %}"
           data-navigation-toggle="dropdown"
           aria-haspopup="true"
           aria-expanded="false">
@@ -75,6 +75,7 @@
   </button>
   <div class="dropdown-menu navigation-menu" aria-labelledby="records-menu">
     <a href="/inventory" class="dropdown-item {% if title == 'Device Inventory' or title[:7] == 'Client ' %}active{% endif %}" {% if title == 'Device Inventory' or title[:7] == 'Client ' %}aria-current="page"{% endif %}>Inventory</a>
+    <a href="/models" class="dropdown-item {% if title == 'Device Model Library' or title[:6] == 'Model ' %}active{% endif %}" {% if title == 'Device Model Library' or title[:6] == 'Model ' %}aria-current="page"{% endif %}>Device Model Library</a>
     <a href="/alerts" class="dropdown-item {% if title == 'Alerts' %}active{% endif %}" {% if title == 'Alerts' %}aria-current="page"{% endif %}>Alerts</a>
     <a href="/reports" class="dropdown-item {% if title == 'Reports' %}active{% endif %}" {% if title == 'Reports' %}aria-current="page"{% endif %}>Reports</a>
     <a href="/evidence" class="dropdown-item {% if title == 'Evidence Vault' %}active{% endif %}" {% if title == 'Evidence Vault' %}aria-current="page"{% endif %}>Evidence Vault</a>

--- a/templates/model_profile_detail.html
+++ b/templates/model_profile_detail.html
@@ -1,0 +1,116 @@
+{% include '_header.html' %}
+<link rel="stylesheet" href="/static/css/interface.css">
+<body class="d-flex flex-column min-vh-100">
+  <main class="page-shell" data-model-profile-detail data-profile-id="{{ profile_id }}">
+    <section class="page-hero">
+      <div class="page-hero-copy">
+        <p class="page-kicker">Device Model Profile</p>
+        <h1 class="page-title">{% if profile %}{{ profile.manufacturer }} {{ profile.model or profile.family }}{% else %}Profile Not Found{% endif %}</h1>
+        <p class="page-subtitle">Canonical identity, inheritance, firmware and hardware applicability, expected ports, fleet drift, conflicts, risk guidance, and revision history.</p>
+      </div>
+      {% if profile %}
+      <div class="theme-actions">
+        <a class="btn btn-outline-secondary" href="/models">Back to Library</a>
+        <a class="btn btn-outline-success" href="/api/model-profiles/{{ profile_id }}/contribution.json">Export Contribution</a>
+      </div>
+      {% endif %}
+    </section>
+
+    {% if profile %}
+    <section class="theme-card card">
+      <div class="card-body">
+        <h2 class="theme-section-title">Identity and Applicability</h2>
+        <form data-model-profile-update>
+          <div class="form-row">
+            <div class="col-md-3"><label>Scope</label><select class="form-control" name="scope"><option value="exact">Exact model</option><option value="family">Model family</option><option value="manufacturer">Manufacturer default</option></select></div>
+            <div class="col-md-3"><label>Manufacturer</label><input class="form-control" name="manufacturer"></div>
+            <div class="col-md-3"><label>Canonical model</label><input class="form-control" name="model"></div>
+            <div class="col-md-3"><label>Family</label><input class="form-control" name="family"></div>
+          </div>
+          <div class="form-row mt-2">
+            <div class="col-md-4"><label>Hardware revision</label><input class="form-control" name="hardwareRevision"></div>
+            <div class="col-md-4"><label>Firmware from</label><input class="form-control" name="firmwareMin"></div>
+            <div class="col-md-4"><label>Firmware to</label><input class="form-control" name="firmwareMax"></div>
+          </div>
+          <div class="form-row mt-2">
+            <div class="col-md-6"><label>Model aliases</label><input class="form-control" name="aliases"></div>
+            <div class="col-md-6"><label>Manufacturer aliases</label><input class="form-control" name="manufacturerAliases"></div>
+          </div>
+          <label class="mt-2">Notes</label><textarea class="form-control" rows="2" name="notes"></textarea>
+          <label class="mt-2">Risk notes</label><textarea class="form-control" rows="2" name="riskNotes"></textarea>
+          <div class="theme-actions"><button class="btn btn-primary" type="submit">Save Profile</button></div>
+        </form>
+        <div data-model-profile-status class="alert alert-light mt-3">Loading profile…</div>
+      </div>
+    </section>
+
+    <section class="theme-card card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-start flex-wrap">
+          <div><h2 class="theme-section-title">Port and Service Rules</h2><p class="text-muted">Classify expected, optional, firmware-specific, deprecated, or investigative services and attach exposure, authentication, encryption, risk, remediation, and provenance.</p></div>
+          <button class="btn btn-primary" type="button" data-model-port-toggle>Add Port Rule</button>
+        </div>
+        <div class="table-responsive"><table class="table table-sm"><thead><tr><th>Port</th><th>Service</th><th>Classification</th><th>Applicability</th><th>Risk</th><th>Source</th><th></th></tr></thead><tbody data-model-port-list></tbody></table></div>
+      </div>
+    </section>
+
+    <section class="theme-card card d-none" data-model-port-panel>
+      <div class="card-body">
+        <h2 class="theme-section-title">Add or Update Port Rule</h2>
+        <form data-model-port-form>
+          <div class="form-row">
+            <div class="col-md-2"><label>Port</label><input type="number" min="1" max="65535" class="form-control" name="port" required></div>
+            <div class="col-md-2"><label>Protocol</label><select class="form-control" name="protocol"><option>tcp</option><option>udp</option></select></div>
+            <div class="col-md-4"><label>Service</label><input class="form-control" name="service" required></div>
+            <div class="col-md-4"><label>Classification</label><select class="form-control" name="classification"><option>expected</option><option>optional</option><option>firmware-specific</option><option>local-configuration</option><option>investigate</option><option>deprecated</option><option>unexpected</option></select></div>
+          </div>
+          <label class="mt-2">Description</label><textarea class="form-control" rows="2" name="description"></textarea>
+          <div class="form-row mt-2">
+            <div class="col-md-3"><label>Exposure</label><select class="form-control" name="exposure"><option>unknown</option><option>lan-only</option><option>management</option><option>local-host</option><option>wan-optional</option><option>wan</option></select></div>
+            <div class="col-md-3"><label>Risk</label><select class="form-control" name="risk"><option>info</option><option>low</option><option>medium</option><option>high</option><option>critical</option></select></div>
+            <div class="col-md-3"><label>Hardware revision</label><input class="form-control" name="hardwareRevision"></div>
+            <div class="col-md-3"><label>Source reliability</label><input type="number" min="0" max="100" value="60" class="form-control" name="sourceReliability"></div>
+          </div>
+          <div class="form-row mt-2">
+            <div class="col-md-3"><label>Firmware from</label><input class="form-control" name="firmwareMin"></div>
+            <div class="col-md-3"><label>Firmware to</label><input class="form-control" name="firmwareMax"></div>
+            <div class="col-md-3"><label class="form-check mt-4"><input class="form-check-input" type="checkbox" name="authenticationExpected"><span class="form-check-label">Authentication expected</span></label></div>
+            <div class="col-md-3"><label class="form-check mt-4"><input class="form-check-input" type="checkbox" name="encryptionExpected"><span class="form-check-label">Encryption expected</span></label></div>
+          </div>
+          <label class="mt-2">Recommended remediation</label><textarea class="form-control" rows="2" name="remediation"></textarea>
+          <div class="form-row mt-2">
+            <div class="col-md-4"><label>Source name</label><input class="form-control" name="sourceName"></div>
+            <div class="col-md-8"><label>Source URL</label><input class="form-control" name="sourceUrl" placeholder="https://..."></div>
+          </div>
+          <label class="form-check mt-2"><input class="form-check-input" type="checkbox" name="replace"><span class="form-check-label">Replace an existing rule with the same applicability instead of recording a conflict</span></label>
+          <div class="theme-actions"><button class="btn btn-primary" type="submit">Save Port Rule</button></div>
+        </form>
+      </div>
+    </section>
+
+    <section class="theme-card card">
+      <div class="card-body">
+        <h2 class="theme-section-title">Fleet Comparison and Drift</h2>
+        <div data-model-fleet><p class="text-muted">Loading matching devices…</p></div>
+      </div>
+    </section>
+
+    <section class="theme-card card">
+      <div class="card-body">
+        <h2 class="theme-section-title">Conflicts</h2>
+        <p class="text-muted">Conflicting sources are retained until a reviewer selects the preferred interpretation.</p>
+        <div data-model-conflicts></div>
+      </div>
+    </section>
+
+    <section class="theme-card card">
+      <div class="card-body">
+        <h2 class="theme-section-title">Revision History and Rollback</h2>
+        <div data-model-history></div>
+      </div>
+    </section>
+    {% endif %}
+  </main>
+</body>
+{% include '_footer.html' %}
+</html>

--- a/templates/model_profiles.html
+++ b/templates/model_profiles.html
@@ -1,0 +1,93 @@
+{% include '_header.html' %}
+<link rel="stylesheet" href="/static/css/interface.css">
+<body class="d-flex flex-column min-vh-100">
+  <main class="page-shell" data-model-library>
+    <section class="page-hero">
+      <div class="page-hero-copy">
+        <p class="page-kicker">Reusable Device Intelligence</p>
+        <h1 class="page-title">Device Model Library</h1>
+        <p class="page-subtitle">Maintain canonical model identities, aliases, firmware and hardware applicability, expected services, risk guidance, fleet drift, provenance, and signed registry updates.</p>
+      </div>
+      <div class="theme-actions">
+        <a class="btn btn-outline-secondary" href="/api/model-registry/export.json">Export Registry</a>
+        <button class="btn btn-outline-success" type="button" data-model-registry-sync>Sync Signed Registries</button>
+      </div>
+    </section>
+
+    <section class="theme-card card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-start flex-wrap">
+          <div>
+            <h2 class="theme-section-title">Profiles</h2>
+            <p class="text-muted">Exact profiles override family profiles, which override manufacturer defaults. Device-specific overrides remain local to one device.</p>
+          </div>
+          <button class="btn btn-primary" type="button" data-model-new-toggle>Create Profile</button>
+        </div>
+        <div class="form-row mt-3">
+          <div class="col-md-8">
+            <input class="form-control" data-model-search placeholder="Search manufacturer, model, family, or alias">
+          </div>
+          <div class="col-md-4">
+            <select class="form-control" data-model-scope-filter>
+              <option value="">All profile scopes</option>
+              <option value="exact">Exact model</option>
+              <option value="family">Model family</option>
+              <option value="manufacturer">Manufacturer default</option>
+            </select>
+          </div>
+        </div>
+        <div data-model-library-status class="alert alert-light mt-3">Loading profiles…</div>
+        <div class="theme-grid" data-model-profile-list></div>
+      </div>
+    </section>
+
+    <section class="theme-card card d-none" data-model-new-panel>
+      <div class="card-body">
+        <h2 class="theme-section-title">Create Model Profile</h2>
+        <form data-model-profile-create>
+          <div class="form-row">
+            <div class="col-md-3">
+              <label>Scope</label>
+              <select class="form-control" name="scope">
+                <option value="exact">Exact model</option>
+                <option value="family">Model family</option>
+                <option value="manufacturer">Manufacturer default</option>
+              </select>
+            </div>
+            <div class="col-md-3"><label>Manufacturer</label><input class="form-control" name="manufacturer" required></div>
+            <div class="col-md-3"><label>Canonical model</label><input class="form-control" name="model"></div>
+            <div class="col-md-3"><label>Model family</label><input class="form-control" name="family"></div>
+          </div>
+          <div class="form-row mt-2">
+            <div class="col-md-4"><label>Hardware revision</label><input class="form-control" name="hardwareRevision"></div>
+            <div class="col-md-4"><label>Firmware from</label><input class="form-control" name="firmwareMin"></div>
+            <div class="col-md-4"><label>Firmware to</label><input class="form-control" name="firmwareMax"></div>
+          </div>
+          <div class="form-row mt-2">
+            <div class="col-md-6"><label>Model aliases</label><input class="form-control" name="aliases" placeholder="Sky Broadband Hub, Sky SR203"></div>
+            <div class="col-md-6"><label>Manufacturer aliases</label><input class="form-control" name="manufacturerAliases" placeholder="Sky UK, Sky Broadband"></div>
+          </div>
+          <label class="mt-2">Profile notes</label><textarea class="form-control" rows="2" name="notes"></textarea>
+          <label class="mt-2">Security and risk notes</label><textarea class="form-control" rows="2" name="riskNotes"></textarea>
+          <div class="theme-actions"><button class="btn btn-primary" type="submit">Create Profile</button></div>
+        </form>
+      </div>
+    </section>
+
+    <section class="theme-card card">
+      <div class="card-body">
+        <h2 class="theme-section-title">Registry Management</h2>
+        <p class="text-muted">Preview the manifest and profile list before importing. Signed registries use HMAC-SHA256 publisher keys configured by the administrator.</p>
+        <textarea class="form-control" rows="6" data-model-registry-json placeholder='{"schema":"mobile-router-model-profiles-v2","manifest":{},"profiles":[]}'></textarea>
+        <label class="form-check mt-2"><input class="form-check-input" type="checkbox" data-model-registry-require-signature checked><span class="form-check-label">Require a trusted signature</span></label>
+        <div class="theme-actions">
+          <button class="btn btn-outline-info" type="button" data-model-registry-preview>Preview Registry</button>
+          <button class="btn btn-outline-primary" type="button" data-model-registry-import>Import Registry</button>
+        </div>
+        <pre class="theme-results mt-3" data-model-registry-output>Nothing previewed yet.</pre>
+      </div>
+    </section>
+  </main>
+</body>
+{% include '_footer.html' %}
+</html>

--- a/tests/test_model_profiles.py
+++ b/tests/test_model_profiles.py
@@ -1,0 +1,399 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import app as app_module
+from app import app
+from services import model_profiles
+
+
+class ModelProfileServiceTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.database = Path(self.tempdir.name) / "profiles.sqlite3"
+
+    def tearDown(self):
+        self.tempdir.cleanup()
+
+    def create_profile(self, **overrides):
+        values = {
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "scope": "exact",
+            "aliases": ["Sky Broadband Hub"],
+            "actor": "tester",
+        }
+        values.update(overrides)
+        return model_profiles.upsert_profile(self.database, **values)
+
+    def test_profile_hierarchy_and_alias_matching(self):
+        manufacturer = self.create_profile(
+            scope="manufacturer", model="", aliases=[], notes="Sky defaults"
+        )
+        family = self.create_profile(
+            scope="family", model="", family="Sky Hub", aliases=[]
+        )
+        exact = self.create_profile()
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=manufacturer["id"],
+            port=53,
+            protocol="udp",
+            service="DNS forwarder",
+            classification="expected",
+        )
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=family["id"],
+            port=80,
+            service="Family web redirect",
+            classification="optional",
+        )
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=exact["id"],
+            port=443,
+            service="SR203 administration",
+            classification="expected",
+        )
+        device = {
+            "manufacturer": "Sky",
+            "model": "Sky Broadband Hub",
+            "model_family": "Sky Hub",
+            "open_port_details": [
+                {"port": 53, "protocol": "udp", "service": "Unknown"},
+                {"port": 80, "protocol": "tcp", "service": "Unknown"},
+                {"port": 443, "protocol": "tcp", "service": "Unknown"},
+            ],
+        }
+
+        result = model_profiles.apply_device_profile(self.database, device)
+
+        self.assertEqual([item["scope"] for item in result["profiles"]], [
+            "manufacturer", "family", "exact"
+        ])
+        self.assertTrue(result["drift"]["matches_profile"])
+        services = {item["port"]: item["service"] for item in result["device"]["open_port_details"]}
+        self.assertEqual(services[443], "SR203 administration")
+
+    def test_hardware_and_firmware_applicability(self):
+        profile = self.create_profile(
+            hardware_revision="B",
+            firmware_min="7.00",
+            firmware_max="7.09",
+        )
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=4567,
+            service="ISP diagnostics",
+            classification="firmware-specific",
+            firmware_min="7.03",
+            firmware_max="7.05",
+        )
+        matching = {
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "hardware_revision": "B",
+            "firmware": "7.04.1",
+            "open_port_details": [{"port": 4567, "protocol": "tcp"}],
+        }
+        outside = {**matching, "firmware": "8.00"}
+
+        matched = model_profiles.apply_device_profile(self.database, matching)
+        unmatched = model_profiles.apply_device_profile(self.database, outside)
+
+        self.assertEqual(matched["primary_profile"]["id"], profile["id"])
+        self.assertIsNone(unmatched["primary_profile"])
+
+    def test_drift_and_device_override(self):
+        profile = self.create_profile()
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=443,
+            service="Administration",
+            classification="expected",
+            risk="high",
+            remediation="Restrict to the management network.",
+        )
+        device = {
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "open_port_details": [{"port": 51023, "protocol": "tcp", "service": "Unknown"}],
+        }
+        drifted = model_profiles.apply_device_profile(self.database, device)
+        overridden = model_profiles.set_device_override(
+            device,
+            port=51023,
+            service="Locally configured support service",
+        )
+        after_override = model_profiles.apply_device_profile(self.database, overridden)
+
+        self.assertEqual(drifted["drift"]["unexpected"][0]["port"], 51023)
+        self.assertEqual(drifted["drift"]["missing_expected"][0]["port"], 443)
+        self.assertFalse(any(item["port"] == 51023 for item in after_override["drift"]["unexpected"]))
+
+    def test_conflict_is_preserved_and_resolved(self):
+        profile = self.create_profile()
+        first = model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=4567,
+            service="TR-069 management",
+            classification="expected",
+            source_name="Source A",
+        )
+        conflict = model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=4567,
+            service="Sky diagnostics",
+            classification="optional",
+            source_name="Source B",
+        )
+
+        self.assertEqual(conflict["status"], "conflict")
+        self.assertEqual(first["service"], "TR-069 management")
+        resolved = model_profiles.resolve_conflict(
+            self.database, conflict["conflict_id"], "incoming", actor="reviewer"
+        )
+        self.assertEqual(resolved["ports"][0]["service"], "Sky diagnostics")
+        self.assertFalse(resolved["conflicts"])
+
+    def test_revision_history_and_rollback(self):
+        profile = self.create_profile(notes="Initial")
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=80,
+            service="Initial web service",
+        )
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=80,
+            service="Changed web service",
+            allow_replace=True,
+        )
+        history = model_profiles.revision_history(self.database, profile["id"])
+        target = next(item for item in history if item["action"] == "port-rule-created")
+
+        rolled_back = model_profiles.rollback(
+            self.database, profile["id"], target["revision"], actor="reviewer"
+        )
+
+        self.assertEqual(rolled_back["ports"][0]["service"], "Initial web service")
+        self.assertEqual(model_profiles.revision_history(self.database, profile["id"])[0]["action"], "profile-rollback")
+
+    def test_signed_registry_round_trip_and_tamper_detection(self):
+        profile = self.create_profile()
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=443,
+            service="Administration",
+        )
+        payload = model_profiles.export_registry(
+            self.database,
+            publisher="test-publisher",
+            version="1.0.0",
+            signing_key="secret",
+        )
+        verified = model_profiles.verify_registry(
+            payload,
+            trusted={"test-publisher": "secret"},
+            require_signature=True,
+        )
+        target = Path(self.tempdir.name) / "imported.sqlite3"
+        imported = model_profiles.import_registry(
+            target,
+            payload,
+            trusted={"test-publisher": "secret"},
+            require_signature=True,
+        )
+
+        self.assertEqual(verified["signature_status"], "verified")
+        self.assertEqual(imported["imported"], 1)
+        payload["profiles"][0]["model"] = "Tampered"
+        with self.assertRaisesRegex(ValueError, "digest"):
+            model_profiles.verify_registry(
+                payload,
+                trusted={"test-publisher": "secret"},
+                require_signature=True,
+            )
+
+    def test_fleet_summary_and_privacy_clean_contribution(self):
+        profile = self.create_profile()
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=443,
+            service="Administration",
+        )
+        inventory = [
+            {
+                "id": "private-id",
+                "ip": "192.168.1.1",
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "hostname": "private-router",
+                "manufacturer": "Sky",
+                "model": "SR203",
+                "firmware": "7.04",
+                "open_port_details": [{"port": 443, "protocol": "tcp"}],
+            }
+        ]
+        fleet = model_profiles.fleet_summary(self.database, inventory, profile["id"])
+        contribution = model_profiles.contribution_payload(
+            self.database, profile["id"], inventory
+        )
+        serialized = json.dumps(contribution)
+
+        self.assertEqual(fleet["device_count"], 1)
+        self.assertNotIn("192.168.1.1", serialized)
+        self.assertNotIn("aa:bb:cc:dd:ee:ff", serialized)
+        self.assertNotIn("private-router", serialized)
+
+
+class ModelProfileRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.database = Path(self.tempdir.name) / "route.sqlite3"
+        self.path_patch = patch(
+            "routes.model_profiles._database_path", return_value=self.database
+        )
+        self.path_patch.start()
+        app_module.device_inventory.clear()
+        app_module.social_users.clear()
+        app_module.social_users["test-admin"] = {
+            "id": "test-admin",
+            "username": "test-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        app_module.device_inventory["ip:192.168.1.1"] = {
+            "id": "ip:192.168.1.1",
+            "ip": "192.168.1.1",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "manufacturer": "Sky",
+            "model": "SR203",
+            "open_port_details": [{"port": 443, "protocol": "tcp", "service": "Unknown"}],
+            "interfaces": ["eth0"],
+        }
+        self.client = app.test_client()
+        self.csrf = "model-profile-csrf"
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {
+                "username": "test-admin",
+                "role": "admin",
+            }
+            flask_session["social_csrf_token"] = self.csrf
+
+    def tearDown(self):
+        self.path_patch.stop()
+        app_module.device_inventory.clear()
+        app_module.social_users.clear()
+        self.tempdir.cleanup()
+
+    def post(self, url, data=None):
+        return self.client.post(url, data={"csrf_token": self.csrf, **(data or {})})
+
+    def test_library_pages_and_profile_crud(self):
+        page = self.client.get("/models")
+        self.assertEqual(page.status_code, 200)
+        self.assertIn(b"Device Model Library", page.data)
+
+        created = self.post(
+            "/api/model-profiles",
+            {
+                "manufacturer": "Sky",
+                "model": "SR203",
+                "scope": "exact",
+                "aliases": "Sky Broadband Hub",
+            },
+        )
+        self.assertEqual(created.status_code, 200)
+        profile_id = created.get_json()["profile"]["id"]
+        detail_page = self.client.get(f"/models/{profile_id}")
+        self.assertEqual(detail_page.status_code, 200)
+        self.assertIn(b"Port and Service Rules", detail_page.data)
+
+        rule = self.post(
+            f"/api/model-profiles/{profile_id}/ports",
+            {
+                "port": "443",
+                "protocol": "tcp",
+                "service": "Sky administration",
+                "classification": "expected",
+                "risk": "high",
+            },
+        )
+        self.assertEqual(rule.status_code, 200)
+        self.assertEqual(rule.get_json()["profile"]["ports"][0]["port"], 443)
+
+    def test_client_profile_apply_and_manual_override(self):
+        profile = model_profiles.upsert_profile(
+            self.database,
+            manufacturer="Sky",
+            model="SR203",
+            actor="test",
+        )
+        model_profiles.add_port_rule(
+            self.database,
+            profile_id=profile["id"],
+            port=443,
+            service="Sky administration",
+            classification="expected",
+        )
+        loaded = self.client.get("/clients/192.168.1.1/model-profile")
+        self.assertEqual(loaded.status_code, 200)
+        self.assertTrue(loaded.get_json()["result"]["drift"]["matches_profile"])
+
+        overridden = self.post(
+            "/clients/192.168.1.1/model-profile/override",
+            {
+                "port": "51023",
+                "protocol": "tcp",
+                "service": "Local support service",
+                "classification": "local-configuration",
+            },
+        )
+        self.assertEqual(overridden.status_code, 200)
+        self.assertEqual(
+            app_module.device_inventory["ip:192.168.1.1"]["model_port_overrides"][0]["port"],
+            51023,
+        )
+
+    def test_registry_preview_and_ui_script(self):
+        profile = model_profiles.upsert_profile(
+            self.database,
+            manufacturer="Sky",
+            model="SR203",
+        )
+        payload = model_profiles.export_registry(
+            self.database,
+            publisher="test-publisher",
+            signing_key="secret",
+        )
+        with patch.dict(
+            os.environ,
+            {"MOBILE_ROUTER_MODEL_REGISTRY_KEYS": json.dumps({"test-publisher": "secret"})},
+        ):
+            preview = self.post(
+                "/api/model-registry/preview",
+                {"registryJson": json.dumps(payload), "requireSignature": "on"},
+            )
+        self.assertEqual(preview.status_code, 200)
+        self.assertEqual(preview.get_json()["verification"]["profile_count"], 1)
+
+        client_page = self.client.get("/clients/192.168.1.1")
+        self.assertEqual(client_page.status_code, 200)
+        self.assertIn(b"model-profiles.js", client_page.data)
+        self.assertTrue(profile["id"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/build_model_registry.py
+++ b/tools/build_model_registry.py
@@ -1,0 +1,244 @@
+"""Build, validate, deduplicate, and optionally sign model-profile registries."""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import os
+from pathlib import Path
+import sys
+import tempfile
+
+from services import model_profiles
+
+
+CONTRIBUTION_SCHEMA = "mobile-router-model-contribution-v1"
+
+
+def profile_key(profile):
+    return (
+        model_profiles.key(profile.get("scope") or "exact"),
+        model_profiles.key(profile.get("manufacturer")),
+        model_profiles.key(profile.get("model")),
+        model_profiles.key(profile.get("family")),
+        model_profiles.clean(profile.get("hardware_revision"), 120),
+        model_profiles.clean(profile.get("firmware_min"), 160),
+        model_profiles.clean(profile.get("firmware_max"), 160),
+    )
+
+
+def rule_key(rule):
+    return (
+        int(rule.get("port")),
+        model_profiles.valid_protocol(rule.get("protocol") or "tcp"),
+        model_profiles.clean(rule.get("hardware_revision"), 120),
+        model_profiles.clean(rule.get("firmware_min"), 160),
+        model_profiles.clean(rule.get("firmware_max"), 160),
+    )
+
+
+def load_payload(path):
+    return json.loads(Path(path).read_text(encoding="utf-8"))
+
+
+def profiles_from_payload(payload):
+    schema = payload.get("schema") if isinstance(payload, dict) else None
+    if schema == model_profiles.SCHEMA:
+        model_profiles.verify_registry(payload, require_signature=False)
+        return copy.deepcopy(payload.get("profiles") or [])
+    if schema == CONTRIBUTION_SCHEMA:
+        profile = copy.deepcopy(payload.get("profile") or {})
+        profile["ports"] = copy.deepcopy(payload.get("ports") or [])
+        return [profile]
+    raise ValueError(
+        f"Unsupported input schema {schema!r}; expected {model_profiles.SCHEMA} or {CONTRIBUTION_SCHEMA}"
+    )
+
+
+def merge_profiles(payloads):
+    merged = {}
+    conflicts = []
+    for source_name, payload in payloads:
+        for incoming in profiles_from_payload(payload):
+            incoming = copy.deepcopy(incoming)
+            incoming.setdefault("scope", "exact")
+            incoming.setdefault("ports", [])
+            item_key = profile_key(incoming)
+            current = merged.get(item_key)
+            if current is None:
+                incoming["_sources"] = [source_name]
+                merged[item_key] = incoming
+                continue
+            current["_sources"].append(source_name)
+            current["aliases"] = sorted(
+                set(current.get("aliases") or []) | set(incoming.get("aliases") or [])
+            )
+            current["manufacturer_aliases"] = sorted(
+                set(current.get("manufacturer_aliases") or [])
+                | set(incoming.get("manufacturer_aliases") or [])
+            )
+            current_rules = {rule_key(rule): rule for rule in current.get("ports") or []}
+            for rule in incoming.get("ports") or []:
+                incoming_rule_key = rule_key(rule)
+                existing = current_rules.get(incoming_rule_key)
+                if existing is None:
+                    current.setdefault("ports", []).append(rule)
+                    current_rules[incoming_rule_key] = rule
+                    continue
+                compared = (
+                    existing.get("service"),
+                    existing.get("classification"),
+                    existing.get("risk"),
+                    existing.get("description"),
+                )
+                proposed = (
+                    rule.get("service"),
+                    rule.get("classification"),
+                    rule.get("risk"),
+                    rule.get("description"),
+                )
+                if compared != proposed:
+                    conflicts.append(
+                        {
+                            "profile": {
+                                "manufacturer": current.get("manufacturer"),
+                                "model": current.get("model"),
+                                "family": current.get("family"),
+                                "scope": current.get("scope"),
+                            },
+                            "port": incoming_rule_key[0],
+                            "protocol": incoming_rule_key[1],
+                            "current": existing,
+                            "incoming": rule,
+                            "source": source_name,
+                        }
+                    )
+    profiles = []
+    for profile in merged.values():
+        profile.pop("_sources", None)
+        profile["ports"] = sorted(
+            profile.get("ports") or [],
+            key=lambda rule: (
+                str(rule.get("protocol") or "tcp"),
+                int(rule.get("port") or 0),
+            ),
+        )
+        profiles.append(profile)
+    profiles.sort(
+        key=lambda profile: (
+            model_profiles.key(profile.get("manufacturer")),
+            model_profiles.key(profile.get("model")),
+            model_profiles.key(profile.get("family")),
+            model_profiles.key(profile.get("scope")),
+        )
+    )
+    return profiles, conflicts
+
+
+def build_registry(profiles, publisher, version, signing_key=None):
+    with tempfile.TemporaryDirectory() as tempdir:
+        database = Path(tempdir) / "registry.sqlite3"
+        for profile in profiles:
+            created = model_profiles.upsert_profile(
+                database,
+                manufacturer=profile.get("manufacturer"),
+                model=profile.get("model"),
+                family=profile.get("family"),
+                scope=profile.get("scope") or "exact",
+                hardware_revision=profile.get("hardware_revision"),
+                firmware_min=profile.get("firmware_min"),
+                firmware_max=profile.get("firmware_max"),
+                aliases=profile.get("aliases"),
+                manufacturer_aliases=profile.get("manufacturer_aliases"),
+                notes=profile.get("notes"),
+                risk_notes=profile.get("risk_notes"),
+                actor="registry-builder",
+            )
+            for rule in profile.get("ports") or []:
+                model_profiles.add_port_rule(
+                    database,
+                    profile_id=created["id"],
+                    port=rule.get("port"),
+                    protocol=rule.get("protocol") or "tcp",
+                    service=rule.get("service"),
+                    description=rule.get("description"),
+                    classification=rule.get("classification") or "expected",
+                    exposure=rule.get("exposure") or "unknown",
+                    authentication_expected=rule.get("authentication_expected"),
+                    encryption_expected=rule.get("encryption_expected"),
+                    risk=rule.get("risk") or "info",
+                    remediation=rule.get("remediation"),
+                    hardware_revision=rule.get("hardware_revision"),
+                    firmware_min=rule.get("firmware_min"),
+                    firmware_max=rule.get("firmware_max"),
+                    source_name=rule.get("source_name"),
+                    source_url=rule.get("source_url"),
+                    source_reliability=rule.get("source_reliability") or 50,
+                    confidence=rule.get("confidence") or "registry",
+                    actor="registry-builder",
+                    allow_replace=True,
+                )
+        return model_profiles.export_registry(
+            database,
+            publisher=publisher,
+            version=version,
+            signing_key=signing_key,
+        )
+
+
+def parse_args(argv=None):
+    parser = argparse.ArgumentParser(
+        description="Build a validated Mobile Router device-model registry."
+    )
+    parser.add_argument("inputs", nargs="+", help="Registry or contribution JSON files")
+    parser.add_argument("--output", required=True, help="Output registry JSON")
+    parser.add_argument("--publisher", required=True, help="Registry publisher name")
+    parser.add_argument("--version", required=True, help="Registry version")
+    parser.add_argument(
+        "--signing-key-env",
+        default="MOBILE_ROUTER_MODEL_REGISTRY_SIGNING_KEY",
+        help="Environment variable containing the HMAC signing key",
+    )
+    parser.add_argument(
+        "--allow-conflicts",
+        action="store_true",
+        help="Build even when conflicting port descriptions are found",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    args = parse_args(argv)
+    payloads = [(path, load_payload(path)) for path in args.inputs]
+    profiles, conflicts = merge_profiles(payloads)
+    conflict_path = Path(args.output).with_suffix(".conflicts.json")
+    conflict_path.write_text(json.dumps(conflicts, indent=2), encoding="utf-8")
+    if conflicts and not args.allow_conflicts:
+        print(
+            f"Refusing to build: {len(conflicts)} conflict(s). Review {conflict_path}",
+            file=sys.stderr,
+        )
+        return 2
+    signing_key = os.environ.get(args.signing_key_env)
+    registry = build_registry(
+        profiles,
+        publisher=args.publisher,
+        version=args.version,
+        signing_key=signing_key,
+    )
+    model_profiles.verify_registry(
+        registry,
+        trusted={args.publisher: signing_key} if signing_key else {},
+        require_signature=bool(signing_key),
+    )
+    Path(args.output).write_text(json.dumps(registry, indent=2), encoding="utf-8")
+    print(
+        f"Wrote {len(registry['profiles'])} profile(s) to {args.output}; "
+        f"conflicts: {len(conflicts)}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What changed

- evolves model-specific port mappings into a Device Model Profile library
- supports exact-model, family, manufacturer, and device-specific override inheritance
- adds canonical names, aliases, firmware ranges, hardware revisions, expected/optional/firmware-specific/deprecated classifications, exposure expectations, risk, remediation, and provenance
- applies profiles to saved devices and calculates unexpected, missing-expected, and deprecated-service drift
- adds fleet-wide comparisons, firmware distribution, common ports, and drift summaries
- adds bounded unknown-port investigation guidance and peer-device comparison
- preserves conflicting source claims for reviewer resolution instead of silently overwriting them
- adds revision history and rollback
- adds privacy-clean contribution exports
- adds digest-verified and optionally HMAC-signed registries with preview, import, configured HTTPS sync, and import history
- adds a registry build tool that merges contributions, deduplicates entries, emits conflict reports, validates, and signs releases
- migrates existing approved model-port mappings into the new profile schema

## UI

- new `/models` Device Model Library
- model detail pages for identity, applicability, port rules, fleet drift, conflicts, and history
- model-profile and remediation card on IP client pages
- navigation entry under Records

## Validation

Final GitHub Actions run `30800621146` passed on both platforms:

- Ubuntu: compile, application import, duplicate-code report, `378 passed, 1 skipped`
- Windows: compile, application import, duplicate-code report, `378 passed, 1 skipped`
- duplicate-code analysis scanned 98 Python files and 891 non-trivial functions; it identified several small shared authentication/validation helpers as future consolidation candidates, but no test or runtime failures

Tests cover profile hierarchy, aliases, firmware/hardware applicability, local overrides, drift, conflicts, rollback, signed registries, fleet comparison, privacy-clean contributions, routes, UI loading, SQLite cleanup, and legacy mapping migration.
