### PR TITLE
Add editable saved service records

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -7,6 +7,7 @@ from .deauth_control import create_deauth_control_blueprint
 from .device_identification import create_device_identification_blueprint
 from .port_knowledge import create_port_knowledge_blueprint
 from .model_profiles import create_model_profiles_blueprint
+from .service_records import create_service_records_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -19,3 +20,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_device_identification_blueprint(context_provider))
     app.register_blueprint(create_port_knowledge_blueprint(context_provider))
     app.register_blueprint(create_model_profiles_blueprint(context_provider))
+    app.register_blueprint(create_service_records_blueprint(context_provider))

--- a/routes/service_records.py
+++ b/routes/service_records.py
@@ -1,0 +1,193 @@
+"""Edit saved service records and optionally publish them to model profiles."""
+
+from functools import wraps
+from pathlib import Path
+import secrets
+
+from flask import Blueprint, current_app, jsonify, redirect, request, session, url_for
+
+from services import model_profiles, service_records
+
+
+def _error(message, status=400):
+    return jsonify({"status": "error", "message": str(message)}), status
+
+
+def _write_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        user = session.get("social_user") or {}
+        if not user:
+            return _error("Login required", 401)
+        expected = str(session.get("social_csrf_token") or "")
+        supplied = str(
+            request.form.get("csrf_token")
+            or request.headers.get("X-CSRF-Token")
+            or ""
+        )
+        if not expected or not secrets.compare_digest(expected, supplied):
+            return _error("Invalid or expired form token", 400)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _find_inventory_key(app_module, identifier):
+    normalized = app_module.normalize_mac(identifier)
+    for item_key, item in app_module.device_inventory.items():
+        values = {
+            str(item_key),
+            str(item.get("id") or ""),
+            str(item.get("ip") or ""),
+            str(item.get("mac") or ""),
+            str(item.get("address") or ""),
+        }
+        if str(identifier) in values or (normalized and normalized in values):
+            return item_key
+    return None
+
+
+def _persist_device(app_module, identifier, device):
+    with app_module.device_inventory_lock:
+        item_key = _find_inventory_key(app_module, identifier)
+        if item_key is None:
+            return None
+        app_module.device_inventory[item_key] = dict(device)
+        return dict(app_module.device_inventory[item_key])
+
+
+def _model_database_path():
+    return Path(current_app.instance_path) / "device_port_knowledge.sqlite3"
+
+
+def create_service_records_blueprint(context_provider):
+    del context_provider
+    blueprint = Blueprint("service_records", __name__)
+
+    @blueprint.before_app_request
+    def apply_service_record_overrides():
+        """Reapply manual values after a later scan refreshes detected services."""
+        if request.method != "GET" or request.endpoint not in {
+            "client_detail",
+            "client_service_detail",
+        }:
+            return None
+        identifier = (request.view_args or {}).get("identifier")
+        if not identifier:
+            return None
+        import app as app_module
+
+        device = app_module.find_inventory_device(identifier) or {}
+        if not device or not device.get("service_record_overrides"):
+            return None
+        updated = service_records.apply_overrides(device)
+        _persist_device(app_module, identifier, updated)
+        return None
+
+    @blueprint.post("/clients/<identifier>/services/<int:port>")
+    @_write_required
+    def update_service_record(identifier, port):
+        import app as app_module
+
+        device = app_module.find_inventory_device(identifier) or {}
+        if not device:
+            return _error("Device was not found in inventory", 404)
+        protocol = request.form.get("protocol") or "tcp"
+        clear = request.form.get("clearOverride") == "on"
+        actor = (session.get("social_user") or {}).get("username") or "unknown"
+        try:
+            updated = service_records.update_override(
+                device,
+                port=port,
+                protocol=protocol,
+                service=request.form.get("service"),
+                description=request.form.get("description"),
+                notes=request.form.get("notes"),
+                source_name=request.form.get("sourceName"),
+                source_url=request.form.get("sourceUrl"),
+                updated_by=actor,
+                clear=clear,
+            )
+        except ValueError as exc:
+            if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+                return _error(exc)
+            return redirect(url_for(
+                "client_service_detail",
+                identifier=identifier,
+                port=port,
+                error=str(exc),
+            ))
+
+        persisted = _persist_device(app_module, identifier, updated) or updated
+        host = persisted.get("ip") or identifier
+        action = "Saved service override removed" if clear else "Saved service record edited"
+        app_module.append_client_timeline_event(
+            host,
+            action,
+            f"Updated {port}/{protocol} from the saved-service editor.",
+            "saved-service-editor",
+        )
+        app_module.record_social_audit(
+            "service-record.clear" if clear else "service-record.update",
+            profile_id=str(identifier),
+            detail=f"port={port}; protocol={protocol}",
+        )
+
+        model_result = None
+        model_status = ""
+        if not clear and request.form.get("applyToModel") == "on":
+            profile_id = persisted.get("model_profile_id") or persisted.get(
+                "model_profile_manual_id"
+            )
+            if not profile_id:
+                model_status = "no-profile"
+            else:
+                try:
+                    model_result = model_profiles.add_port_rule(
+                        _model_database_path(),
+                        profile_id=profile_id,
+                        port=port,
+                        protocol=protocol,
+                        service=request.form.get("service"),
+                        description=request.form.get("description"),
+                        classification=request.form.get("classification") or "investigate",
+                        exposure=request.form.get("exposure") or "unknown",
+                        authentication_expected=request.form.get("authenticationExpected") == "on",
+                        encryption_expected=request.form.get("encryptionExpected") == "on",
+                        risk=request.form.get("risk") or "info",
+                        remediation=request.form.get("remediation"),
+                        source_name=request.form.get("sourceName"),
+                        source_url=request.form.get("sourceUrl"),
+                        source_reliability=request.form.get("sourceReliability") or 50,
+                        confidence="user-confirmed",
+                        actor=actor,
+                        allow_replace=request.form.get("replaceModelRule") == "on",
+                    )
+                    model_status = (
+                        "conflict"
+                        if isinstance(model_result, dict)
+                        and model_result.get("status") == "conflict"
+                        else "saved"
+                    )
+                except ValueError as exc:
+                    model_status = f"error:{exc}"
+
+        app_module.save_runtime_state("saved-service-record")
+        if request.headers.get("X-Requested-With") == "XMLHttpRequest":
+            return jsonify({
+                "status": "success",
+                "message": action,
+                "device": persisted,
+                "model_status": model_status,
+                "model_result": model_result,
+            })
+        return redirect(url_for(
+            "client_service_detail",
+            identifier=identifier,
+            port=port,
+            saved="1",
+            cleared="1" if clear else "",
+            model=model_status,
+        ))
+
+    return blueprint

