### PR TITLE
Add host facts and capabilities workspace

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -8,6 +8,7 @@ from .device_identification import create_device_identification_blueprint
 from .port_knowledge import create_port_knowledge_blueprint
 from .model_profiles import create_model_profiles_blueprint
 from .service_records import create_service_records_blueprint
+from .host_facts import create_host_facts_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -21,3 +22,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_port_knowledge_blueprint(context_provider))
     app.register_blueprint(create_model_profiles_blueprint(context_provider))
     app.register_blueprint(create_service_records_blueprint(context_provider))
+    app.register_blueprint(create_host_facts_blueprint(context_provider))

--- a/routes/host_facts.py
+++ b/routes/host_facts.py
@@ -1,0 +1,373 @@
+"""Host facts and capabilities workspace routes."""
+
+from functools import wraps
+from pathlib import Path
+import secrets
+import time
+
+from flask import (
+    Blueprint,
+    current_app,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+
+from services import host_facts
+
+
+def _error(message, status=400):
+    return jsonify({"status": "error", "message": str(message)}), status
+
+
+def _login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not session.get("social_user"):
+            return _error("Login required", 401)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _write_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not session.get("social_user"):
+            return _error("Login required", 401)
+        expected = str(session.get("social_csrf_token") or "")
+        supplied = str(
+            request.form.get("csrf_token")
+            or request.headers.get("X-CSRF-Token")
+            or ""
+        )
+        if not expected or not secrets.compare_digest(expected, supplied):
+            return _error("Invalid or expired form token", 400)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _find_inventory_key(app_module, identifier):
+    normalized = app_module.normalize_mac(identifier)
+    for item_key, item in app_module.device_inventory.items():
+        values = {
+            str(item_key),
+            str(item.get("id") or ""),
+            str(item.get("ip") or ""),
+            str(item.get("mac") or ""),
+            str(item.get("address") or ""),
+        }
+        if str(identifier) in values or (normalized and normalized in values):
+            return item_key
+    return None
+
+
+def _persist_device(app_module, identifier, device):
+    with app_module.device_inventory_lock:
+        item_key = _find_inventory_key(app_module, identifier)
+        if item_key is None:
+            return None
+        app_module.device_inventory[item_key] = dict(device)
+        return dict(app_module.device_inventory[item_key])
+
+
+def _credential_path():
+    return Path(current_app.instance_path) / "host_credential_references.json"
+
+
+def _decorate_for_page(device):
+    decorated = dict(device or {})
+    facts = []
+    for raw in decorated.get("host_facts") or []:
+        item = dict(raw)
+        item["first_seen_label"] = time.strftime(
+            "%Y-%m-%d %H:%M:%S",
+            time.localtime(float(
+                item.get("first_seen")
+                or item.get("observed_at")
+                or time.time()
+            )),
+        )
+        item["last_seen_label"] = time.strftime(
+            "%Y-%m-%d %H:%M:%S",
+            time.localtime(float(
+                item.get("last_seen")
+                or item.get("observed_at")
+                or time.time()
+            )),
+        )
+        facts.append(item)
+    decorated["host_facts"] = facts
+    runs = []
+    for raw in decorated.get("host_fact_runs") or []:
+        item = dict(raw)
+        item["time_label"] = time.strftime(
+            "%Y-%m-%d %H:%M:%S",
+            time.localtime(float(item.get("timestamp") or time.time())),
+        )
+        runs.append(item)
+    decorated["host_fact_runs"] = runs
+    baseline = dict(decorated.get("host_fact_baseline") or {})
+    if baseline.get("saved_at"):
+        baseline["saved_at_label"] = time.strftime(
+            "%Y-%m-%d %H:%M:%S",
+            time.localtime(float(baseline["saved_at"])),
+        )
+    decorated["host_fact_baseline"] = baseline
+    return decorated
+
+
+def create_host_facts_blueprint(context_provider):
+    blueprint = Blueprint("host_facts", __name__)
+
+    @blueprint.get("/clients/<path:identifier>/host-facts")
+    @_login_required
+    def host_facts_page(identifier):
+        import app as app_module
+
+        device = app_module.find_inventory_device(identifier) or {}
+        if not device:
+            return render_template(
+                "host_facts.html",
+                title="Host not found",
+                identifier=identifier,
+                device=None,
+                facts=[],
+                credential_profiles=[],
+                capabilities=host_facts.capabilities(),
+                error="Device was not found in inventory.",
+                **context_provider(),
+            ), 404
+        decorated = _decorate_for_page(device)
+        facts = decorated.get("host_facts") or []
+        summary = {
+            "total": len(facts),
+            "changed": len([
+                item for item in facts if item.get("changed_since_baseline")
+            ]),
+            "high_confidence": len([
+                item
+                for item in facts
+                if item.get("confidence") in {"high", "very-high"}
+            ]),
+            "sensitive": len([
+                item
+                for item in facts
+                if item.get("sensitivity") == "sensitive"
+            ]),
+        }
+        return render_template(
+            "host_facts.html",
+            title=(
+                "Host Facts · "
+                f"{device.get('display_name') or device.get('name') or device.get('ip') or identifier}"
+            ),
+            identifier=identifier,
+            device=decorated,
+            facts=facts,
+            summary=summary,
+            credential_profiles=host_facts.load_credential_references(
+                _credential_path()
+            ),
+            capabilities=host_facts.capabilities(),
+            error=request.args.get("error"),
+            message=request.args.get("message"),
+            **context_provider(),
+        )
+
+    @blueprint.post("/clients/<path:identifier>/host-facts/collect")
+    @_write_required
+    def collect_host_facts(identifier):
+        import app as app_module
+
+        device = app_module.find_inventory_device(identifier) or {}
+        if not device:
+            return _error("Device was not found in inventory", 404)
+        user = session.get("social_user") or {}
+        actor = user.get("username") or "unknown"
+        mode = str(request.form.get("mode") or "passive").strip().casefold()
+        host = device.get("ip") or identifier
+        try:
+            if mode == "passive":
+                relationship_map = app_module.client_relationship_map(identifier)
+                passive_provider = getattr(
+                    app_module,
+                    "passive_observation_summary",
+                    None,
+                )
+                passive_summary = (
+                    passive_provider() if callable(passive_provider) else {}
+                )
+                observed = host_facts.passive_facts(
+                    device,
+                    relationships=relationship_map,
+                    passive_summary=passive_summary,
+                )
+            elif mode == "safe":
+                if request.form.get("authorized") != "on":
+                    raise ValueError(
+                        "Confirm authorization before safe protocol negotiation"
+                    )
+                fingerprints = app_module.fingerprint_client_services(identifier)
+                observed = host_facts.safe_facts(
+                    device,
+                    host,
+                    base_fingerprints=fingerprints,
+                )
+            elif mode == "deep":
+                if user.get("role") != "admin":
+                    return _error(
+                        "Administrator role required for deep identification",
+                        403,
+                    )
+                if request.form.get("authorized") != "on":
+                    raise ValueError(
+                        "Confirm authorization before deep identification"
+                    )
+                profiles = host_facts.load_credential_references(
+                    _credential_path()
+                )
+                profile = host_facts.credential_reference(
+                    profiles,
+                    request.form.get("credentialProfile"),
+                )
+                snmp_community = ""
+                if profile and profile.get("kind") == "snmp-v2c":
+                    snmp_community = host_facts.resolve_secret(profile)
+                    if not snmp_community:
+                        raise ValueError(
+                            f"Environment variable {profile.get('secret_env')} is not set"
+                        )
+                observed = host_facts.deep_facts(
+                    device,
+                    host,
+                    authorized=True,
+                    snmp_community=snmp_community or None,
+                )
+            else:
+                raise ValueError("Unsupported host-facts collection mode")
+        except ValueError as exc:
+            return redirect(url_for(
+                "host_facts.host_facts_page",
+                identifier=identifier,
+                error=str(exc),
+            ))
+        updated = host_facts.apply_fact_run(
+            device,
+            observed,
+            mode=mode,
+            actor=actor,
+        )
+        _persist_device(app_module, identifier, updated)
+        app_module.append_client_timeline_event(
+            host,
+            "Host facts collected",
+            f"Collected {len(observed)} {mode} host fact(s).",
+            "host-facts",
+        )
+        app_module.record_social_audit(
+            "host-facts.collect",
+            profile_id=str(identifier),
+            detail=f"mode={mode}; facts={len(observed)}",
+        )
+        app_module.save_runtime_state(f"host-facts:{mode}")
+        return redirect(url_for(
+            "host_facts.host_facts_page",
+            identifier=identifier,
+            message=f"Collected {len(observed)} {mode} host fact(s).",
+        ))
+
+    @blueprint.post("/clients/<path:identifier>/host-facts/baseline")
+    @_write_required
+    def baseline_host_facts(identifier):
+        import app as app_module
+
+        device = app_module.find_inventory_device(identifier) or {}
+        if not device:
+            return _error("Device was not found in inventory", 404)
+        actor = (session.get("social_user") or {}).get("username") or "unknown"
+        updated = host_facts.save_baseline(device, actor=actor)
+        _persist_device(app_module, identifier, updated)
+        app_module.append_client_timeline_event(
+            device.get("ip") or identifier,
+            "Host facts baseline saved",
+            (
+                f"Saved {len(updated.get('host_facts') or [])} fact(s) "
+                "as the comparison baseline."
+            ),
+            "host-facts",
+        )
+        app_module.record_social_audit(
+            "host-facts.baseline",
+            profile_id=str(identifier),
+            detail=f"facts={len(updated.get('host_facts') or [])}",
+        )
+        app_module.save_runtime_state("host-facts-baseline")
+        return redirect(url_for(
+            "host_facts.host_facts_page",
+            identifier=identifier,
+            message="Host facts baseline saved.",
+        ))
+
+    @blueprint.post(
+        "/clients/<path:identifier>/host-facts/credential-references"
+    )
+    @_write_required
+    def create_credential_reference(identifier):
+        user = session.get("social_user") or {}
+        if user.get("role") != "admin":
+            return _error("Administrator role required", 403)
+        try:
+            profile = host_facts.save_credential_reference(
+                _credential_path(),
+                name=request.form.get("name"),
+                kind=request.form.get("kind"),
+                secret_env=request.form.get("secretEnv"),
+                username=request.form.get("username"),
+                notes=request.form.get("notes"),
+                actor=user.get("username") or "unknown",
+            )
+        except ValueError as exc:
+            return redirect(url_for(
+                "host_facts.host_facts_page",
+                identifier=identifier,
+                error=str(exc),
+            ))
+        return redirect(url_for(
+            "host_facts.host_facts_page",
+            identifier=identifier,
+            message=f"Credential reference {profile['name']} saved.",
+        ))
+
+    @blueprint.get("/clients/<path:identifier>/host-facts.json")
+    @_login_required
+    def export_host_facts(identifier):
+        import app as app_module
+
+        device = app_module.find_inventory_device(identifier) or {}
+        if not device:
+            return _error("Device was not found in inventory", 404)
+        return jsonify({
+            "schema": "mobile-router-host-facts-v1",
+            "exported_at": time.time(),
+            "identifier": identifier,
+            "device": {
+                "ip": device.get("ip"),
+                "mac": device.get("mac"),
+                "manufacturer": device.get("manufacturer"),
+                "model": device.get("model"),
+                "firmware": (
+                    device.get("firmware")
+                    or device.get("firmware_version")
+                ),
+            },
+            "facts": device.get("host_facts") or [],
+            "baseline": device.get("host_fact_baseline"),
+            "runs": device.get("host_fact_runs") or [],
+        })
+
+    return blueprint

--- a/services/host_facts.py
+++ b/services/host_facts.py
@@ -1,0 +1,927 @@
+"""Explainable host facts, bounded capability probes, baselines, and secret references."""
+
+from __future__ import annotations
+
+import base64
+import copy
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import shutil
+import socket
+import ssl
+import struct
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+from services import device_identification
+
+_MAX_TEXT = 4000
+_MAX_FACTS = 240
+_MAX_PORTS = 24
+_CREDENTIAL_KINDS = {"snmp-v2c", "ssh", "http-basic", "api-token"}
+_CONFIDENCE = {"low", "medium", "high", "very-high"}
+_SENSITIVITY = {"public", "internal", "sensitive"}
+
+
+def _clean(value, limit=_MAX_TEXT):
+    return str(value or "").strip()[:limit]
+
+
+def _value_text(value):
+    if isinstance(value, (dict, list, tuple, set)):
+        return json.dumps(value, sort_keys=True, default=str)[:_MAX_TEXT]
+    return _clean(value)
+
+
+def fact(
+    key,
+    label,
+    value,
+    source,
+    confidence="medium",
+    *,
+    category="identity",
+    sensitivity="internal",
+    observed_at=None,
+):
+    confidence = confidence if confidence in _CONFIDENCE else "medium"
+    sensitivity = sensitivity if sensitivity in _SENSITIVITY else "internal"
+    return {
+        "key": _clean(key, 180),
+        "label": _clean(label, 240),
+        "value": value,
+        "value_text": _value_text(value),
+        "source": _clean(source, 240),
+        "confidence": confidence,
+        "category": _clean(category, 80),
+        "sensitivity": sensitivity,
+        "observed_at": float(observed_at or time.time()),
+    }
+
+
+def _ipv6_addresses(device):
+    values = []
+    for field in ("ipv6", "ipv6_address", "ipv6_addresses"):
+        raw = (device or {}).get(field)
+        if isinstance(raw, str):
+            values.extend(part.strip() for part in raw.split(","))
+        elif isinstance(raw, (list, tuple, set)):
+            values.extend(str(item).strip() for item in raw)
+    for item in (device or {}).get("addresses") or []:
+        if isinstance(item, dict):
+            values.append(str(item.get("address") or item.get("ip") or "").strip())
+        else:
+            values.append(str(item).strip())
+    result = []
+    for value in values:
+        value = value.split("%", 1)[0]
+        try:
+            parsed = ipaddress.ip_address(value)
+        except ValueError:
+            continue
+        if parsed.version == 6 and str(parsed) not in result:
+            result.append(str(parsed))
+    return result[:12]
+
+
+def _open_ports(device):
+    ports = []
+    for item in (device or {}).get("open_port_details") or []:
+        try:
+            port = int(item.get("port"))
+        except (TypeError, ValueError, AttributeError):
+            continue
+        if 1 <= port <= 65535 and port not in ports:
+            ports.append(port)
+    return ports[:_MAX_PORTS]
+
+
+def _local_default_gateways():
+    gateways = set()
+    commands = []
+    if os.name == "nt":
+        commands.append(["route", "print", "-4"])
+    else:
+        commands.extend([["ip", "route", "show", "default"], ["route", "-n"]])
+    for command in commands:
+        if not shutil.which(command[0]):
+            continue
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                timeout=4,
+                check=False,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        for token in re.findall(r"(?:\d{1,3}\.){3}\d{1,3}", result.stdout or ""):
+            try:
+                ipaddress.ip_address(token)
+            except ValueError:
+                continue
+            if token not in {"0.0.0.0", "255.255.255.255"}:
+                gateways.add(token)
+        if gateways:
+            break
+    return sorted(gateways)
+
+
+def infer_network_role(device):
+    ports = set(_open_ports(device))
+    host = str((device or {}).get("ip") or "")
+    gateways = _local_default_gateways()
+    evidence = []
+    scores = {}
+
+    def add(role, score, reason):
+        scores[role] = scores.get(role, 0) + score
+        evidence.append({"role": role, "reason": reason, "weight": score})
+
+    if host and host in gateways:
+        add("Default gateway/router", 70, "Host matches a local default gateway")
+    if 53 in ports:
+        add("DNS server", 30, "DNS port is open")
+    if ports & {67, 68}:
+        add("DHCP service", 35, "DHCP port is open")
+    if 53 in ports and ports & {67, 68}:
+        add("Default gateway/router", 30, "DNS and DHCP services are combined")
+    if ports & {445, 2049}:
+        add("File server/NAS", 35, "File-sharing service is exposed")
+    if ports & {631, 9100, 515}:
+        add("Printer", 50, "Print service is exposed")
+    if ports & {554, 8554}:
+        add("Camera/NVR", 50, "RTSP service is exposed")
+    if ports & {1883, 8883, 6053}:
+        add("IoT or automation endpoint", 40, "MQTT or automation service is exposed")
+    if 123 in ports:
+        add("Time server", 25, "NTP port is open")
+    if ports & {80, 443, 8443, 9443}:
+        add("Managed network appliance", 12, "Web management service is exposed")
+    guessed = ((device or {}).get("device_role_guess") or {}).get("role")
+    if guessed:
+        add(str(guessed), 20, "Existing device-role classifier")
+    if not scores:
+        return {"role": "Client/endpoint", "confidence": "low", "evidence": []}
+    role, score = max(scores.items(), key=lambda item: item[1])
+    confidence = (
+        "very-high" if score >= 80
+        else "high" if score >= 55
+        else "medium" if score >= 30
+        else "low"
+    )
+    return {
+        "role": role,
+        "confidence": confidence,
+        "score": min(100, score),
+        "evidence": [item for item in evidence if item["role"] == role],
+        "default_gateways": gateways,
+    }
+
+
+def passive_facts(device, *, relationships=None, passive_summary=None, now=None):
+    device = dict(device or {})
+    now = float(now or time.time())
+    facts = []
+    fields = (
+        ("identity.ipv4", "IPv4 address", device.get("ip"), "Inventory", "high", "address"),
+        ("identity.mac", "MAC address", device.get("mac") or device.get("address"), "Inventory", "high", "address"),
+        ("identity.manufacturer", "Manufacturer", device.get("manufacturer"), "OUI/inventory", "medium", "identity"),
+        ("identity.model", "Model", device.get("model") or device.get("model_name"), "Discovery/model profile", "high", "identity"),
+        ("identity.hardware", "Hardware revision", device.get("hardware_revision"), "Discovery/model profile", "high", "lifecycle"),
+        ("identity.firmware", "Firmware", device.get("firmware") or device.get("firmware_version"), "Discovery/model profile", "high", "lifecycle"),
+    )
+    for item_key, label, value, source, confidence, category in fields:
+        if value not in (None, "", "Unknown"):
+            facts.append(fact(item_key, label, value, source, confidence, category=category))
+    names = []
+    for field_name in ("hostname", "name", "display_name", "detected_display_name"):
+        if device.get(field_name):
+            names.append(str(device[field_name]))
+    names.extend(
+        str(item.get("name"))
+        for item in device.get("observed_names") or []
+        if isinstance(item, dict) and item.get("name")
+    )
+    if names:
+        facts.append(fact(
+            "identity.names",
+            "Observed names",
+            sorted(set(names))[:16],
+            "Inventory/DNS/DHCP",
+            "high",
+            category="identity",
+        ))
+    ipv6 = _ipv6_addresses(device)
+    if ipv6:
+        facts.append(fact(
+            "identity.ipv6",
+            "IPv6 addresses",
+            ipv6,
+            "Inventory/neighbor discovery",
+            "high",
+            category="address",
+        ))
+    if device.get("likely_randomized_mac"):
+        facts.append(fact(
+            "identity.private_mac",
+            "Private/randomized MAC",
+            True,
+            "MAC bit analysis",
+            "high",
+            category="limitation",
+        ))
+    if device.get("interfaces"):
+        facts.append(fact(
+            "network.interfaces",
+            "Observed interfaces",
+            device["interfaces"],
+            "Inventory",
+            "high",
+            category="network",
+        ))
+    if device.get("sources"):
+        facts.append(fact(
+            "network.discovery_sources",
+            "Discovery sources",
+            device["sources"],
+            "Inventory",
+            "high",
+            category="network",
+        ))
+    open_ports = _open_ports(device)
+    facts.append(fact(
+        "services.open_port_count",
+        "Saved open-port count",
+        len(open_ports),
+        "Saved service profile",
+        "high",
+        category="services",
+    ))
+    if open_ports:
+        facts.append(fact(
+            "services.open_ports",
+            "Saved open ports",
+            open_ports,
+            "Saved service profile",
+            "high",
+            category="services",
+        ))
+    first_seen = device.get("first_seen")
+    last_seen = device.get("last_seen")
+    if first_seen:
+        facts.append(fact(
+            "stability.first_seen",
+            "First observed",
+            float(first_seen),
+            "Inventory timeline",
+            "high",
+            category="stability",
+        ))
+    if last_seen:
+        facts.append(fact(
+            "stability.last_seen",
+            "Last observed",
+            float(last_seen),
+            "Inventory timeline",
+            "high",
+            category="stability",
+        ))
+    if first_seen and last_seen and last_seen >= first_seen:
+        facts.append(fact(
+            "stability.observation_window_seconds",
+            "Observed over at least",
+            int(last_seen - first_seen),
+            "Inventory timeline; not device uptime",
+            "low",
+            category="uptime",
+        ))
+    role = infer_network_role(device)
+    facts.append(fact(
+        "network.inferred_role",
+        "Inferred network role",
+        role,
+        "Role evidence",
+        role["confidence"],
+        category="network",
+    ))
+    if relationships:
+        facts.append(fact(
+            "network.relationship_counts",
+            "Known relationships",
+            {
+                "nodes": len((relationships or {}).get("nodes") or []),
+                "links": len((relationships or {}).get("links") or []),
+            },
+            "Relationship map",
+            "medium",
+            category="relationships",
+        ))
+    summaries = passive_summary or {}
+    if isinstance(summaries, dict):
+        target_ip = str(device.get("ip") or "")
+        target_mac = str(device.get("mac") or "").casefold()
+        matches = []
+        collection = (
+            summaries.values()
+            if summaries and "interface" not in summaries
+            else [summaries]
+        )
+        for summary in collection:
+            if not isinstance(summary, dict):
+                continue
+            states = (
+                ("active", summary.get("active_devices")),
+                ("quiet", summary.get("recently_disappeared")),
+            )
+            for state, items in states:
+                for item in items or []:
+                    if (
+                        str(item.get("ip") or "") == target_ip
+                        or str(item.get("mac") or "").casefold() == target_mac
+                    ):
+                        matches.append({
+                            "interface": summary.get("interface"),
+                            "state": state,
+                            "seen_count": item.get("seen_count"),
+                            "first_seen": item.get("first_seen"),
+                            "last_seen": item.get("last_seen"),
+                        })
+        if matches:
+            facts.append(fact(
+                "behaviour.passive_presence",
+                "Passive presence",
+                matches,
+                "Passive observation analytics",
+                "medium",
+                category="behaviour",
+            ))
+    return facts[:_MAX_FACTS]
+
+
+def _ssh_banner(host, port):
+    try:
+        with socket.create_connection((host, int(port)), timeout=2) as sock:
+            sock.settimeout(2)
+            return _clean(sock.recv(512).decode("latin-1", errors="ignore"), 500)
+    except OSError:
+        return ""
+
+
+def _ssh_host_keys(host, port):
+    tool = shutil.which("ssh-keyscan")
+    if not tool:
+        return {"available": False, "keys": []}
+    try:
+        result = subprocess.run(
+            [tool, "-T", "3", "-p", str(port), host],
+            capture_output=True,
+            text=True,
+            timeout=6,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": True, "error": _clean(exc), "keys": []}
+    keys = []
+    for line in (result.stdout or "").splitlines():
+        if not line or line.startswith("#"):
+            continue
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        try:
+            raw = base64.b64decode(parts[2] + "===")
+            fingerprint = base64.b64encode(hashlib.sha256(raw).digest()).decode().rstrip("=")
+        except (ValueError, TypeError):
+            fingerprint = ""
+        keys.append({"type": parts[1], "sha256": fingerprint})
+    return {"available": True, "keys": keys[:12], "returncode": result.returncode}
+
+
+def _tls_posture(host, port):
+    try:
+        context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        context.check_hostname = False
+        context.verify_mode = ssl.CERT_NONE
+        with socket.create_connection((host, int(port)), timeout=3) as raw:
+            with context.wrap_socket(raw, server_hostname=host) as wrapped:
+                cert_der = wrapped.getpeercert(binary_form=True) or b""
+                cipher = wrapped.cipher()
+                return {
+                    "protocol": wrapped.version(),
+                    "cipher": cipher[0] if cipher else None,
+                    "cipher_bits": cipher[2] if cipher else None,
+                    "certificate_sha256": hashlib.sha256(cert_der).hexdigest() if cert_der else None,
+                    "compression": wrapped.compression(),
+                    "alpn": wrapped.selected_alpn_protocol(),
+                }
+    except (OSError, ssl.SSLError, ValueError) as exc:
+        return {"error": _clean(exc, 500)}
+
+
+def _nmap_script(host, port, scripts):
+    tool = shutil.which("nmap")
+    if not tool:
+        return {"available": False, "message": "nmap is not installed"}
+    try:
+        result = subprocess.run(
+            [
+                tool,
+                "-Pn",
+                "-p",
+                str(port),
+                "--script",
+                ",".join(scripts),
+                "--host-timeout",
+                "20s",
+                host,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=24,
+            check=False,
+        )
+        return {
+            "available": True,
+            "returncode": result.returncode,
+            "output": _clean(result.stdout or result.stderr, 8000),
+        }
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"available": True, "error": _clean(exc)}
+
+
+def _ntp_probe(host, port=123):
+    packet = b"\x1b" + 47 * b"\0"
+    started = time.time()
+    try:
+        family = socket.AF_INET6 if ":" in host else socket.AF_INET
+        with socket.socket(family, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(2)
+            sock.sendto(packet, (host, int(port)))
+            data, _ = sock.recvfrom(512)
+        elapsed_ms = round((time.time() - started) * 1000, 2)
+        if len(data) < 48:
+            return {"error": "Short NTP response", "response_bytes": len(data)}
+        words = struct.unpack("!12I", data[:48])
+        seconds = words[10] - 2208988800
+        fraction = words[11] / 2**32
+        remote_time = seconds + fraction
+        return {
+            "stratum": data[1],
+            "version": (data[0] >> 3) & 7,
+            "mode": data[0] & 7,
+            "remote_unix_time": remote_time,
+            "clock_offset_seconds": round(remote_time - time.time(), 3),
+            "round_trip_ms": elapsed_ms,
+        }
+    except OSError as exc:
+        return {"error": _clean(exc)}
+
+
+def _dns_version_probe(host, port=53):
+    transaction = 0x4D52
+    header = struct.pack("!HHHHHH", transaction, 0x0100, 1, 0, 0, 0)
+    name = (
+        b"".join(
+            bytes([len(part)]) + part.encode("ascii")
+            for part in "version.bind".split(".")
+        )
+        + b"\0"
+    )
+    packet = header + name + struct.pack("!HH", 16, 3)
+    try:
+        family = socket.AF_INET6 if ":" in host else socket.AF_INET
+        with socket.socket(family, socket.SOCK_DGRAM) as sock:
+            sock.settimeout(2)
+            sock.sendto(packet, (host, int(port)))
+            data, _ = sock.recvfrom(2048)
+        if len(data) < 12:
+            return {"error": "Short DNS response"}
+        response_id, flags, qd, an, ns, ar = struct.unpack("!HHHHHH", data[:12])
+        printable = re.findall(rb"[ -~]{4,}", data[12:])
+        return {
+            "responded": response_id == transaction,
+            "rcode": flags & 0x000F,
+            "authoritative": bool(flags & 0x0400),
+            "recursive_available": bool(flags & 0x0080),
+            "answers": an,
+            "printable_hints": [
+                item.decode("latin-1", errors="ignore")[:160]
+                for item in printable[:6]
+            ],
+            "counts": {"questions": qd, "authority": ns, "additional": ar},
+        }
+    except OSError as exc:
+        return {"error": _clean(exc)}
+
+
+def _ipv6_exposure(device, ports):
+    results = []
+    for address in _ipv6_addresses(device)[:4]:
+        for port in list(ports)[:12]:
+            try:
+                with socket.create_connection((address, int(port)), timeout=0.75):
+                    results.append({
+                        "address": address,
+                        "port": int(port),
+                        "reachable": True,
+                    })
+            except OSError:
+                continue
+    return results
+
+
+def safe_facts(device, host, *, base_fingerprints=None):
+    device = dict(device or {})
+    host = str(host or "").strip()
+    if not host:
+        raise ValueError("A host is required")
+    observed = []
+    safe = device_identification.supplement_service_probes(
+        device,
+        host,
+        base_fingerprints=base_fingerprints,
+    )
+    for finding in safe.get("services") or []:
+        port = finding.get("port")
+        for name in ("banner", "http", "tls", "rtsp", "mqtt", "netbios"):
+            value = finding.get(name)
+            if value not in (None, "", [], {}):
+                observed.append(fact(
+                    f"service.{port}.{name}",
+                    f"{name.upper()} evidence on {port}/tcp",
+                    value,
+                    "Bounded service negotiation",
+                    "high" if name in {"tls", "rtsp", "mqtt", "netbios"} else "medium",
+                    category="protocol",
+                ))
+    for index, description in enumerate(safe.get("upnp") or []):
+        if description:
+            observed.append(fact(
+                f"discovery.upnp.{index}",
+                "UPnP device description",
+                description,
+                "Same-device UPnP description",
+                "high",
+                category="identity",
+                sensitivity=(
+                    "sensitive" if description.get("serial_number") else "internal"
+                ),
+            ))
+    details = device.get("open_port_details") or []
+    for detail in details[:_MAX_PORTS]:
+        try:
+            port = int(detail.get("port"))
+        except (TypeError, ValueError):
+            continue
+        service = str(detail.get("service") or "").casefold()
+        if port == 22 or "ssh" in service:
+            banner = _ssh_banner(host, port)
+            if banner:
+                observed.append(fact(
+                    "protocol.ssh.banner",
+                    "SSH banner",
+                    banner,
+                    f"SSH {port}/tcp",
+                    "high",
+                    category="ssh",
+                ))
+            keys = _ssh_host_keys(host, port)
+            observed.append(fact(
+                "protocol.ssh.host_keys",
+                "SSH host keys",
+                keys,
+                f"ssh-keyscan {port}/tcp",
+                "high" if keys.get("keys") else "low",
+                category="ssh",
+                sensitivity="sensitive",
+            ))
+            algos = _nmap_script(
+                host,
+                port,
+                ["ssh2-enum-algos", "ssh-hostkey"],
+            )
+            observed.append(fact(
+                "protocol.ssh.algorithms",
+                "SSH algorithms and host keys",
+                algos,
+                "Nmap safe SSH scripts",
+                "high" if algos.get("output") else "low",
+                category="ssh",
+                sensitivity="sensitive",
+            ))
+        if (
+            port in {443, 465, 636, 853, 993, 995, 8443, 8883, 9443}
+            or any(word in service for word in ("https", "ssl", "tls"))
+        ):
+            posture = _tls_posture(host, port)
+            observed.append(fact(
+                f"protocol.tls.{port}",
+                f"TLS posture on {port}/tcp",
+                posture,
+                "TLS handshake",
+                "high" if not posture.get("error") else "low",
+                category="tls",
+                sensitivity="sensitive",
+            ))
+    ports = _open_ports(device)
+    if 445 in ports or 139 in ports:
+        smb_port = 445 if 445 in ports else 139
+        smb = _nmap_script(
+            host,
+            smb_port,
+            ["smb-protocols", "smb2-security-mode", "smb2-capabilities"],
+        )
+        observed.append(fact(
+            "protocol.smb.capabilities",
+            "SMB capabilities",
+            smb,
+            "Nmap safe SMB negotiation",
+            "high" if smb.get("output") else "low",
+            category="smb",
+            sensitivity="sensitive",
+        ))
+    if 123 in ports:
+        ntp = _ntp_probe(host)
+        observed.append(fact(
+            "protocol.ntp",
+            "NTP response and clock offset",
+            ntp,
+            "NTP client query",
+            "high" if not ntp.get("error") else "low",
+            category="time",
+        ))
+    if 53 in ports:
+        dns = _dns_version_probe(host)
+        observed.append(fact(
+            "protocol.dns",
+            "DNS server behaviour",
+            dns,
+            "CHAOS TXT version.bind query",
+            "medium" if not dns.get("error") else "low",
+            category="dns",
+        ))
+    ipv6 = _ipv6_exposure(device, ports)
+    if _ipv6_addresses(device):
+        observed.append(fact(
+            "network.ipv6_exposure",
+            "Known services reachable over IPv6",
+            ipv6,
+            "Bounded TCP connection checks",
+            "high" if ipv6 else "medium",
+            category="ipv6",
+        ))
+    return observed[:_MAX_FACTS]
+
+
+def _parse_snmp_uptime(output):
+    text = str(output or "")
+    match = re.search(
+        r"(?:sysUpTime|1\.3\.6\.1\.2\.1\.1\.3\.0).*?"
+        r"(?:Timeticks:\s*\((\d+)\)|INTEGER:\s*(\d+))",
+        text,
+        re.I,
+    )
+    if not match:
+        return None
+    ticks = int(match.group(1) or match.group(2))
+    return {"timeticks": ticks, "seconds": round(ticks / 100, 2)}
+
+
+def deep_facts(device, host, *, authorized=False, snmp_community=None):
+    ports = _open_ports(device)
+    deep = device_identification.deep_device_probe(
+        host,
+        ports,
+        authorized=authorized,
+        snmp_community=snmp_community,
+    )
+    observed = []
+    nmap = deep.get("nmap") or {}
+    observed.append(fact(
+        "deep.nmap",
+        "Nmap OS and service identification",
+        nmap,
+        "Authorized bounded Nmap",
+        "high" if nmap.get("output") else "low",
+        category="deep",
+        sensitivity="sensitive",
+    ))
+    snmp = deep.get("snmp") or {}
+    observed.append(fact(
+        "deep.snmp",
+        "SNMP system information",
+        snmp,
+        "Authorized read-only SNMP",
+        "very-high" if snmp.get("output") else "low",
+        category="deep",
+        sensitivity="sensitive",
+    ))
+    uptime = _parse_snmp_uptime(snmp.get("output"))
+    if uptime:
+        observed.append(fact(
+            "uptime.snmp",
+            "Device uptime",
+            uptime,
+            "SNMP sysUpTime",
+            "very-high",
+            category="uptime",
+        ))
+    return observed
+
+
+def _baseline_map(baseline):
+    if isinstance(baseline, dict):
+        items = baseline.get("facts") or []
+    else:
+        items = baseline or []
+    return {
+        str(item.get("key")): item
+        for item in items
+        if isinstance(item, dict) and item.get("key")
+    }
+
+
+def merge_facts(existing, observed, *, baseline=None, now=None):
+    now = float(now or time.time())
+    current = {
+        str(item.get("key")): dict(item)
+        for item in existing or []
+        if isinstance(item, dict) and item.get("key")
+    }
+    baseline_items = _baseline_map(baseline)
+    for raw in observed or []:
+        item = dict(raw)
+        item_key = str(item.get("key") or "").strip()
+        if not item_key:
+            continue
+        previous = current.get(item_key) or {}
+        value_text = _value_text(item.get("value"))
+        item["value_text"] = value_text
+        item["first_seen"] = previous.get(
+            "first_seen",
+            item.get("first_seen", item.get("observed_at", now)),
+        )
+        item["last_seen"] = item.get(
+            "last_seen",
+            item.get("observed_at", now),
+        )
+        if previous and previous.get("value_text") != value_text:
+            item["previous_value"] = previous.get("value")
+            item["changed_at"] = now
+        baseline_item = baseline_items.get(item_key)
+        item["changed_since_baseline"] = bool(
+            baseline_item
+            and _value_text(baseline_item.get("value")) != value_text
+        )
+        current[item_key] = item
+    return sorted(
+        current.values(),
+        key=lambda item: (item.get("category", ""), item.get("label", "")),
+    )[:_MAX_FACTS]
+
+
+def apply_fact_run(device, facts, *, mode, actor="unknown", now=None):
+    now = float(now or time.time())
+    updated = copy.deepcopy(device or {})
+    updated["host_facts"] = merge_facts(
+        updated.get("host_facts") or [],
+        facts,
+        baseline=updated.get("host_fact_baseline"),
+        now=now,
+    )
+    runs = list(updated.get("host_fact_runs") or [])
+    runs.insert(0, {
+        "mode": _clean(mode, 32),
+        "actor": _clean(actor, 120),
+        "timestamp": now,
+        "fact_count": len(facts or []),
+        "changed_count": len([
+            item
+            for item in updated["host_facts"]
+            if item.get("changed_since_baseline")
+        ]),
+    })
+    updated["host_fact_runs"] = runs[:30]
+    updated["host_facts_updated_at"] = now
+    return updated
+
+
+def save_baseline(device, *, actor="unknown", now=None):
+    now = float(now or time.time())
+    updated = copy.deepcopy(device or {})
+    updated["host_fact_baseline"] = {
+        "saved_at": now,
+        "saved_by": _clean(actor, 120),
+        "facts": copy.deepcopy(updated.get("host_facts") or []),
+    }
+    updated["host_facts"] = merge_facts(
+        [],
+        updated.get("host_facts") or [],
+        baseline=updated["host_fact_baseline"],
+        now=now,
+    )
+    return updated
+
+
+def capabilities():
+    return {
+        "nmap": bool(shutil.which("nmap")),
+        "ssh_keyscan": bool(shutil.which("ssh-keyscan")),
+        "snmpwalk": bool(shutil.which("snmpwalk")),
+        "safe_protocols": [
+            "HTTP",
+            "TLS",
+            "SSH",
+            "SMB",
+            "IPP",
+            "NTP",
+            "DNS",
+            "RTSP",
+            "MQTT",
+            "UPnP",
+        ],
+        "credential_policy": (
+            "Only environment-variable references are persisted; secret values "
+            "are never written to inventory or credential files."
+        ),
+    }
+
+
+def load_credential_references(path):
+    path = Path(path)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return []
+    items = payload.get("profiles") if isinstance(payload, dict) else []
+    return [dict(item) for item in items or [] if isinstance(item, dict)][:100]
+
+
+def save_credential_reference(
+    path,
+    *,
+    name,
+    kind,
+    secret_env,
+    username="",
+    notes="",
+    actor="unknown",
+):
+    name = _clean(name, 160)
+    kind = _clean(kind, 40).casefold()
+    secret_env = _clean(secret_env, 128)
+    if not name:
+        raise ValueError("Credential profile name is required")
+    if kind not in _CREDENTIAL_KINDS:
+        raise ValueError("Credential type is not supported")
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]{0,127}", secret_env):
+        raise ValueError("Secret environment variable name is invalid")
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    profiles = load_credential_references(path)
+    profile = {
+        "id": uuid.uuid4().hex,
+        "name": name,
+        "kind": kind,
+        "username": _clean(username, 160),
+        "secret_env": secret_env,
+        "notes": _clean(notes, 1000),
+        "created_at": time.time(),
+        "created_by": _clean(actor, 120),
+    }
+    profiles.append(profile)
+    temporary = path.with_suffix(path.suffix + ".tmp")
+    temporary.write_text(
+        json.dumps(
+            {
+                "schema": "mobile-router-host-credential-references-v1",
+                "profiles": profiles,
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    temporary.replace(path)
+    return profile
+
+
+def credential_reference(profiles, profile_id):
+    for item in profiles or []:
+        if str(item.get("id")) == str(profile_id):
+            return dict(item)
+    return None
+
+
+def resolve_secret(profile, environ=None):
+    if not profile:
+        return ""
+    environ = os.environ if environ is None else environ
+    return str(environ.get(str(profile.get("secret_env") or ""), ""))

--- a/static/js/host-facts.js
+++ b/static/js/host-facts.js
@@ -1,0 +1,18 @@
+$(document).ready(function () {
+  const tools = $('[data-ip-client-tools]');
+  const host = tools.data('host');
+  if (!host || $('[data-host-facts-link]').length) {
+    return;
+  }
+  const actions = $('[data-ip-client-intelligence]').closest('.theme-actions');
+  if (!actions.length) {
+    return;
+  }
+  const link = $('<a>', {
+    class: 'btn btn-outline-primary',
+    href: `/clients/${encodeURIComponent(host)}/host-facts`,
+    text: 'Host facts & capabilities',
+    'data-host-facts-link': 'true'
+  });
+  actions.append(link);
+});

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -10,4 +10,5 @@
 <script src="/static/js/device-identification.js"></script>
 <script src="/static/js/port-knowledge.js"></script>
 <script src="/static/js/model-profiles.js"></script>
+<script src="/static/js/host-facts.js"></script>
 

--- a/templates/host_facts.html
+++ b/templates/host_facts.html
@@ -1,0 +1,206 @@
+{% include '_header.html' %}
+<link rel="stylesheet" href="/static/css/interface.css">
+<body class="d-flex flex-column min-vh-100">
+  <main class="theme-page container py-4">
+    <section class="page-hero">
+      <div class="page-hero-copy">
+        <p class="page-kicker">Host Intelligence</p>
+        <h1 class="page-title">Host Facts &amp; Capabilities</h1>
+        <p class="page-subtitle">
+          {% if device %}
+            Explainable observations for {{ device.display_name or device.name or device.ip or identifier }}. Every fact records its source, confidence, history, baseline state, and sensitivity.
+          {% else %}
+            The requested device is not available in inventory.
+          {% endif %}
+        </p>
+      </div>
+      {% if device %}
+        <div class="theme-actions">
+          <a class="btn btn-outline-secondary" href="/clients/{{ (device.ip or identifier)|urlencode }}">Back to device</a>
+          <a class="btn btn-outline-primary" href="/clients/{{ identifier|urlencode }}/host-facts.json">Export JSON</a>
+        </div>
+      {% endif %}
+    </section>
+
+    {% if error %}<div class="alert alert-danger mt-3" role="alert">{{ error }}</div>{% endif %}
+    {% if message %}<div class="alert alert-success mt-3" role="alert">{{ message }}</div>{% endif %}
+
+    {% if device %}
+      <section class="theme-card card mt-3">
+        <div class="card-body">
+          <div class="d-flex justify-content-between align-items-start flex-wrap">
+            <div>
+              <h2 class="theme-section-title">Acquisition levels</h2>
+              <p class="text-muted">Begin passively, then opt into bounded protocol negotiation or administrator-only deep identification when appropriate.</p>
+            </div>
+            {% if device.host_fact_baseline.saved_at_label %}
+              <span class="badge badge-info p-2">Baseline {{ device.host_fact_baseline.saved_at_label }}</span>
+            {% else %}
+              <span class="badge badge-light border p-2">No fact baseline</span>
+            {% endif %}
+          </div>
+
+          <div class="theme-grid">
+            <article class="port-service-card">
+              <strong>1. Passive facts</strong>
+              <span>No packets sent</span>
+              <small>Names, addresses, model data, role inference, observation window, relationships, and passive-presence history.</small>
+              <form method="post" action="/clients/{{ identifier|urlencode }}/host-facts/collect" class="mt-2">
+                <input type="hidden" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
+                <input type="hidden" name="mode" value="passive">
+                <button class="btn btn-outline-primary btn-sm" type="submit">Collect passive facts</button>
+              </form>
+            </article>
+
+            <article class="port-service-card">
+              <strong>2. Safe negotiation</strong>
+              <span>Saved open ports only</span>
+              <small>HTTP/TLS, SSH keys and algorithms, SMB posture, IPP/web evidence, NTP, DNS, RTSP, MQTT, UPnP, and IPv6 reachability.</small>
+              <form method="post" action="/clients/{{ identifier|urlencode }}/host-facts/collect" class="mt-2">
+                <input type="hidden" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
+                <input type="hidden" name="mode" value="safe">
+                <label class="form-check small">
+                  <input class="form-check-input" type="checkbox" name="authorized" required>
+                  <span class="form-check-label">I am authorised to negotiate services on this host.</span>
+                </label>
+                <button class="btn btn-outline-success btn-sm" type="submit">Run safe negotiation</button>
+              </form>
+            </article>
+
+            <article class="port-service-card">
+              <strong>3. Deep identification</strong>
+              <span>Administrator only</span>
+              <small>Bounded Nmap OS/service identification and optional read-only SNMP system information.</small>
+              {% if app_user and app_user.role == 'admin' %}
+                <form method="post" action="/clients/{{ identifier|urlencode }}/host-facts/collect" class="mt-2">
+                  <input type="hidden" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
+                  <input type="hidden" name="mode" value="deep">
+                  <label for="host-fact-credential">Credential reference</label>
+                  <select id="host-fact-credential" class="form-control form-control-sm mb-2" name="credentialProfile">
+                    <option value="">No credential profile</option>
+                    {% for profile in credential_profiles %}
+                      <option value="{{ profile.id }}">{{ profile.name }} · {{ profile.kind }} · {{ profile.secret_env }}</option>
+                    {% endfor %}
+                  </select>
+                  <label class="form-check small">
+                    <input class="form-check-input" type="checkbox" name="authorized" required>
+                    <span class="form-check-label">I am authorised to run bounded deep identification.</span>
+                  </label>
+                  <button class="btn btn-outline-danger btn-sm" type="submit">Run deep identification</button>
+                </form>
+              {% else %}
+                <small class="text-muted">Sign in as an administrator to run deep identification.</small>
+              {% endif %}
+            </article>
+
+            <article class="port-service-card">
+              <strong>4. Authenticated sources</strong>
+              <span>Secret references only</span>
+              <small>{{ capabilities.credential_policy }}</small>
+              {% if app_user and app_user.role == 'admin' %}
+                <a class="btn btn-outline-secondary btn-sm mt-2" href="#credential-references">Manage references</a>
+              {% endif %}
+            </article>
+          </div>
+
+          <div class="theme-actions mt-3">
+            <form method="post" action="/clients/{{ identifier|urlencode }}/host-facts/baseline">
+              <input type="hidden" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
+              <button class="btn btn-primary" type="submit" {% if not facts %}disabled{% endif %}>Save current facts as baseline</button>
+            </form>
+          </div>
+        </div>
+      </section>
+
+      <section class="theme-card card mt-3">
+        <div class="card-body">
+          <h2 class="theme-section-title">Current summary</h2>
+          <div class="theme-grid">
+            <article class="port-service-card"><strong>{{ summary.total }}</strong><span>Facts retained</span><small>Across passive, safe, and deep sources.</small></article>
+            <article class="port-service-card"><strong>{{ summary.high_confidence }}</strong><span>High-confidence facts</span><small>High or very-high confidence.</small></article>
+            <article class="port-service-card"><strong>{{ summary.changed }}</strong><span>Changed from baseline</span><small>Value differs from the saved host-facts baseline.</small></article>
+            <article class="port-service-card"><strong>{{ summary.sensitive }}</strong><span>Sensitive facts</span><small>Keys, certificates, serials, or management metadata.</small></article>
+          </div>
+          <div class="network-device-tags mt-3">
+            <span class="badge badge-{{ 'success' if capabilities.nmap else 'secondary' }}">Nmap {{ 'available' if capabilities.nmap else 'missing' }}</span>
+            <span class="badge badge-{{ 'success' if capabilities.ssh_keyscan else 'secondary' }}">ssh-keyscan {{ 'available' if capabilities.ssh_keyscan else 'missing' }}</span>
+            <span class="badge badge-{{ 'success' if capabilities.snmpwalk else 'secondary' }}">snmpwalk {{ 'available' if capabilities.snmpwalk else 'missing' }}</span>
+          </div>
+        </div>
+      </section>
+
+      <section class="theme-card card mt-3">
+        <div class="card-body">
+          <h2 class="theme-section-title">Facts</h2>
+          <p class="text-muted">A changed marker means the current value differs from the explicitly saved host-facts baseline, not merely from the previous scan.</p>
+          <div class="table-responsive">
+            <table class="table table-hover">
+              <thead><tr><th>Fact</th><th>Value</th><th>Source</th><th>Confidence</th><th>History</th></tr></thead>
+              <tbody>
+                {% for item in facts %}
+                  <tr class="{{ 'table-warning' if item.changed_since_baseline else '' }}">
+                    <td>
+                      <strong>{{ item.label }}</strong><br>
+                      <small>{{ item.category }} · {{ item.sensitivity }}</small>
+                      {% if item.changed_since_baseline %}<span class="badge badge-warning">Changed</span>{% endif %}
+                    </td>
+                    <td><pre class="interface-pre mb-0">{{ item.value_text }}</pre></td>
+                    <td>{{ item.source }}</td>
+                    <td><span class="badge badge-{{ 'success' if item.confidence in ['high', 'very-high'] else 'warning' if item.confidence == 'medium' else 'secondary' }}">{{ item.confidence }}</span></td>
+                    <td><small>First {{ item.first_seen_label }}<br>Last {{ item.last_seen_label }}</small></td>
+                  </tr>
+                {% else %}
+                  <tr><td colspan="5" class="text-muted">No host facts have been collected yet. Passive collection is the safest starting point.</td></tr>
+                {% endfor %}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </section>
+
+      <section class="theme-card card mt-3">
+        <div class="card-body">
+          <h2 class="theme-section-title">Collection history</h2>
+          <ol class="client-timeline">
+            {% for run in device.host_fact_runs %}
+              <li><strong>{{ run.time_label }}</strong> — {{ run.mode }} collection by {{ run.actor }}<p class="mb-0">{{ run.fact_count }} fact(s) collected; {{ run.changed_count }} currently differ from baseline.</p></li>
+            {% else %}
+              <li class="text-muted">No host-facts collection runs have been recorded.</li>
+            {% endfor %}
+          </ol>
+        </div>
+      </section>
+
+      {% if app_user and app_user.role == 'admin' %}
+        <section class="theme-card card mt-3" id="credential-references">
+          <div class="card-body">
+            <h2 class="theme-section-title">Credential references</h2>
+            <p class="text-muted">Only an environment-variable name is persisted. The secret value stays outside inventory, exports, logs, and this JSON reference file.</p>
+            <form class="theme-form" method="post" action="/clients/{{ identifier|urlencode }}/host-facts/credential-references">
+              <input type="hidden" name="csrf_token" value="{{ session.get('social_csrf_token', '') }}">
+              <div class="form-row">
+                <div class="col-md-4"><label for="credential-name">Profile name</label><input id="credential-name" class="form-control" name="name" maxlength="160" required placeholder="Lab router SNMP"></div>
+                <div class="col-md-3"><label for="credential-kind">Type</label><select id="credential-kind" class="form-control" name="kind"><option value="snmp-v2c">SNMP v2c</option><option value="ssh">SSH</option><option value="http-basic">HTTP Basic</option><option value="api-token">API token</option></select></div>
+                <div class="col-md-5"><label for="credential-secret-env">Secret environment variable</label><input id="credential-secret-env" class="form-control" name="secretEnv" required placeholder="MOBILE_ROUTER_SKY_SNMP_COMMUNITY"></div>
+              </div>
+              <div class="form-row mt-2">
+                <div class="col-md-4"><label for="credential-username">Username, when applicable</label><input id="credential-username" class="form-control" name="username"></div>
+                <div class="col-md-8"><label for="credential-notes">Notes</label><input id="credential-notes" class="form-control" name="notes" placeholder="Read-only account; lab VLAN only"></div>
+              </div>
+              <div class="theme-actions"><button class="btn btn-primary" type="submit">Save credential reference</button></div>
+            </form>
+            <div class="theme-grid mt-3">
+              {% for profile in credential_profiles %}
+                <article class="port-service-card"><strong>{{ profile.name }}</strong><span>{{ profile.kind }}</span><small>Secret: {{ profile.secret_env }}{% if profile.username %} · User: {{ profile.username }}{% endif %}</small></article>
+              {% else %}
+                <p class="text-muted">No credential references are configured.</p>
+              {% endfor %}
+            </div>
+          </div>
+        </section>
+      {% endif %}
+    {% endif %}
+  </main>
+  {% include '_footer.html' %}
+</body>
+</html>

--- a/tests/test_host_facts.py
+++ b/tests/test_host_facts.py
@@ -1,0 +1,391 @@
+import json
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+import app as app_module
+from app import app
+from services import host_facts
+
+
+class HostFactsServiceTest(unittest.TestCase):
+    @patch(
+        "services.host_facts._local_default_gateways",
+        return_value=["192.0.2.1"],
+    )
+    def test_passive_facts_include_role_ipv6_and_stability(self, gateways):
+        device = {
+            "ip": "192.0.2.1",
+            "mac": "aa:bb:cc:dd:ee:ff",
+            "manufacturer": "Example Networks",
+            "model": "XR1",
+            "ipv6_addresses": ["2001:db8::1"],
+            "first_seen": 100.0,
+            "last_seen": 400.0,
+            "interfaces": ["wlan0"],
+            "sources": ["arp-scan"],
+            "open_port_details": [
+                {"port": 53, "service": "DNS"},
+                {"port": 67, "service": "DHCP"},
+                {"port": 443, "service": "HTTPS"},
+            ],
+        }
+
+        facts = host_facts.passive_facts(
+            device,
+            relationships={"nodes": [1, 2], "links": [1]},
+        )
+        by_key = {item["key"]: item for item in facts}
+
+        self.assertEqual(
+            by_key["network.inferred_role"]["value"]["role"],
+            "Default gateway/router",
+        )
+        self.assertEqual(
+            by_key["identity.ipv6"]["value"],
+            ["2001:db8::1"],
+        )
+        self.assertEqual(
+            by_key["stability.observation_window_seconds"]["value"],
+            300,
+        )
+        self.assertEqual(
+            by_key["network.relationship_counts"]["value"]["nodes"],
+            2,
+        )
+
+    def test_merge_marks_changes_against_explicit_baseline(self):
+        initial = [
+            host_facts.fact(
+                "identity.model",
+                "Model",
+                "XR1",
+                "UPnP",
+                "high",
+                observed_at=10,
+            )
+        ]
+        device = host_facts.apply_fact_run(
+            {},
+            initial,
+            mode="passive",
+            actor="tester",
+            now=10,
+        )
+        baseline = host_facts.save_baseline(
+            device,
+            actor="tester",
+            now=20,
+        )
+        changed = [
+            host_facts.fact(
+                "identity.model",
+                "Model",
+                "XR2",
+                "UPnP",
+                "high",
+                observed_at=30,
+            )
+        ]
+        updated = host_facts.apply_fact_run(
+            baseline,
+            changed,
+            mode="safe",
+            actor="tester",
+            now=30,
+        )
+
+        item = next(
+            item
+            for item in updated["host_facts"]
+            if item["key"] == "identity.model"
+        )
+        self.assertTrue(item["changed_since_baseline"])
+        self.assertEqual(item["previous_value"], "XR1")
+        self.assertEqual(updated["host_fact_runs"][0]["changed_count"], 1)
+
+    def test_credential_store_persists_reference_not_secret(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "credentials.json"
+            profile = host_facts.save_credential_reference(
+                path,
+                name="Router SNMP",
+                kind="snmp-v2c",
+                secret_env="TEST_ROUTER_SNMP",
+                username="readonly",
+                actor="tester",
+            )
+            raw = path.read_text(encoding="utf-8")
+            self.assertIn("TEST_ROUTER_SNMP", raw)
+            self.assertNotIn("super-secret", raw)
+            self.assertEqual(
+                host_facts.resolve_secret(
+                    profile,
+                    {"TEST_ROUTER_SNMP": "super-secret"},
+                ),
+                "super-secret",
+            )
+
+    @patch("services.host_facts.device_identification.deep_device_probe")
+    def test_deep_facts_extract_snmp_uptime(self, probe):
+        probe.return_value = {
+            "nmap": {"available": True, "output": "Running: Linux"},
+            "snmp": {
+                "available": True,
+                "output": (
+                    "SNMPv2-MIB::sysUpTime.0 = "
+                    "Timeticks: (123450) 0:20:34.50"
+                ),
+            },
+        }
+        facts = host_facts.deep_facts(
+            {"open_port_details": [{"port": 443}]},
+            "192.0.2.10",
+            authorized=True,
+            snmp_community="public",
+        )
+        uptime = next(
+            item for item in facts if item["key"] == "uptime.snmp"
+        )
+        self.assertEqual(uptime["value"]["seconds"], 1234.5)
+
+
+class HostFactsRouteTest(unittest.TestCase):
+    identifier = "192.0.2.77"
+    inventory_key = "ip:192.0.2.77"
+
+    def setUp(self):
+        self.client = app.test_client()
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.credential_path = Path(self.tempdir.name) / "credentials.json"
+        self.previous_users = dict(app_module.social_users)
+        app_module.social_users.clear()
+        app_module.social_users["test-admin"] = {
+            "id": "test-admin",
+            "username": "test-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        with app_module.device_inventory_lock:
+            self.previous_device = app_module.device_inventory.pop(
+                self.inventory_key,
+                None,
+            )
+            app_module.device_inventory[self.inventory_key] = {
+                "id": self.inventory_key,
+                "ip": self.identifier,
+                "mac": "aa:bb:cc:dd:ee:77",
+                "manufacturer": "Example Networks",
+                "model": "XR1",
+                "first_seen": 100.0,
+                "last_seen": 200.0,
+                "open_ports": [22, 443],
+                "open_port_details": [
+                    {
+                        "port": 22,
+                        "protocol": "tcp",
+                        "service": "SSH",
+                    },
+                    {
+                        "port": 443,
+                        "protocol": "tcp",
+                        "service": "HTTPS",
+                    },
+                ],
+            }
+        self.csrf = "host-facts-csrf"
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {
+                "username": "test-admin",
+                "role": "admin",
+            }
+            flask_session["social_csrf_token"] = self.csrf
+        self.path_patch = patch(
+            "routes.host_facts._credential_path",
+            return_value=self.credential_path,
+        )
+        self.path_patch.start()
+
+    def tearDown(self):
+        self.path_patch.stop()
+        self.tempdir.cleanup()
+        with app_module.device_inventory_lock:
+            app_module.device_inventory.pop(self.inventory_key, None)
+            if self.previous_device is not None:
+                app_module.device_inventory[self.inventory_key] = (
+                    self.previous_device
+                )
+        app_module.social_users.clear()
+        app_module.social_users.update(self.previous_users)
+
+    def test_workspace_renders_and_client_page_loads_entry_script(self):
+        response = self.client.get(
+            f"/clients/{self.identifier}/host-facts"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Host Facts &amp; Capabilities", response.data)
+        self.assertIn(b"Collect passive facts", response.data)
+
+        client_page = self.client.get(f"/clients/{self.identifier}")
+        self.assertEqual(client_page.status_code, 200)
+        self.assertIn(b"/static/js/host-facts.js", client_page.data)
+
+    @patch("routes.host_facts.host_facts.passive_facts")
+    @patch("app.save_runtime_state")
+    @patch("app.record_social_audit")
+    @patch("app.append_client_timeline_event")
+    def test_passive_collection_persists_facts(
+        self,
+        timeline,
+        audit,
+        save_state,
+        passive,
+    ):
+        passive.return_value = [
+            host_facts.fact(
+                "network.inferred_role",
+                "Role",
+                "Router",
+                "Test",
+                "high",
+            )
+        ]
+        response = self.client.post(
+            f"/clients/{self.identifier}/host-facts/collect",
+            data={"csrf_token": self.csrf, "mode": "passive"},
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b"Collected 1 passive host fact", response.data)
+        saved = app_module.find_inventory_device(self.identifier)
+        self.assertEqual(
+            saved["host_facts"][0]["key"],
+            "network.inferred_role",
+        )
+        save_state.assert_called_once_with("host-facts:passive")
+        timeline.assert_called_once()
+        audit.assert_called_once()
+
+    @patch("routes.host_facts.host_facts.safe_facts")
+    @patch("app.fingerprint_client_services", return_value=[])
+    @patch("app.save_runtime_state")
+    @patch("app.record_social_audit")
+    @patch("app.append_client_timeline_event")
+    def test_safe_collection_requires_authorization(
+        self,
+        timeline,
+        audit,
+        save_state,
+        fingerprints,
+        safe,
+    ):
+        denied = self.client.post(
+            f"/clients/{self.identifier}/host-facts/collect",
+            data={"csrf_token": self.csrf, "mode": "safe"},
+            follow_redirects=True,
+        )
+        self.assertIn(b"Confirm authorization", denied.data)
+        safe.assert_not_called()
+
+        safe.return_value = [
+            host_facts.fact(
+                "protocol.tls.443",
+                "TLS",
+                {"protocol": "TLSv1.3"},
+                "Test",
+                "high",
+            )
+        ]
+        allowed = self.client.post(
+            f"/clients/{self.identifier}/host-facts/collect",
+            data={
+                "csrf_token": self.csrf,
+                "mode": "safe",
+                "authorized": "on",
+            },
+            follow_redirects=True,
+        )
+        self.assertEqual(allowed.status_code, 200)
+        safe.assert_called_once()
+
+    @patch("app.save_runtime_state")
+    @patch("app.record_social_audit")
+    @patch("app.append_client_timeline_event")
+    def test_baseline_and_export(self, timeline, audit, save_state):
+        with app_module.device_inventory_lock:
+            app_module.device_inventory[self.inventory_key]["host_facts"] = [
+                host_facts.fact(
+                    "identity.model",
+                    "Model",
+                    "XR1",
+                    "Test",
+                    "high",
+                )
+            ]
+        response = self.client.post(
+            f"/clients/{self.identifier}/host-facts/baseline",
+            data={"csrf_token": self.csrf},
+            follow_redirects=True,
+        )
+        self.assertIn(b"Host facts baseline saved", response.data)
+        exported = self.client.get(
+            f"/clients/{self.identifier}/host-facts.json"
+        )
+        self.assertEqual(exported.status_code, 200)
+        payload = exported.get_json()
+        self.assertEqual(
+            payload["schema"],
+            "mobile-router-host-facts-v1",
+        )
+        self.assertIsNotNone(payload["baseline"])
+
+    def test_credential_reference_requires_csrf_and_does_not_store_secret(self):
+        invalid = self.client.post(
+            (
+                f"/clients/{self.identifier}/host-facts/"
+                "credential-references"
+            ),
+            data={
+                "csrf_token": "wrong",
+                "name": "Router SNMP",
+                "kind": "snmp-v2c",
+                "secretEnv": "TEST_ROUTER_SNMP",
+            },
+        )
+        self.assertEqual(invalid.status_code, 400)
+
+        with patch.dict(
+            os.environ,
+            {"TEST_ROUTER_SNMP": "super-secret"},
+        ):
+            valid = self.client.post(
+                (
+                    f"/clients/{self.identifier}/host-facts/"
+                    "credential-references"
+                ),
+                data={
+                    "csrf_token": self.csrf,
+                    "name": "Router SNMP",
+                    "kind": "snmp-v2c",
+                    "secretEnv": "TEST_ROUTER_SNMP",
+                },
+                follow_redirects=True,
+            )
+        self.assertEqual(valid.status_code, 200)
+        payload = json.loads(
+            self.credential_path.read_text(encoding="utf-8")
+        )
+        self.assertEqual(
+            payload["profiles"][0]["secret_env"],
+            "TEST_ROUTER_SNMP",
+        )
+        self.assertNotIn(
+            "super-secret",
+            self.credential_path.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- adds a per-device Host Facts & Capabilities workspace with passive, safe, deep, and authenticated-source acquisition levels
- records every fact with source, confidence, category, sensitivity, first/last observation, previous value, and baseline-change state
- adds passive role inference, IPv4/IPv6 identity, model/firmware/hardware facts, observation-window evidence, relationship counts, and passive-presence history
- adds bounded safe negotiation for existing open services, including HTTP/TLS, SSH banners and host keys, SSH algorithms, SMB posture, NTP, DNS, RTSP, MQTT, UPnP, and IPv6 reachability
- reuses the existing bounded Nmap/SNMP deep-identification workflow and extracts high-confidence SNMP uptime
- adds explicit host-facts baselines, collection history, and JSON export
- adds administrator-managed credential references that persist only environment-variable names; secret values are never written to inventory, exports, logs, or reference files
- adds a client-page entry point and cross-platform tests

## Safety boundaries

- passive collection sends no traffic
- safe negotiation requires explicit authorization and only touches saved open ports
- deep identification is administrator-only and requires explicit authorization
- credential secrets remain outside application state and are resolved from environment variables only at execution time

## Validation

Final GitHub Actions run `30808253754` passed on both platforms:

- Ubuntu: compile, application import, duplicate-code report, `394 passed, 1 skipped`
- Windows: compile, application import, duplicate-code report, `394 passed, 1 skipped`
- duplicate-code analysis scanned 102 Python files and 942 non-trivial functions; shared route-helper consolidation candidates were reported without test or runtime failures
