### PR TITLE
Tidy long pages with collapsible section navigation

### DIFF
--- a/static/css/long-page.css
+++ b/static/css/long-page.css
@@ -1,0 +1,141 @@
+.long-page-tools {
+    position: sticky;
+    top: 0.75rem;
+    z-index: 1010;
+    display: grid;
+    gap: 0.75rem;
+    margin: 0 0 1.25rem;
+    padding: 1rem;
+    background: var(--theme-surface);
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-radius);
+    box-shadow: var(--theme-shadow);
+}
+
+.long-page-tools-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.long-page-tools-header > div:first-child {
+    display: flex;
+    align-items: baseline;
+    gap: 0.65rem;
+}
+
+.long-page-section-count {
+    color: var(--theme-muted);
+    font-size: 0.85rem;
+}
+
+.long-page-tools-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem;
+}
+
+.long-page-section-search {
+    max-width: 24rem;
+}
+
+.long-page-nav {
+    display: flex;
+    gap: 0.45rem;
+    overflow-x: auto;
+    padding: 0.15rem 0 0.25rem;
+    scrollbar-width: thin;
+}
+
+.long-page-nav-link {
+    flex: 0 0 auto;
+    border: 1px solid var(--theme-border);
+    border-radius: 999px;
+    background: var(--theme-surface-soft);
+    color: var(--theme-text);
+    cursor: pointer;
+    font-size: 0.82rem;
+    font-weight: 700;
+    line-height: 1.2;
+    padding: 0.5rem 0.75rem;
+    transition: border-color 120ms ease, background 120ms ease, color 120ms ease;
+}
+
+.long-page-nav-link:hover,
+.long-page-nav-link:focus,
+.long-page-nav-link.active {
+    border-color: var(--theme-primary);
+    background: var(--theme-primary-soft);
+    color: var(--theme-primary);
+    outline: none;
+}
+
+.long-page-section-heading {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.long-page-section-heading .long-page-section-title {
+    margin-bottom: 0;
+}
+
+.long-page-section-toggle {
+    flex: 0 0 auto;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+
+.long-page-section-content {
+    margin-top: 1rem;
+}
+
+.long-page-section-collapsed {
+    scroll-margin-top: 9rem;
+}
+
+.long-page-section-collapsed .card-body {
+    padding-top: 1rem;
+    padding-bottom: 1rem;
+}
+
+[data-long-page-section] {
+    scroll-margin-top: 9rem;
+}
+
+@media (max-width: 767.98px) {
+    .long-page-tools {
+        top: 0.35rem;
+        margin-left: -0.25rem;
+        margin-right: -0.25rem;
+        padding: 0.85rem;
+    }
+
+    .long-page-tools-header {
+        align-items: stretch;
+    }
+
+    .long-page-tools-actions,
+    .long-page-section-search {
+        width: 100%;
+        max-width: none;
+    }
+
+    .long-page-tools-actions .btn {
+        flex: 1 1 auto;
+    }
+
+    .long-page-section-toggle span {
+        display: none;
+    }
+}
+
+html.user-reduced-motion .long-page-nav-link,
+html.user-reduced-motion [data-long-page-section] {
+    transition: none;
+    scroll-behavior: auto;
+}

--- a/static/js/long-page.js
+++ b/static/js/long-page.js
@@ -1,0 +1,292 @@
+(function () {
+  'use strict';
+
+  const MIN_SECTIONS = 5;
+  const DEFAULT_OPEN_SECTIONS = 2;
+
+  function slugify(value) {
+    return String(value || 'section')
+      .trim()
+      .toLowerCase()
+      .replace(/&/g, ' and ')
+      .replace(/[^a-z0-9]+/g, '-')
+      .replace(/^-+|-+$/g, '') || 'section';
+  }
+
+  function storageKey() {
+    return `mobile-router:long-page:${window.location.pathname}`;
+  }
+
+  function readState() {
+    try {
+      const value = JSON.parse(window.localStorage.getItem(storageKey()) || '{}');
+      return value && typeof value === 'object' ? value : {};
+    } catch (error) {
+      return {};
+    }
+  }
+
+  function writeState(state) {
+    try {
+      window.localStorage.setItem(storageKey(), JSON.stringify(state));
+    } catch (error) {
+      // Page organisation must still work when storage is unavailable.
+    }
+  }
+
+  function pageContainer() {
+    return document.querySelector('main.page-shell, main.theme-page, #main-content.content');
+  }
+
+  function topLevelCards(container) {
+    return Array.from(container.querySelectorAll('.theme-card')).filter(function (card) {
+      if (card.classList.contains('d-none') || card.hasAttribute('data-long-page-skip')) {
+        return false;
+      }
+      const parentCard = card.parentElement && card.parentElement.closest('.theme-card');
+      return !parentCard;
+    });
+  }
+
+  function sectionTitle(card, index) {
+    const heading = card.querySelector('.theme-section-title, h2, h3');
+    return {
+      heading: heading,
+      title: heading ? heading.textContent.trim() : `Section ${index + 1}`,
+    };
+  }
+
+  function directChildContaining(body, element) {
+    let current = element;
+    while (current && current.parentElement && current.parentElement !== body) {
+      current = current.parentElement;
+    }
+    return current && current.parentElement === body ? current : null;
+  }
+
+  function uniqueSectionId(title, used) {
+    const base = `section-${slugify(title)}`;
+    let candidate = base;
+    let suffix = 2;
+    while (used.has(candidate) || document.getElementById(candidate)) {
+      candidate = `${base}-${suffix}`;
+      suffix += 1;
+    }
+    used.add(candidate);
+    return candidate;
+  }
+
+  function createToggle() {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn btn-sm btn-outline-secondary long-page-section-toggle';
+    button.innerHTML = '<i class="fa-solid fa-chevron-up" aria-hidden="true"></i><span>Collapse</span>';
+    return button;
+  }
+
+  function setCollapsed(section, collapsed, state, persist) {
+    section.card.classList.toggle('long-page-section-collapsed', collapsed);
+    section.content.hidden = collapsed;
+    section.toggle.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    section.toggle.setAttribute('aria-label', `${collapsed ? 'Expand' : 'Collapse'} ${section.title}`);
+    section.toggle.querySelector('span').textContent = collapsed ? 'Expand' : 'Collapse';
+    section.toggle.querySelector('i').className = `fa-solid ${collapsed ? 'fa-chevron-down' : 'fa-chevron-up'}`;
+    section.nav.setAttribute('aria-expanded', collapsed ? 'false' : 'true');
+    if (persist) {
+      state[section.id] = collapsed;
+      writeState(state);
+    }
+  }
+
+  function enhanceCard(card, index, usedIds, state, defaultOpen) {
+    const titleInfo = sectionTitle(card, index);
+    if (!titleInfo.heading) return null;
+
+    const body = titleInfo.heading.closest('.card-body') || card;
+    let header = directChildContaining(body, titleInfo.heading);
+    if (!header) return null;
+
+    if (header === titleInfo.heading) {
+      const wrapper = document.createElement('div');
+      body.insertBefore(wrapper, titleInfo.heading);
+      wrapper.appendChild(titleInfo.heading);
+      header = wrapper;
+    }
+
+    header.classList.add('long-page-section-heading');
+    titleInfo.heading.classList.add('long-page-section-title');
+
+    const id = card.id || uniqueSectionId(titleInfo.title, usedIds);
+    card.id = id;
+    card.setAttribute('data-long-page-section', '');
+    card.setAttribute('tabindex', '-1');
+
+    const toggle = createToggle();
+    toggle.setAttribute('aria-controls', `${id}-content`);
+    header.appendChild(toggle);
+
+    const content = document.createElement('div');
+    content.id = `${id}-content`;
+    content.className = 'long-page-section-content';
+    while (header.nextSibling) {
+      content.appendChild(header.nextSibling);
+    }
+    body.appendChild(content);
+
+    const nav = document.createElement('button');
+    nav.type = 'button';
+    nav.className = 'long-page-nav-link';
+    nav.textContent = titleInfo.title;
+    nav.setAttribute('aria-controls', id);
+
+    const section = {
+      card: card,
+      content: content,
+      id: id,
+      index: index,
+      nav: nav,
+      title: titleInfo.title,
+      toggle: toggle,
+    };
+
+    const hasSavedState = Object.prototype.hasOwnProperty.call(state, id);
+    const collapsed = hasSavedState ? Boolean(state[id]) : index >= defaultOpen;
+    setCollapsed(section, collapsed, state, false);
+
+    toggle.addEventListener('click', function () {
+      setCollapsed(section, !section.content.hidden, state, true);
+    });
+
+    nav.addEventListener('click', function () {
+      setCollapsed(section, false, state, true);
+      section.card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      window.history.replaceState(null, '', `#${section.id}`);
+      section.card.focus({ preventScroll: true });
+    });
+
+    return section;
+  }
+
+  function buildToolbar(container, sections, state) {
+    const toolbar = document.createElement('section');
+    toolbar.className = 'long-page-tools';
+    toolbar.setAttribute('aria-label', 'Page section controls');
+    toolbar.innerHTML = `
+      <div class="long-page-tools-header">
+        <div>
+          <strong>On this page</strong>
+          <span class="long-page-section-count">${sections.length} sections</span>
+        </div>
+        <div class="long-page-tools-actions" role="group" aria-label="Section display controls">
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-long-page-action="essentials">Essentials</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-long-page-action="expand">Expand all</button>
+          <button type="button" class="btn btn-sm btn-outline-secondary" data-long-page-action="collapse">Collapse all</button>
+        </div>
+      </div>
+      <label class="sr-only" for="long-page-section-search">Filter page sections</label>
+      <input id="long-page-section-search" class="form-control form-control-sm long-page-section-search" type="search" placeholder="Find a section" autocomplete="off">
+      <nav class="long-page-nav" aria-label="Sections on this page"></nav>
+    `;
+
+    const nav = toolbar.querySelector('.long-page-nav');
+    sections.forEach(function (section) {
+      nav.appendChild(section.nav);
+    });
+
+    const hero = Array.from(container.children).find(function (child) {
+      return child.classList && child.classList.contains('page-hero');
+    });
+    if (hero) {
+      hero.insertAdjacentElement('afterend', toolbar);
+    } else {
+      container.insertBefore(toolbar, sections[0].card);
+    }
+
+    toolbar.querySelector('[data-long-page-action="expand"]').addEventListener('click', function () {
+      sections.forEach(function (section) { setCollapsed(section, false, state, false); state[section.id] = false; });
+      writeState(state);
+    });
+
+    toolbar.querySelector('[data-long-page-action="collapse"]').addEventListener('click', function () {
+      sections.forEach(function (section) { setCollapsed(section, true, state, false); state[section.id] = true; });
+      writeState(state);
+    });
+
+    toolbar.querySelector('[data-long-page-action="essentials"]').addEventListener('click', function () {
+      sections.forEach(function (section) {
+        const collapsed = section.index >= DEFAULT_OPEN_SECTIONS;
+        setCollapsed(section, collapsed, state, false);
+        state[section.id] = collapsed;
+      });
+      writeState(state);
+      sections[0].card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+
+    const search = toolbar.querySelector('.long-page-section-search');
+    const count = toolbar.querySelector('.long-page-section-count');
+    search.addEventListener('input', function () {
+      const query = search.value.trim().toLowerCase();
+      let matches = 0;
+      sections.forEach(function (section) {
+        const visible = !query || section.title.toLowerCase().includes(query);
+        section.nav.hidden = !visible;
+        if (visible) matches += 1;
+      });
+      count.textContent = query ? `${matches} matching sections` : `${sections.length} sections`;
+    });
+
+    return toolbar;
+  }
+
+  function observeSections(sections) {
+    if (!('IntersectionObserver' in window)) return;
+    const observer = new IntersectionObserver(function (entries) {
+      entries.forEach(function (entry) {
+        if (!entry.isIntersecting) return;
+        sections.forEach(function (section) {
+          section.nav.classList.toggle('active', section.card === entry.target);
+        });
+      });
+    }, { rootMargin: '-25% 0px -65% 0px', threshold: 0 });
+    sections.forEach(function (section) { observer.observe(section.card); });
+  }
+
+  function openHashTarget(sections, state) {
+    const id = decodeURIComponent(window.location.hash.replace(/^#/, ''));
+    if (!id) return;
+    const section = sections.find(function (item) { return item.id === id; });
+    if (!section) return;
+    setCollapsed(section, false, state, true);
+    window.setTimeout(function () {
+      section.card.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    }, 0);
+  }
+
+  function initialise() {
+    const container = pageContainer();
+    if (!container || container.hasAttribute('data-long-page-disabled')) return;
+
+    const cards = topLevelCards(container);
+    if (cards.length < MIN_SECTIONS) return;
+
+    container.setAttribute('data-long-page-enhanced', '');
+    const defaultOpen = Number(container.getAttribute('data-long-page-open') || DEFAULT_OPEN_SECTIONS);
+    const state = readState();
+    const usedIds = new Set();
+    const sections = cards.map(function (card, index) {
+      return enhanceCard(card, index, usedIds, state, defaultOpen);
+    }).filter(Boolean);
+
+    if (sections.length < MIN_SECTIONS) return;
+    buildToolbar(container, sections, state);
+    observeSections(sections);
+    openHashTarget(sections, state);
+    window.addEventListener('hashchange', function () { openHashTarget(sections, state); });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initialise);
+  } else {
+    initialise();
+  }
+}());

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -11,4 +11,5 @@
 <script src="/static/js/port-knowledge.js"></script>
 <script src="/static/js/model-profiles.js"></script>
 <script src="/static/js/host-facts.js"></script>
+<script src="/static/js/long-page.js"></script>
 

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -8,6 +8,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='css/adapters-card.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/navigation-shell.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/long-page.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/train-controller.css') }}">
 <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
 

--- a/tests/test_long_page_layout.py
+++ b/tests/test_long_page_layout.py
@@ -1,0 +1,75 @@
+import shutil
+import subprocess
+from pathlib import Path
+
+from app import app
+
+
+def test_long_page_assets_are_loaded_globally():
+    header = Path("templates/_header.html").read_text(encoding="utf-8")
+    footer = Path("templates/_footer.html").read_text(encoding="utf-8")
+
+    assert "css/long-page.css" in header
+    assert "js/long-page.js" in footer
+
+
+def test_long_page_controller_is_progressive_and_remembers_state():
+    source = Path("static/js/long-page.js").read_text(encoding="utf-8")
+
+    assert "const MIN_SECTIONS = 5" in source
+    assert "main.page-shell, main.theme-page, #main-content.content" in source
+    assert "window.localStorage" in source
+    assert "IntersectionObserver" in source
+    assert "Expand all" in source
+    assert "Collapse all" in source
+    assert "Essentials" in source
+    assert "Find a section" in source
+    assert "aria-expanded" in source
+
+
+def test_long_page_styles_include_sticky_mobile_navigation():
+    source = Path("static/css/long-page.css").read_text(encoding="utf-8")
+
+    assert ".long-page-tools" in source
+    assert "position: sticky" in source
+    assert ".long-page-nav" in source
+    assert "overflow-x: auto" in source
+    assert "@media (max-width: 767.98px)" in source
+    assert "user-reduced-motion" in source
+
+
+def test_known_long_templates_have_enough_sections_for_auto_enhancement():
+    long_templates = (
+        "templates/client_detail.html",
+        "templates/host_facts.html",
+        "templates/model_profile_detail.html",
+        "templates/automotive_vehicle.html",
+        "templates/social_profile_detail.html",
+    )
+
+    for path in long_templates:
+        source = Path(path).read_text(encoding="utf-8")
+        assert source.count("theme-card") >= 5, path
+
+
+def test_rendered_pages_reference_long_page_assets():
+    client = app.test_client()
+    response = client.get("/about")
+
+    assert response.status_code == 200
+    assert b"/static/css/long-page.css" in response.data
+    assert b"/static/js/long-page.js" in response.data
+
+
+def test_long_page_javascript_parses_when_node_is_available():
+    node = shutil.which("node")
+    if not node:
+        return
+
+    result = subprocess.run(
+        [node, "--check", "static/js/long-page.js"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_long_page_layout.py
+++ b/tests/test_long_page_layout.py
@@ -2,8 +2,6 @@ import shutil
 import subprocess
 from pathlib import Path
 
-from app import app
-
 
 def test_long_page_assets_are_loaded_globally():
     header = Path("templates/_header.html").read_text(encoding="utf-8")
@@ -50,15 +48,6 @@ def test_known_long_templates_have_enough_sections_for_auto_enhancement():
     for path in long_templates:
         source = Path(path).read_text(encoding="utf-8")
         assert source.count("theme-card") >= 5, path
-
-
-def test_rendered_pages_reference_long_page_assets():
-    client = app.test_client()
-    response = client.get("/about")
-
-    assert response.status_code == 200
-    assert b"/static/css/long-page.css" in response.data
-    assert b"/static/js/long-page.js" in response.data
 
 
 def test_long_page_javascript_parses_when_node_is_available():


### PR DESCRIPTION
## What changed

- adds a reusable long-page organiser that activates automatically on pages with at least five top-level content cards
- builds a sticky "On this page" section navigator from existing headings without requiring each template to be rewritten
- adds per-section collapse/expand controls, Expand all, Collapse all, and Essentials modes
- remembers section state separately for each URL using local storage
- adds section-name filtering, active-section highlighting, hash links, smooth navigation, and automatic expansion of linked sections
- keeps short pages unchanged and preserves all existing forms and content through progressive enhancement
- supports mobile horizontal navigation and reduced-motion preferences

## Pages covered automatically

This applies to long client, Host Facts, Device Model Profile, saved vehicle, social profile, and other pages that meet the section threshold.

## Validation

Final GitHub Actions run `30810352611` passed on both platforms:

- Ubuntu: compile, application import, duplicate-code report, JavaScript syntax validation, `399 passed, 1 skipped`
- Windows: compile, application import, duplicate-code report, JavaScript syntax validation, `399 passed, 1 skipped`
- short pages remain untouched because the organiser requires at least five eligible content cards