--- a/services/service_records.py
+++ b/services/service_records.py
@@ -1,0 +1,157 @@
+"""Editable saved-service records that survive later port scans."""
+
+from __future__ import annotations
+
+import copy
+import time
+from urllib.parse import urlsplit
+
+
+_PROTOCOLS = {"tcp", "udp"}
+_MANUAL_DETAIL_FIELDS = {
+    "service_manual_override",
+    "detected_service",
+    "detected_description",
+    "service_notes",
+    "service_source_name",
+    "service_source_url",
+    "service_updated_at",
+    "service_updated_by",
+}
+
+
+def _clean(value, limit):
+    return str(value or "").strip()[:limit]
+
+
+def valid_port(value):
+    try:
+        port = int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Port must be an integer") from exc
+    if not 1 <= port <= 65535:
+        raise ValueError("Port must be between 1 and 65535")
+    return port
+
+
+def valid_protocol(value):
+    protocol = _clean(value or "tcp", 8).casefold()
+    if protocol not in _PROTOCOLS:
+        raise ValueError("Protocol must be TCP or UDP")
+    return protocol
+
+
+def valid_source_url(value):
+    url = _clean(value, 1000)
+    if not url:
+        return ""
+    parsed = urlsplit(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Source URL must be a complete HTTP or HTTPS URL")
+    if parsed.username or parsed.password:
+        raise ValueError("Source URL must not contain credentials")
+    return url
+
+
+def _key(item):
+    try:
+        return valid_port(item.get("port")), valid_protocol(item.get("protocol") or "tcp")
+    except (AttributeError, ValueError):
+        return None
+
+
+def override_for(device, port, protocol="tcp"):
+    target = valid_port(port), valid_protocol(protocol)
+    for item in (device or {}).get("service_record_overrides") or []:
+        if _key(item) == target:
+            return dict(item)
+    return None
+
+
+def apply_overrides(device):
+    """Return a device copy with saved manual values applied to port details."""
+    updated = copy.deepcopy(device or {})
+    overrides = {
+        item_key: dict(item)
+        for item in updated.get("service_record_overrides") or []
+        if (item_key := _key(item)) is not None
+    }
+    details = []
+    for raw in updated.get("open_port_details") or []:
+        detail = dict(raw)
+        item_key = _key(detail)
+        override = overrides.get(item_key)
+        was_manual = bool(detail.get("service_manual_override"))
+        if override:
+            detected_service = (
+                detail.get("detected_service") if was_manual else detail.get("service")
+            ) or "Unknown"
+            detected_description = (
+                detail.get("detected_description") if was_manual else detail.get("description")
+            ) or ""
+            detail.update({
+                "detected_service": detected_service,
+                "detected_description": detected_description,
+                "service": override["service"],
+                "description": override.get("description") or detected_description,
+                "service_notes": override.get("notes") or "",
+                "service_source_name": override.get("source_name") or "",
+                "service_source_url": override.get("source_url") or "",
+                "service_updated_at": override.get("updated_at"),
+                "service_updated_by": override.get("updated_by") or "",
+                "service_manual_override": True,
+            })
+        elif was_manual:
+            detail["service"] = detail.get("detected_service") or "Unknown"
+            detail["description"] = detail.get("detected_description") or ""
+            for field in _MANUAL_DETAIL_FIELDS:
+                detail.pop(field, None)
+        details.append(detail)
+    updated["open_port_details"] = details
+    return updated
+
+
+def update_override(
+    device,
+    *,
+    port,
+    protocol="tcp",
+    service="",
+    description="",
+    notes="",
+    source_name="",
+    source_url="",
+    updated_by="",
+    clear=False,
+):
+    """Create, replace, or remove a device-specific saved-service override."""
+    port, protocol = valid_port(port), valid_protocol(protocol)
+    updated = copy.deepcopy(device or {})
+    details = updated.get("open_port_details") or []
+    if not any(_key(item) == (port, protocol) for item in details):
+        raise ValueError(f"No saved {port}/{protocol} service exists for this device")
+
+    overrides = [
+        dict(item)
+        for item in updated.get("service_record_overrides") or []
+        if _key(item) != (port, protocol)
+    ]
+    if not clear:
+        service = _clean(service, 200)
+        if not service:
+            raise ValueError("Service name is required")
+        overrides.append({
+            "port": port,
+            "protocol": protocol,
+            "service": service,
+            "description": _clean(description, 2000),
+            "notes": _clean(notes, 2000),
+            "source_name": _clean(source_name, 240),
+            "source_url": valid_source_url(source_url),
+            "updated_at": time.time(),
+            "updated_by": _clean(updated_by, 120),
+        })
+    updated["service_record_overrides"] = sorted(
+        overrides, key=lambda item: (item["protocol"], item["port"])
+    )
+    return apply_overrides(updated)

--- a/templates/service_detail.html
+++ b/templates/service_detail.html
@@ -4,20 +4,168 @@
   <main class="theme-page container py-4">
     <section class="theme-card card">
       <div class="card-body">
-        <p class="interface-kicker mb-1">Saved Service</p>
+        <p class="interface-kicker mb-1">Saved Service Record</p>
         <h1 class="page-title">{{ host }}:{{ port }}</h1>
         {% if service %}
+          {% if request.args.get('saved') %}
+            <div class="alert alert-success" role="alert">
+              {% if request.args.get('cleared') %}
+                Manual service override removed. The scanner-detected value is shown again.
+              {% else %}
+                Saved service record updated.
+              {% endif %}
+            </div>
+          {% endif %}
+          {% if request.args.get('error') %}
+            <div class="alert alert-danger" role="alert">{{ request.args.get('error') }}</div>
+          {% endif %}
+          {% if request.args.get('model') == 'saved' %}
+            <div class="alert alert-success" role="alert">The mapping was also saved to the matched device-model profile.</div>
+          {% elif request.args.get('model') == 'conflict' %}
+            <div class="alert alert-warning" role="alert">The model profile already has a different mapping. A conflict was recorded for review rather than overwriting it silently.</div>
+          {% elif request.args.get('model') == 'no-profile' %}
+            <div class="alert alert-warning" role="alert">The device record was saved, but this device has no matched model profile to reuse the mapping against.</div>
+          {% elif request.args.get('model', '').startswith('error:') %}
+            <div class="alert alert-warning" role="alert">The device record was saved, but the reusable model rule failed: {{ request.args.get('model')[6:] }}</div>
+          {% endif %}
+
           <div class="theme-actions">
             {% if service.web_url %}<a class="btn btn-primary" href="{{ service.web_url }}" target="_blank" rel="noopener noreferrer">Open web service</a>{% endif %}
             <a class="btn btn-outline-secondary" href="/clients/{{ host|urlencode }}">Back to device</a>
           </div>
-          <dl class="interface-definition-list mt-3">
-            <div><dt>Service</dt><dd>{{ service.service or 'Unknown' }}</dd></div>
-            <div><dt>Description</dt><dd>{{ service.description or 'No service description saved.' }}</dd></div>
+
+          <div class="theme-grid mt-3">
+            <article class="port-service-card">
+              <strong>Scanner-detected service</strong>
+              <span>{{ service.detected_service or service.service or 'Unknown' }}</span>
+              <small>{{ service.detected_description or service.description or 'No scanner description captured.' }}</small>
+            </article>
+            <article class="port-service-card">
+              <strong>Current saved value</strong>
+              <span>{{ service.service or 'Unknown' }}</span>
+              <small>{% if service.service_manual_override %}Manual device override{% else %}Scanner/model-profile value{% endif %}</small>
+            </article>
+            <article class="port-service-card">
+              <strong>Protocol</strong>
+              <span>{{ (service.protocol or 'tcp')|upper }}</span>
+              <small>Port {{ port }}</small>
+            </article>
+          </div>
+
+          <form class="theme-form mt-4" method="post" action="/clients/{{ host|urlencode }}/services/{{ port }}" data-saved-service-editor>
+            <input type="hidden" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
+            <input type="hidden" name="protocol" value="{{ service.protocol or 'tcp' }}">
+
+            <h2 class="theme-section-title">Edit this device’s saved service</h2>
+            <p class="text-muted">Manual values are retained separately from scan evidence, so another port scan can refresh the detected result without erasing your edit.</p>
+
+            <div class="form-row">
+              <div class="col-md-5">
+                <label for="saved-service-name">Service name</label>
+                <input id="saved-service-name" class="form-control" name="service" maxlength="200" value="{{ service.service or '' }}" placeholder="Sky diagnostics, Chromecast service, vendor agent…" required>
+              </div>
+              <div class="col-md-7">
+                <label for="saved-service-description">Description</label>
+                <input id="saved-service-description" class="form-control" name="description" maxlength="2000" value="{{ service.description or '' }}" placeholder="What this service is used for">
+              </div>
+            </div>
+
+            <label class="mt-3" for="saved-service-notes">Device-specific notes</label>
+            <textarea id="saved-service-notes" class="form-control" name="notes" rows="3" maxlength="2000" placeholder="How this was identified, whether it is expected here, and any local configuration details.">{{ service.service_notes or '' }}</textarea>
+
+            <div class="form-row mt-3">
+              <div class="col-md-5">
+                <label for="saved-service-source-name">Research source</label>
+                <input id="saved-service-source-name" class="form-control" name="sourceName" maxlength="240" value="{{ service.service_source_name or '' }}" placeholder="Vendor manual, support article, packet capture…">
+              </div>
+              <div class="col-md-7">
+                <label for="saved-service-source-url">Source URL</label>
+                <input id="saved-service-source-url" class="form-control" type="url" name="sourceUrl" maxlength="1000" value="{{ service.service_source_url or '' }}" placeholder="https://…">
+              </div>
+            </div>
+
+            {% if device.model_profile_id or device.model_profile_manual_id %}
+              <details class="mt-4">
+                <summary><strong>Reuse this mapping for the matched device model</strong></summary>
+                <div class="mt-3">
+                  <label class="form-check">
+                    <input class="form-check-input" type="checkbox" name="applyToModel" id="apply-service-to-model">
+                    <span class="form-check-label">Also add or update port {{ port }} in model profile #{{ device.model_profile_id or device.model_profile_manual_id }}.</span>
+                  </label>
+                  <p class="text-muted small">Leave this unticked for a one-device override. Model reuse is suitable only when the service is genuinely associated with this model or firmware.</p>
+
+                  <div class="form-row">
+                    <div class="col-md-4">
+                      <label for="model-service-classification">Classification</label>
+                      <select id="model-service-classification" class="form-control" name="classification">
+                        <option value="investigate" selected>Investigate</option>
+                        <option value="optional">Optional</option>
+                        <option value="expected">Expected</option>
+                        <option value="firmware-specific">Firmware-specific</option>
+                        <option value="local-configuration">Local configuration</option>
+                        <option value="deprecated">Deprecated</option>
+                        <option value="unexpected">Unexpected</option>
+                      </select>
+                    </div>
+                    <div class="col-md-4">
+                      <label for="model-service-exposure">Expected exposure</label>
+                      <select id="model-service-exposure" class="form-control" name="exposure">
+                        <option value="unknown" selected>Unknown</option>
+                        <option value="lan-only">LAN only</option>
+                        <option value="management-network">Management network</option>
+                        <option value="localhost">Localhost only</option>
+                        <option value="wan">WAN/Internet</option>
+                      </select>
+                    </div>
+                    <div class="col-md-4">
+                      <label for="model-service-risk">Risk</label>
+                      <select id="model-service-risk" class="form-control" name="risk">
+                        <option value="info" selected>Informational</option>
+                        <option value="low">Low</option>
+                        <option value="medium">Medium</option>
+                        <option value="high">High</option>
+                        <option value="critical">Critical</option>
+                      </select>
+                    </div>
+                  </div>
+
+                  <label class="mt-3" for="model-service-remediation">Recommended action</label>
+                  <textarea id="model-service-remediation" class="form-control" name="remediation" rows="2" maxlength="2000" placeholder="Restrict to LAN, disable when unused, verify firmware, etc."></textarea>
+
+                  <div class="form-row mt-3">
+                    <div class="col-md-4">
+                      <label for="model-source-reliability">Source reliability</label>
+                      <input id="model-source-reliability" class="form-control" type="number" name="sourceReliability" min="0" max="100" value="70">
+                    </div>
+                    <div class="col-md-8 d-flex align-items-end">
+                      <div>
+                        <label class="form-check mb-1"><input class="form-check-input" type="checkbox" name="authenticationExpected"><span class="form-check-label">Authentication expected</span></label>
+                        <label class="form-check mb-1"><input class="form-check-input" type="checkbox" name="encryptionExpected"><span class="form-check-label">Encryption expected</span></label>
+                        <label class="form-check"><input class="form-check-input" type="checkbox" name="replaceModelRule"><span class="form-check-label">Replace an existing matching rule rather than record a conflict</span></label>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </details>
+            {% else %}
+              <div class="alert alert-info mt-4">This device does not yet have a matched model profile. The edit will be saved for this device only. Use the Device Model Profile section on the device page to assign or create a reusable profile.</div>
+            {% endif %}
+
+            <div class="theme-actions mt-4">
+              <button class="btn btn-primary" type="submit">Save service record</button>
+              {% if service.service_manual_override %}
+                <button class="btn btn-outline-danger" type="submit" name="clearOverride" value="on">Remove manual override</button>
+              {% endif %}
+              <a class="btn btn-link" href="/clients/{{ host|urlencode }}">Cancel</a>
+            </div>
+          </form>
+
+          <dl class="interface-definition-list mt-4">
             <div><dt>HTTP Status</dt><dd>{{ service.http_status or 'Not captured' }}</dd></div>
             <div><dt>HTTP Title</dt><dd>{{ service.http_title or 'Not captured' }}</dd></div>
             <div><dt>Server Header</dt><dd>{{ service.http_server or 'Not captured' }}</dd></div>
             <div><dt>URL</dt><dd>{% if service.web_url %}<a href="{{ service.web_url }}" target="_blank" rel="noopener noreferrer">{{ service.web_url }}</a>{% else %}No web URL saved{% endif %}</dd></div>
+            {% if service.service_updated_by %}<div><dt>Last manually edited by</dt><dd>{{ service.service_updated_by }}</dd></div>{% endif %}
           </dl>
           {% if service.http_thumbnail_url %}
             <img class="web-service-preview-image mt-3" src="{{ service.http_thumbnail_url }}" alt="Preview of {{ service.web_url }}">

--- a/templates/service_detail.html
+++ b/templates/service_detail.html
@@ -112,8 +112,9 @@
                       <select id="model-service-exposure" class="form-control" name="exposure">
                         <option value="unknown" selected>Unknown</option>
                         <option value="lan-only">LAN only</option>
-                        <option value="management-network">Management network</option>
-                        <option value="localhost">Localhost only</option>
+                        <option value="management">Management network</option>
+                        <option value="local-host">Localhost only</option>
+                        <option value="wan-optional">Optional WAN exposure</option>
                         <option value="wan">WAN/Internet</option>
                       </select>
                     </div>

--- a/tests/test_service_records.py
+++ b/tests/test_service_records.py
@@ -1,0 +1,218 @@
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+from app import app
+from services import service_records
+
+
+class ServiceRecordServiceTest(unittest.TestCase):
+    def test_manual_override_survives_refreshed_scan_evidence(self):
+        device = {
+            "id": "ip:192.0.2.45",
+            "ip": "192.0.2.45",
+            "open_port_details": [
+                {
+                    "port": 5555,
+                    "protocol": "tcp",
+                    "service": "Unknown",
+                    "description": "No common service mapping found",
+                }
+            ],
+        }
+        edited = service_records.update_override(
+            device,
+            port=5555,
+            protocol="tcp",
+            service="Sky diagnostics",
+            description="Router diagnostics service",
+            notes="Confirmed from the vendor support page.",
+            source_name="Sky support",
+            source_url="https://example.com/sky-router",
+            updated_by="test-admin",
+        )
+        self.assertEqual(edited["open_port_details"][0]["service"], "Sky diagnostics")
+        self.assertEqual(edited["open_port_details"][0]["detected_service"], "Unknown")
+
+        rescanned = {
+            **edited,
+            "open_port_details": [
+                {
+                    "port": 5555,
+                    "protocol": "tcp",
+                    "service": "Unknown",
+                    "description": "No common service mapping found",
+                    "banner": "fresh scan evidence",
+                }
+            ],
+        }
+        reapplied = service_records.apply_overrides(rescanned)
+
+        detail = reapplied["open_port_details"][0]
+        self.assertEqual(detail["service"], "Sky diagnostics")
+        self.assertEqual(detail["detected_service"], "Unknown")
+        self.assertEqual(detail["banner"], "fresh scan evidence")
+        self.assertTrue(detail["service_manual_override"])
+
+    def test_removing_override_restores_detected_value(self):
+        device = {
+            "open_port_details": [
+                {"port": 8443, "protocol": "tcp", "service": "HTTPS alternate"}
+            ]
+        }
+        edited = service_records.update_override(
+            device,
+            port=8443,
+            service="Router management",
+            updated_by="test-admin",
+        )
+        cleared = service_records.update_override(
+            edited,
+            port=8443,
+            clear=True,
+        )
+
+        self.assertEqual(cleared["open_port_details"][0]["service"], "HTTPS alternate")
+        self.assertFalse(cleared["open_port_details"][0].get("service_manual_override"))
+        self.assertEqual(cleared.get("service_record_overrides"), [])
+
+    def test_source_url_rejects_credentials(self):
+        with self.assertRaisesRegex(ValueError, "must not contain credentials"):
+            service_records.valid_source_url("https://user:pass@example.com/reference")
+
+
+class ServiceRecordRouteTest(unittest.TestCase):
+    identifier = "192.0.2.45"
+    inventory_key = "ip:192.0.2.45"
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.previous_users = dict(app_module.social_users)
+        app_module.social_users.clear()
+        app_module.social_users["test-admin"] = {
+            "id": "test-admin",
+            "username": "test-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        with app_module.device_inventory_lock:
+            self.previous_device = app_module.device_inventory.pop(self.inventory_key, None)
+            app_module.device_inventory[self.inventory_key] = {
+                "id": self.inventory_key,
+                "ip": self.identifier,
+                "mac": "aa:bb:cc:dd:ee:ff",
+                "manufacturer": "Sky",
+                "model": "SR203",
+                "model_profile_id": 12,
+                "open_ports": [5555],
+                "open_port_details": [
+                    {
+                        "port": 5555,
+                        "protocol": "tcp",
+                        "service": "Unknown",
+                        "description": "No common service mapping found",
+                    }
+                ],
+            }
+        self.csrf = "service-record-csrf"
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {
+                "username": "test-admin",
+                "role": "admin",
+            }
+            flask_session["social_csrf_token"] = self.csrf
+
+    def tearDown(self):
+        with app_module.device_inventory_lock:
+            app_module.device_inventory.pop(self.inventory_key, None)
+            if self.previous_device is not None:
+                app_module.device_inventory[self.inventory_key] = self.previous_device
+        app_module.social_users.clear()
+        app_module.social_users.update(self.previous_users)
+
+    def test_saved_service_card_destination_contains_editor(self):
+        response = self.client.get(
+            f"/clients/{self.identifier}/services/5555"
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"data-saved-service-editor", response.data)
+        self.assertIn(b"Save service record", response.data)
+        self.assertIn(b"Reuse this mapping for the matched device model", response.data)
+
+    @patch("app.save_runtime_state")
+    @patch("app.record_social_audit")
+    @patch("app.append_client_timeline_event")
+    def test_post_updates_device_record(self, timeline, audit, save_state):
+        response = self.client.post(
+            f"/clients/{self.identifier}/services/5555",
+            data={
+                "csrf_token": self.csrf,
+                "protocol": "tcp",
+                "service": "Sky diagnostics",
+                "description": "Router diagnostics service",
+                "notes": "Confirmed in an authorised lab.",
+                "sourceName": "Sky support",
+                "sourceUrl": "https://example.com/sky-router",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Saved service record updated", response.data)
+        saved = app_module.find_inventory_device(self.identifier)
+        self.assertEqual(saved["open_port_details"][0]["service"], "Sky diagnostics")
+        self.assertTrue(saved["open_port_details"][0]["service_manual_override"])
+        self.assertEqual(saved["service_record_overrides"][0]["source_name"], "Sky support")
+        timeline.assert_called_once()
+        audit.assert_called_once()
+        save_state.assert_called_once_with("saved-service-record")
+
+    @patch("routes.service_records.model_profiles.add_port_rule")
+    @patch("app.save_runtime_state")
+    @patch("app.record_social_audit")
+    @patch("app.append_client_timeline_event")
+    def test_can_publish_edit_to_matched_model_profile(
+        self, timeline, audit, save_state, add_port_rule
+    ):
+        add_port_rule.return_value = {"id": 99, "service": "Sky diagnostics"}
+
+        response = self.client.post(
+            f"/clients/{self.identifier}/services/5555",
+            data={
+                "csrf_token": self.csrf,
+                "protocol": "tcp",
+                "service": "Sky diagnostics",
+                "description": "Router diagnostics service",
+                "applyToModel": "on",
+                "classification": "optional",
+                "exposure": "lan-only",
+                "risk": "low",
+                "sourceReliability": "80",
+            },
+            follow_redirects=True,
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"also saved to the matched device-model profile", response.data)
+        kwargs = add_port_rule.call_args.kwargs
+        self.assertEqual(kwargs["profile_id"], 12)
+        self.assertEqual(kwargs["port"], 5555)
+        self.assertEqual(kwargs["classification"], "optional")
+        self.assertEqual(kwargs["exposure"], "lan-only")
+
+    def test_post_requires_valid_csrf(self):
+        response = self.client.post(
+            f"/clients/{self.identifier}/services/5555",
+            data={
+                "csrf_token": "wrong",
+                "service": "Sky diagnostics",
+            },
+        )
+
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("Invalid or expired", response.get_json()["message"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- turns the existing saved-service detail destination into an editor for the selected port card
- stores device-specific service names, descriptions, notes, and research provenance separately from scanner evidence
- reapplies manual service values after later scans so generic `Unknown` results do not erase operator edits
- keeps the latest scanner-detected service and description visible alongside the manual value
- allows a manual override to be removed and the detected value restored
- optionally publishes the mapping into the matched Device Model Profile with classification, exposure, risk, authentication, encryption, remediation, source reliability, and conflict handling
- records service edits in the client timeline and social audit log
- requires login and CSRF validation for writes

## Validation

Final GitHub Actions run `30804937001` passed on both platforms:

- Ubuntu: compile, application import, duplicate-code report, `385 passed, 1 skipped`
- Windows: compile, application import, duplicate-code report, `385 passed, 1 skipped`
- duplicate-code analysis scanned 100 Python files and 905 non-trivial functions; existing shared helper candidates were reported without test or runtime failures

Tests cover persistent overrides across refreshed scan evidence, removal/restoration, source URL validation, editor rendering, device-record updates, optional model-profile publication, and CSRF enforcement.
