### PR TITLE
Build six-part device workspace dashboard

### DIFF
--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -9,6 +9,7 @@ from .port_knowledge import create_port_knowledge_blueprint
 from .model_profiles import create_model_profiles_blueprint
 from .service_records import create_service_records_blueprint
 from .host_facts import create_host_facts_blueprint
+from .client_workspace import create_client_workspace_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -23,3 +24,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_model_profiles_blueprint(context_provider))
     app.register_blueprint(create_service_records_blueprint(context_provider))
     app.register_blueprint(create_host_facts_blueprint(context_provider))
+    app.register_blueprint(create_client_workspace_blueprint(context_provider))

--- a/routes/client_workspace.py
+++ b/routes/client_workspace.py
@@ -1,0 +1,102 @@
+"""Lazy-rendered panels for the six-part IP client workspace."""
+
+import time
+
+from flask import Blueprint, render_template
+
+
+WORKSPACE_SECTIONS = {"network", "services", "security", "history"}
+
+
+def _client_context(app_module, context_provider, identifier):
+    device = app_module.find_inventory_device(identifier) or {}
+    if not device:
+        return None
+
+    device = app_module.enrich_ip_client_display_name(identifier, device)
+    host = device.get("ip") or identifier
+    if not device.get("ip"):
+        return None
+
+    mac = device.get("mac") or app_module.get_mac_by_ip(host)
+    manufacturer = device.get("manufacturer")
+    if not manufacturer or str(manufacturer).casefold() == "unknown":
+        manufacturer = app_module.lookup_manufacturer(mac)
+
+    last_port_scan = device.get("last_port_scan")
+    context = {
+        "identifier": identifier,
+        "ip": host,
+        "mac": mac,
+        "manufacturer": manufacturer or "Unknown",
+        "display_name": app_module.display_name_for_inventory_device(
+            device,
+            host,
+        ),
+        "inventory_device": device,
+        "open_port_details": device.get("open_port_details", []),
+        "open_ports": device.get("open_ports", []),
+        "last_port_scan_label": (
+            time.strftime(
+                "%Y-%m-%d %H:%M:%S",
+                time.localtime(last_port_scan),
+            )
+            if last_port_scan
+            else None
+        ),
+        "health_summary": app_module.client_health_summary(device, host),
+        "watched_client": app_module.is_client_watched(host),
+        "baseline_diff": app_module.client_baseline_diff(device),
+        **context_provider(),
+    }
+    return context
+
+
+def create_client_workspace_blueprint(context_provider):
+    blueprint = Blueprint("client_workspace", __name__)
+
+    @blueprint.get("/clients/<path:identifier>/workspace/<section>")
+    def client_workspace_panel(identifier, section):
+        if section not in WORKSPACE_SECTIONS:
+            return "Unknown client workspace section", 404
+
+        import app as app_module
+
+        context = _client_context(app_module, context_provider, identifier)
+        if context is None:
+            return "Client was not found in inventory", 404
+
+        host = context["ip"]
+        device = context["inventory_device"]
+        if section == "network":
+            context.update(
+                relationship_map=app_module.client_relationship_map(host),
+                scheduled_check=app_module.scheduled_client_checks.get(host),
+                reachability_history=app_module.client_reachability_history(host),
+            )
+        elif section == "security":
+            context.update(
+                host_fact_changes=[
+                    fact
+                    for fact in device.get("host_facts", [])
+                    if fact.get("changed_since_baseline")
+                ],
+                identity_assessment=device.get("identity_assessment") or {},
+                model_drift=(
+                    device.get("model_profile_drift")
+                    or device.get("port_profile_drift")
+                    or {}
+                ),
+            )
+        elif section == "history":
+            context.update(
+                client_timeline=app_module.client_timeline(host, device),
+                reachability_history=app_module.client_reachability_history(host),
+            )
+
+        return render_template(
+            f"client_workspace/_{section}.html",
+            **context,
+        )
+
+    return blueprint

--- a/static/css/device-workspace.css
+++ b/static/css/device-workspace.css
@@ -1,0 +1,349 @@
+.device-compact-header {
+    position: sticky;
+    top: 0.45rem;
+    z-index: 1020;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto auto;
+    align-items: center;
+    gap: 1rem;
+    margin: 0 0 0.75rem;
+    padding: 0.75rem 1rem;
+    background: color-mix(in srgb, var(--theme-surface) 94%, transparent);
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-radius);
+    box-shadow: var(--theme-shadow);
+    backdrop-filter: blur(12px);
+}
+
+.device-compact-identity,
+.device-compact-summary,
+.device-compact-actions,
+.device-workspace-section-heading,
+.device-dashboard-heading {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.device-compact-identity {
+    min-width: 0;
+}
+
+.device-compact-identity > div {
+    display: grid;
+    min-width: 0;
+}
+
+.device-compact-identity strong,
+.device-compact-identity span {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.device-compact-identity span {
+    color: var(--theme-muted);
+    font-size: 0.82rem;
+}
+
+.device-status-dot {
+    width: 0.72rem;
+    height: 0.72rem;
+    flex: 0 0 auto;
+    border-radius: 999px;
+    background: var(--theme-muted);
+    box-shadow: 0 0 0 0.2rem var(--theme-surface-soft);
+}
+
+.device-status-dot-online {
+    background: #2ca35c;
+}
+
+.device-workspace-navigation {
+    position: sticky;
+    top: 5rem;
+    z-index: 1015;
+    margin-bottom: 1rem;
+    padding: 0.55rem 0.75rem 0;
+    background: var(--theme-surface);
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-radius);
+    box-shadow: var(--theme-shadow);
+}
+
+.device-workspace-tablist {
+    display: grid;
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    gap: 0.25rem;
+}
+
+.device-workspace-tab {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.45rem;
+    min-height: 3rem;
+    padding: 0.6rem 0.55rem;
+    border: 1px solid transparent;
+    border-bottom: 0.22rem solid transparent;
+    border-radius: 0.6rem 0.6rem 0 0;
+    background: transparent;
+    color: var(--theme-muted);
+    font-weight: 700;
+    cursor: pointer;
+}
+
+.device-workspace-tab:hover,
+.device-workspace-tab:focus {
+    color: var(--theme-text);
+    border-color: var(--theme-border);
+    outline: none;
+}
+
+.device-workspace-tab.active,
+.device-workspace-tab[aria-selected="true"] {
+    color: var(--theme-primary);
+    background: var(--theme-primary-soft);
+    border-color: var(--theme-border);
+    border-bottom-color: var(--theme-primary);
+}
+
+.device-tab-badge {
+    min-width: 1.35rem;
+    padding: 0.15rem 0.38rem;
+    border-radius: 999px;
+    background: var(--theme-surface-soft);
+    color: var(--theme-text);
+    font-size: 0.72rem;
+    line-height: 1.2;
+    text-align: center;
+}
+
+.device-tab-badge-warning {
+    background: rgba(255, 193, 7, 0.24);
+    color: var(--theme-text);
+}
+
+.device-workspace-tab.is-dirty::after {
+    content: "";
+    position: absolute;
+    top: 0.38rem;
+    right: 0.38rem;
+    width: 0.5rem;
+    height: 0.5rem;
+    border-radius: 999px;
+    background: #dc3545;
+    box-shadow: 0 0 0 0.12rem var(--theme-surface);
+}
+
+.device-workspace-select-group {
+    display: none;
+}
+
+.device-workspace-panel {
+    min-height: 18rem;
+}
+
+.device-workspace-panel[hidden] {
+    display: none !important;
+}
+
+.device-workspace-panel.active {
+    animation: device-workspace-enter 150ms ease-out;
+}
+
+.device-workspace-loading {
+    min-height: 18rem;
+    display: grid;
+    place-items: center;
+    align-content: center;
+    gap: 0.75rem;
+    color: var(--theme-muted);
+}
+
+.device-workspace-global-output:not(:empty) {
+    margin-bottom: 1rem;
+}
+
+.device-workspace-global-output .alert {
+    margin-bottom: 0;
+}
+
+.device-dashboard-heading,
+.device-workspace-section-heading {
+    justify-content: space-between;
+    align-items: flex-start;
+    flex-wrap: wrap;
+}
+
+.device-dashboard-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.device-dashboard-card {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-rows: auto auto auto;
+    column-gap: 0.75rem;
+    row-gap: 0.15rem;
+    min-height: 8rem;
+    padding: 1rem;
+    text-align: left;
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-radius);
+    background: var(--theme-surface);
+    color: var(--theme-text);
+    box-shadow: var(--theme-shadow);
+    cursor: pointer;
+}
+
+.device-dashboard-card:hover,
+.device-dashboard-card:focus {
+    border-color: var(--theme-primary);
+    transform: translateY(-1px);
+    outline: none;
+}
+
+.device-dashboard-card-warning {
+    border-color: rgba(255, 193, 7, 0.65);
+}
+
+.device-dashboard-icon {
+    grid-row: 1 / 4;
+    display: grid;
+    place-items: center;
+    width: 2.6rem;
+    height: 2.6rem;
+    border-radius: 0.7rem;
+    background: var(--theme-primary-soft);
+    color: var(--theme-primary);
+}
+
+.device-dashboard-card > strong {
+    font-size: 1rem;
+}
+
+.device-dashboard-card > span:not(.device-dashboard-icon),
+.device-dashboard-card > small {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.device-dashboard-card > small {
+    color: var(--theme-muted);
+}
+
+.device-overview-columns {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.device-recommendation-list li + li {
+    margin-top: 0.6rem;
+}
+
+.device-empty-state {
+    display: grid;
+    justify-items: start;
+    gap: 0.65rem;
+    padding: 1rem;
+    border: 1px dashed var(--theme-border);
+    border-radius: var(--theme-radius);
+    background: var(--theme-surface-soft);
+}
+
+.device-empty-state > i {
+    font-size: 1.35rem;
+    color: var(--theme-primary);
+}
+
+.device-empty-state h4,
+.device-empty-state p {
+    margin: 0;
+}
+
+.workspace-form-status {
+    align-self: center;
+    font-size: 0.82rem;
+}
+
+form.is-dirty .workspace-form-status {
+    color: #dc3545 !important;
+    font-weight: 700;
+}
+
+@keyframes device-workspace-enter {
+    from { opacity: 0; transform: translateY(0.25rem); }
+    to { opacity: 1; transform: translateY(0); }
+}
+
+@media (max-width: 991.98px) {
+    .device-compact-header {
+        grid-template-columns: minmax(0, 1fr) auto;
+    }
+
+    .device-compact-summary {
+        display: none;
+    }
+
+    .device-dashboard-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .device-workspace-tab span:not(.device-tab-badge) {
+        display: none;
+    }
+}
+
+@media (max-width: 767.98px) {
+    .device-compact-header {
+        top: 0.25rem;
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0.55rem;
+    }
+
+    .device-compact-actions {
+        width: 100%;
+    }
+
+    .device-compact-actions .btn {
+        flex: 1 1 0;
+    }
+
+    .device-workspace-navigation {
+        top: 7.7rem;
+        padding: 0.75rem;
+    }
+
+    .device-workspace-tablist {
+        display: none;
+    }
+
+    .device-workspace-select-group {
+        display: grid;
+        gap: 0.35rem;
+    }
+
+    .device-workspace-select-group label {
+        margin: 0;
+        color: var(--theme-muted);
+        font-size: 0.8rem;
+        font-weight: 700;
+    }
+
+    .device-dashboard-grid,
+    .device-overview-columns {
+        grid-template-columns: minmax(0, 1fr);
+    }
+}
+
+html.user-reduced-motion .device-workspace-panel.active,
+html.user-reduced-motion .device-dashboard-card,
+html.user-reduced-motion .device-workspace-tab {
+    animation: none;
+    transition: none;
+}

--- a/static/js/device-workspace.js
+++ b/static/js/device-workspace.js
@@ -1,6 +1,7 @@
 (function () {
   'use strict';
 
+  // Stable hashes such as workspace-services are used for direct workspace links.
   const root = document.querySelector('[data-device-workspace]');
   if (!root) return;
 

--- a/static/js/device-workspace.js
+++ b/static/js/device-workspace.js
@@ -1,0 +1,241 @@
+(function () {
+  'use strict';
+
+  const root = document.querySelector('[data-device-workspace]');
+  if (!root) return;
+
+  const host = String(root.getAttribute('data-host') || '');
+  const storageKey = `mobile-router:device-workspace:${host || window.location.pathname}`;
+  const tabs = Array.from(root.querySelectorAll('[data-device-workspace-tab]'));
+  const panels = Array.from(root.querySelectorAll('[data-device-workspace-panel]'));
+  const select = root.querySelector('[data-device-workspace-select]');
+  const dirtyForms = new Set();
+  let activeName = 'overview';
+
+  function panelFor(name) {
+    return panels.find(function (panel) {
+      return panel.getAttribute('data-device-workspace-panel') === name;
+    }) || null;
+  }
+
+  function tabFor(name) {
+    return tabs.find(function (tab) {
+      return tab.getAttribute('data-device-workspace-tab') === name;
+    }) || null;
+  }
+
+  function storedWorkspace() {
+    try {
+      return String(window.localStorage.getItem(storageKey) || '');
+    } catch (error) {
+      return '';
+    }
+  }
+
+  function rememberWorkspace(name) {
+    try {
+      window.localStorage.setItem(storageKey, name);
+    } catch (error) {
+      // Navigation remains usable when browser storage is unavailable.
+    }
+  }
+
+  function formSnapshot(form) {
+    const entries = [];
+    new FormData(form).forEach(function (value, key) {
+      if (value instanceof File) {
+        entries.push([key, value.name, value.size]);
+      } else {
+        entries.push([key, String(value)]);
+      }
+    });
+    return JSON.stringify(entries);
+  }
+
+  function formPanel(form) {
+    return form.closest('[data-device-workspace-panel]');
+  }
+
+  function updatePanelDirtyState(panel) {
+    if (!panel) return;
+    const name = panel.getAttribute('data-device-workspace-panel');
+    const tab = tabFor(name);
+    const hasDirty = Array.from(dirtyForms).some(function (form) {
+      return formPanel(form) === panel;
+    });
+    panel.classList.toggle('has-unsaved-changes', hasDirty);
+    if (tab) {
+      tab.classList.toggle('is-dirty', hasDirty);
+      tab.setAttribute('aria-label', `${tab.textContent.trim()}${hasDirty ? ', unsaved changes' : ''}`);
+    }
+  }
+
+  function markFormState(form) {
+    if (!form || form.hasAttribute('data-workspace-no-dirty')) return;
+    if (!form.dataset.workspaceInitialState) {
+      form.dataset.workspaceInitialState = formSnapshot(form);
+    }
+    const dirty = formSnapshot(form) !== form.dataset.workspaceInitialState;
+    form.classList.toggle('is-dirty', dirty);
+    const status = form.querySelector('[data-workspace-form-status]');
+    if (status) status.textContent = dirty ? 'Unsaved changes' : 'Saved';
+    if (dirty) dirtyForms.add(form);
+    else dirtyForms.delete(form);
+    updatePanelDirtyState(formPanel(form));
+  }
+
+  function registerForms(container) {
+    const forms = Array.from(container.querySelectorAll('form[data-workspace-form]'));
+    forms.forEach(function (form) {
+      form.dataset.workspaceInitialState = formSnapshot(form);
+      markFormState(form);
+    });
+  }
+
+  async function loadPanel(panel) {
+    if (!panel || panel.dataset.workspaceLoaded === 'true') return true;
+    const url = panel.getAttribute('data-workspace-url');
+    if (!url) {
+      panel.dataset.workspaceLoaded = 'true';
+      registerForms(panel);
+      return true;
+    }
+    if (panel.dataset.workspaceLoading === 'true') return false;
+
+    panel.dataset.workspaceLoading = 'true';
+    panel.innerHTML = '<div class="device-workspace-loading"><div class="spinner-border text-primary" role="status" aria-hidden="true"></div><p>Loading workspace…</p></div>';
+    try {
+      const response = await fetch(url, {
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      if (!response.ok) throw new Error(`Workspace request failed (${response.status})`);
+      panel.innerHTML = await response.text();
+      panel.dataset.workspaceLoaded = 'true';
+      registerForms(panel);
+      document.dispatchEvent(new CustomEvent('device-workspace:loaded', {
+        detail: { panel: panel },
+      }));
+      return true;
+    } catch (error) {
+      panel.innerHTML = `
+        <div class="alert alert-danger" role="alert">
+          <strong>Unable to load this workspace.</strong>
+          <p class="mb-2">${String(error.message || error)}</p>
+          <button type="button" class="btn btn-sm btn-outline-danger" data-workspace-retry>Retry</button>
+        </div>`;
+      panel.querySelector('[data-workspace-retry]').addEventListener('click', function () {
+        panel.dataset.workspaceLoading = 'false';
+        loadPanel(panel);
+      });
+      return false;
+    } finally {
+      panel.dataset.workspaceLoading = 'false';
+    }
+  }
+
+  function canLeaveActive() {
+    const activePanel = panelFor(activeName);
+    if (!activePanel || !activePanel.classList.contains('has-unsaved-changes')) return true;
+    return window.confirm('This workspace contains unsaved changes. Leave it without saving?');
+  }
+
+  async function activate(name, options) {
+    const settings = Object.assign({ focus: false, updateHash: true, force: false }, options || {});
+    const panel = panelFor(name);
+    const tab = tabFor(name);
+    if (!panel || !tab) return;
+    if (!settings.force && name !== activeName && !canLeaveActive()) {
+      if (select) select.value = activeName;
+      return;
+    }
+
+    await loadPanel(panel);
+    panels.forEach(function (candidate) {
+      const active = candidate === panel;
+      candidate.hidden = !active;
+      candidate.classList.toggle('active', active);
+    });
+    tabs.forEach(function (candidate) {
+      const active = candidate === tab;
+      candidate.classList.toggle('active', active);
+      candidate.setAttribute('aria-selected', active ? 'true' : 'false');
+      candidate.setAttribute('tabindex', active ? '0' : '-1');
+    });
+
+    activeName = name;
+    if (select) select.value = name;
+    rememberWorkspace(name);
+    if (settings.updateHash) window.history.replaceState(null, '', `#workspace-${name}`);
+    if (settings.focus) panel.focus({ preventScroll: true });
+    tab.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+  }
+
+  tabs.forEach(function (tab) {
+    tab.setAttribute('tabindex', tab.classList.contains('active') ? '0' : '-1');
+    tab.addEventListener('click', function () {
+      activate(tab.getAttribute('data-device-workspace-tab'), { focus: true });
+    });
+  });
+
+  const tablist = root.querySelector('.device-workspace-tablist');
+  if (tablist) {
+    tablist.addEventListener('keydown', function (event) {
+      const index = tabs.indexOf(tabFor(activeName));
+      let nextIndex = null;
+      if (event.key === 'ArrowRight' || event.key === 'ArrowDown') nextIndex = (index + 1) % tabs.length;
+      else if (event.key === 'ArrowLeft' || event.key === 'ArrowUp') nextIndex = (index - 1 + tabs.length) % tabs.length;
+      else if (event.key === 'Home') nextIndex = 0;
+      else if (event.key === 'End') nextIndex = tabs.length - 1;
+      if (nextIndex === null) return;
+      event.preventDefault();
+      const name = tabs[nextIndex].getAttribute('data-device-workspace-tab');
+      activate(name).then(function () { tabs[nextIndex].focus(); });
+    });
+  }
+
+  if (select) {
+    select.addEventListener('change', function () {
+      activate(select.value, { focus: true });
+    });
+  }
+
+  root.addEventListener('click', function (event) {
+    const trigger = event.target.closest('[data-workspace-open]');
+    if (!trigger) return;
+    event.preventDefault();
+    activate(trigger.getAttribute('data-workspace-open'), { focus: true });
+  });
+
+  root.addEventListener('input', function (event) {
+    const form = event.target.closest('form[data-workspace-form]');
+    if (form) markFormState(form);
+  });
+  root.addEventListener('change', function (event) {
+    const form = event.target.closest('form[data-workspace-form]');
+    if (form) markFormState(form);
+  });
+
+  document.addEventListener('device-workspace:form-saved', function (event) {
+    const form = event.detail && event.detail.form;
+    if (!form) return;
+    form.dataset.workspaceInitialState = formSnapshot(form);
+    markFormState(form);
+  });
+
+  window.addEventListener('beforeunload', function (event) {
+    if (!dirtyForms.size) return;
+    event.preventDefault();
+    event.returnValue = '';
+  });
+
+  window.addEventListener('hashchange', function () {
+    const match = window.location.hash.match(/^#workspace-(overview|identity|network|services|security|history)$/);
+    if (match) activate(match[1], { updateHash: false, force: true });
+  });
+
+  registerForms(root);
+  const hashMatch = window.location.hash.match(/^#workspace-(overview|identity|network|services|security|history)$/);
+  const initial = hashMatch ? hashMatch[1] : (storedWorkspace() || 'overview');
+  activate(panelFor(initial) ? initial : 'overview', { updateHash: false, force: true });
+}());

--- a/static/js/ip_client.js
+++ b/static/js/ip_client.js
@@ -9,11 +9,22 @@ $(document).ready(function () {
   }
 
   function clientHost() {
-    return $('[data-ip-client-tools]').data('host') || '';
+    return $('[data-device-workspace]').attr('data-host')
+      || $('[data-ip-client-tools]').first().data('host')
+      || '';
   }
 
   function output(html) {
-    $('[data-ip-client-output]').html(html);
+    const $target = $('[data-ip-client-global-output]').first().length
+      ? $('[data-ip-client-global-output]').first()
+      : $('[data-ip-client-output]').first();
+    $target.html(html);
+  }
+
+  function notifyFormSaved(form) {
+    document.dispatchEvent(new CustomEvent('device-workspace:form-saved', {
+      detail: { form: form },
+    }));
   }
 
   function renderPing(result) {
@@ -49,7 +60,7 @@ $(document).ready(function () {
     if (!results || !results.length) return '<div class="alert alert-warning">No saved services are available to fingerprint.</div>';
     return `<div class="alert alert-info"><strong>Service fingerprints</strong></div><div class="port-service-grid">${results.map((item) => {
       const web = item.http ? ` · ${item.http.title || item.http.server || item.http.status || item.http.error || 'HTTP checked'}` : '';
-      const note = (item.banner || (item.notes || []).join('; ') || 'No additional fingerprint data');
+      const note = item.banner || (item.notes || []).join('; ') || 'No additional fingerprint data';
       return `<div class="port-service-card">
         <strong>${escapeHtml(item.port)}/tcp ${escapeHtml(item.service)}</strong>
         <span>Confidence: ${escapeHtml(item.confidence)}${escapeHtml(web)}</span>
@@ -75,172 +86,156 @@ $(document).ready(function () {
       <ul>${recommendations}</ul>`;
   }
 
-  $('[data-ip-client-ping]').on('click', function () {
+  $(document).on('click', '[data-ip-client-ping]', function () {
     const host = clientHost();
     output('<p class="text-muted">Pinging client...</p>');
     $.ajax({
-      url: '/ping',
-      method: 'POST',
-      data: { host: host, count: 4, timeout: 2 },
+      url: '/ping', method: 'POST', data: { host: host, count: 4, timeout: 2 },
       success: function (resp) { output(renderPing(resp.result || {})); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Ping failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-route]').on('click', function () {
+  $(document).on('click', '[data-ip-client-route]', function () {
     const host = clientHost();
     output('<p class="text-muted">Checking route context...</p>');
     $.ajax({
-      url: '/route-diagnostics',
-      method: 'POST',
-      data: { target: host },
+      url: '/route-diagnostics', method: 'POST', data: { target: host },
       success: function (resp) { output(renderRoute(resp.diagnostics || {})); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Route diagnostics failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-traceroute]').on('click', function () {
+  $(document).on('click', '[data-ip-client-traceroute]', function () {
     const host = clientHost();
     output('<p class="text-muted">Running traceroute...</p>');
     $.ajax({
-      url: '/traceroute',
-      method: 'POST',
-      data: { host: host },
+      url: '/traceroute', method: 'POST', data: { host: host },
       success: function (resp) { output(renderTraceroute(resp.hops || [])); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Traceroute failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-evidence-form]').on('submit', function (event) {
+  $(document).on('submit', '[data-ip-client-evidence-form]', function (event) {
     event.preventDefault();
+    const form = this;
     const host = clientHost();
-    const notes = $('[data-ip-client-evidence-notes]').val();
+    const notes = $(form).find('[data-ip-client-evidence-notes]').val();
     output('<p class="text-muted">Saving evidence note...</p>');
     $.ajax({
-      url: '/evidence',
-      method: 'POST',
-      headers: { 'X-Requested-With': 'XMLHttpRequest' },
-      data: {
-        title: `IP client note for ${host}`,
-        category: 'note',
-        source: 'client-detail',
-        device: host,
-        notes: notes,
-        content: notes
-      },
+      url: '/evidence', method: 'POST', headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      data: { title: `IP client note for ${host}`, category: 'note', source: 'client-detail', device: host, notes: notes, content: notes },
       success: function (resp) {
-        $('[data-ip-client-evidence-notes]').val('');
+        $(form).find('[data-ip-client-evidence-notes]').val('');
+        notifyFormSaved(form);
         output(`<div class="alert alert-success">Evidence note saved for ${escapeHtml(resp.evidence?.device || host)}.</div>`);
       },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Evidence note failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-watch]').on('click', function () {
-    const button = $(this);
+  $(document).on('click', '[data-ip-client-watch]', function () {
     const host = clientHost();
-    const nextWatch = button.attr('data-watched') !== 'true';
+    const nextWatch = $(this).attr('data-watched') !== 'true';
     output('<p class="text-muted">Updating client watch...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/watch`,
-      method: 'POST',
-      data: { watch: nextWatch ? 'on' : '' },
+      url: `/clients/${encodeURIComponent(host)}/watch`, method: 'POST', data: { watch: nextWatch ? 'on' : '' },
       success: function (resp) {
-        button.attr('data-watched', resp.watched ? 'true' : 'false');
-        button.toggleClass('btn-warning', resp.watched).toggleClass('btn-outline-warning', !resp.watched);
-        button.text(resp.watched ? 'Watching client' : 'Watch this device');
+        const $buttons = $('[data-ip-client-watch]');
+        $buttons.attr('data-watched', resp.watched ? 'true' : 'false');
+        $buttons.toggleClass('btn-warning', resp.watched).toggleClass('btn-outline-warning', !resp.watched);
+        $buttons.each(function () { $(this).text(resp.watched ? ($(this).closest('.device-compact-actions').length ? 'Watching' : 'Watching client') : ($(this).closest('.device-compact-actions').length ? 'Watch' : 'Watch this device')); });
         output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client watch updated.')}</div>`);
       },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Client watch update failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-http-inspect]').on('click', function () {
+  $(document).on('click', '[data-ip-client-http-inspect]', function () {
     const host = clientHost();
     output('<p class="text-muted">Inspecting saved web-service candidates...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/http-inspect`,
-      method: 'POST',
+      url: `/clients/${encodeURIComponent(host)}/http-inspect`, method: 'POST',
       success: function (resp) { output(renderHttpInspect(resp.results || [])); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'HTTP inspection failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-fingerprint]').on('click', function () {
+  $(document).on('click', '[data-ip-client-fingerprint]', function () {
     const host = clientHost();
     output('<p class="text-muted">Fingerprinting saved service candidates...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/fingerprint`,
-      method: 'POST',
+      url: `/clients/${encodeURIComponent(host)}/fingerprint`, method: 'POST',
       success: function (resp) { output(renderFingerprints(resp.fingerprints || [])); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Service fingerprint failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-intelligence]').on('click', function () {
+  $(document).on('click', '[data-ip-client-intelligence]', function () {
     const host = clientHost();
     output('<p class="text-muted">Gathering device intelligence from saved profile data and safe service probes...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/intelligence`,
-      method: 'POST',
-      data: { activeProbe: 'on' },
+      url: `/clients/${encodeURIComponent(host)}/intelligence`, method: 'POST', data: { activeProbe: 'on' },
       success: function (resp) { output(renderIntelligence(resp.intelligence || {})); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Device intelligence failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-baseline]').on('click', function () {
+  $(document).on('click', '[data-ip-client-baseline]', function () {
     const host = clientHost();
     output('<p class="text-muted">Saving current device baseline...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/baseline`,
-      method: 'POST',
+      url: `/clients/${encodeURIComponent(host)}/baseline`, method: 'POST',
       success: function (resp) { output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client baseline saved.')}</div>`); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Baseline save failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-metadata-form]').on('submit', function (event) {
+  $(document).on('submit', '[data-ip-client-metadata-form]', function (event) {
     event.preventDefault();
+    const form = this;
     const host = clientHost();
+    const $form = $(form);
     output('<p class="text-muted">Saving client profile metadata...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/metadata`,
-      method: 'POST',
+      url: `/clients/${encodeURIComponent(host)}/metadata`, method: 'POST',
       data: {
-        tags: $('[data-ip-client-tags]').val(),
-        owner: $('[data-ip-client-owner]').val(),
-        location: $('[data-ip-client-location]').val(),
-        expectedPorts: $('[data-ip-client-expected-ports]').val(),
-        notes: $('[data-ip-client-notes]').val()
+        tags: $form.find('[data-ip-client-tags]').val(),
+        owner: $form.find('[data-ip-client-owner]').val(),
+        location: $form.find('[data-ip-client-location]').val(),
+        expectedPorts: $form.find('[data-ip-client-expected-ports]').val(),
+        notes: $form.find('[data-ip-client-notes]').val()
       },
-      success: function (resp) { output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client metadata saved.')}</div>`); },
+      success: function (resp) {
+        notifyFormSaved(form);
+        output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Client metadata saved.')}</div>`);
+      },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Client metadata save failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-scheduled-form]').on('submit', function (event) {
+  $(document).on('submit', '[data-ip-client-scheduled-form]', function (event) {
     event.preventDefault();
+    const form = this;
     const host = clientHost();
+    const $form = $(form);
     output('<p class="text-muted">Saving scheduled check plan...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/scheduled-check`,
-      method: 'POST',
-      data: {
-        intervalMinutes: $('[data-ip-client-check-interval]').val(),
-        checks: $('[data-ip-client-checks]').val()
+      url: `/clients/${encodeURIComponent(host)}/scheduled-check`, method: 'POST',
+      data: { intervalMinutes: $form.find('[data-ip-client-check-interval]').val(), checks: $form.find('[data-ip-client-checks]').val() },
+      success: function (resp) {
+        notifyFormSaved(form);
+        output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Scheduled check saved.')}</div>`);
       },
-      success: function (resp) { output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Scheduled check saved.')}</div>`); },
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Scheduled check save failed')}</div>`); }
     });
   });
 
-  $('[data-ip-client-run-scheduled]').on('click', function () {
+  $(document).on('click', '[data-ip-client-run-scheduled]', function () {
     const host = clientHost();
     output('<p class="text-muted">Running saved scheduled checks now...</p>');
     $.ajax({
-      url: `/clients/${encodeURIComponent(host)}/scheduled-check/run`,
-      method: 'POST',
+      url: `/clients/${encodeURIComponent(host)}/scheduled-check/run`, method: 'POST',
       success: function (resp) {
         const resultKeys = Object.keys((resp.plan || {}).last_result || {}).join(', ') || 'no checks';
         output(`<div class="alert alert-success">${escapeHtml(resp.message || 'Scheduled checks ran.')} Results: ${escapeHtml(resultKeys)}.</div>`);
@@ -248,5 +243,4 @@ $(document).ready(function () {
       error: function (xhr) { output(`<div class="alert alert-danger">${escapeHtml(xhr.responseJSON?.message || 'Scheduled check run failed')}</div>`); }
     });
   });
-
 });

--- a/static/js/port_scan_live.js
+++ b/static/js/port_scan_live.js
@@ -10,9 +10,7 @@ $(document).ready(function () {
 
   function detailByPort(job) {
     const details = {};
-    (job.open_port_details || []).forEach(function (item) {
-      details[item.port] = item;
-    });
+    (job.open_port_details || []).forEach(function (item) { details[item.port] = item; });
     return details;
   }
 
@@ -24,7 +22,6 @@ $(document).ready(function () {
       $list.html('<p class="text-muted mb-0">No open ports discovered yet.</p>');
       return;
     }
-
     let html = '<div class="port-service-grid">';
     ports.forEach(function (port) {
       const info = details[port] || { service: 'Unknown', description: 'No common service mapping found' };
@@ -51,10 +48,7 @@ $(document).ready(function () {
     const canCancel = Boolean(job.cancelable && !job.cancel_requested);
     $panel.data('currentJobId', job.id || $panel.data('currentJobId'));
     $panel.find('[data-port-scan-cancel]').toggle(canCancel).prop('disabled', !canCancel);
-
-    $panel.find('[data-port-scan-status]').html(
-      `<div class="alert alert-${statusClass}" role="status"><strong>${escapeHtml(job.status)}</strong>: ${escapeHtml(job.message || '')}${current}</div>`
-    );
+    $panel.find('[data-port-scan-status]').html(`<div class="alert alert-${statusClass}" role="status"><strong>${escapeHtml(job.status)}</strong>: ${escapeHtml(job.message || '')}${current}</div>`);
     $panel.find('[data-port-scan-progress-bar]').css('width', `${progress}%`).attr('aria-valuenow', progress).text(`${progress}%`);
     $panel.find('[data-port-scan-progress-text]').text(`${scanned} of ${total} ports checked`);
     renderOpenPorts($panel, job, previousPorts);
@@ -95,11 +89,8 @@ $(document).ready(function () {
     $panel.find('[data-port-scan-progress-bar]').css('width', '0%').attr('aria-valuenow', 0).text('0%');
     $panel.find('[data-port-scan-progress-text]').text('0 ports checked');
     $panel.find('[data-port-scan-open-ports]').html('<p class="text-muted mb-0">Waiting for open ports...</p>');
-
     $.ajax({
-      url: '/port-scan-jobs',
-      method: 'POST',
-      data: { host: host, start: start, end: end, label: label },
+      url: '/port-scan-jobs', method: 'POST', data: { host: host, start: start, end: end, label: label },
       success: function (resp) {
         $panel.data('currentJobId', resp.job.id);
         renderJob($panel, resp.job, new Set());
@@ -114,7 +105,6 @@ $(document).ready(function () {
     });
   }
 
-
   function cancelScan($panel) {
     const jobId = $panel.data('currentJobId');
     if (!jobId) {
@@ -123,8 +113,7 @@ $(document).ready(function () {
     }
     $panel.find('[data-port-scan-cancel]').prop('disabled', true).text('Cancelling...');
     $.ajax({
-      url: `/jobs/${encodeURIComponent(jobId)}/cancel`,
-      method: 'POST',
+      url: `/jobs/${encodeURIComponent(jobId)}/cancel`, method: 'POST',
       success: function (resp) {
         renderJob($panel, resp.job, new Set(resp.job.open_ports || []));
         $panel.find('[data-port-scan-cancel]').hide().prop('disabled', true);
@@ -135,41 +124,45 @@ $(document).ready(function () {
         $panel.find('[data-port-scan-status]').html(`<div class="alert alert-danger">${escapeHtml(message)}</div>`);
         $panel.find('[data-port-scan-cancel]').prop('disabled', false).text('Cancel scan');
       },
-      complete: function () {
-        $panel.find('[data-port-scan-cancel]').text('Cancel scan');
-      }
+      complete: function () { $panel.find('[data-port-scan-cancel]').text('Cancel scan'); }
     });
   }
 
-  $('.port-scan-panel').each(function () {
-    const $panel = $(this);
+  function initialisePanel(panelElement) {
+    if (!panelElement || panelElement.dataset.portScanInitialized === 'true') return;
+    panelElement.dataset.portScanInitialized = 'true';
+    const $panel = $(panelElement);
     const params = new URLSearchParams(window.location.search);
     const hostParam = params.get('host');
     const $hostInput = $panel.find('[data-port-scan-host]');
-    if (hostParam && $hostInput.length) {
-      $hostInput.val(hostParam);
-    }
+    if (hostParam && $hostInput.length) $hostInput.val(hostParam);
 
-    $panel.on('click', '[data-port-scan-start]', function (e) {
-      e.preventDefault();
+    $panel.on('click', '[data-port-scan-start]', function (event) {
+      event.preventDefault();
       const $button = $(this);
       const host = ($hostInput.val() || $panel.data('host') || '').trim();
       startScan($panel, host, $button.data('start'), $button.data('end'), $button.data('label') || 'port scan');
     });
-
     $panel.find('[data-port-scan-cancel]').hide().prop('disabled', true);
-
-    $panel.on('click', '[data-port-scan-cancel]', function (e) {
-      e.preventDefault();
+    $panel.on('click', '[data-port-scan-cancel]', function (event) {
+      event.preventDefault();
       cancelScan($panel);
     });
-
-    $panel.on('submit', '[data-port-scan-custom-form]', function (e) {
-      e.preventDefault();
+    $panel.on('submit', '[data-port-scan-custom-form]', function (event) {
+      event.preventDefault();
       const host = ($hostInput.val() || $panel.data('host') || '').trim();
-      const start = $panel.find('[data-port-scan-start-input]').val();
-      const end = $panel.find('[data-port-scan-end-input]').val();
-      startScan($panel, host, start, end, 'custom port scan');
+      startScan($panel, host, $panel.find('[data-port-scan-start-input]').val(), $panel.find('[data-port-scan-end-input]').val(), 'custom port scan');
     });
+  }
+
+  function initialisePanels(container) {
+    const root = container || document;
+    if (root.matches && root.matches('.port-scan-panel')) initialisePanel(root);
+    $(root).find('.port-scan-panel').each(function () { initialisePanel(this); });
+  }
+
+  initialisePanels(document);
+  document.addEventListener('device-workspace:loaded', function (event) {
+    initialisePanels(event.detail && event.detail.panel);
   });
 });

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -2,7 +2,7 @@
 <link rel="stylesheet" href="/static/css/interface.css">
 <link rel="stylesheet" href="/static/css/device-workspace.css">
 <body class="d-flex flex-column min-vh-100">
-  <main class="page-shell" data-long-page-disabled {% if not is_bluetooth %}data-device-workspace data-host="{{ ip }}"{% endif %}>
+  <main class="page-shell" data-long-page-disabled {% if ip and not is_bluetooth %}data-device-workspace data-host="{{ ip }}"{% endif %}>
     <section class="page-hero">
       <div class="page-hero-copy">
         <p class="page-kicker">{{ 'Bluetooth Device' if is_bluetooth else 'Client' }}</p>
@@ -135,11 +135,27 @@
       <section id="device-panel-history" class="device-workspace-panel" role="tabpanel" aria-labelledby="device-tab-history" data-device-workspace-panel="history" data-workspace-url="/clients/{{ ip|urlencode }}/workspace/history" hidden>
         <div class="device-workspace-loading"><div class="spinner-border text-primary" role="status" aria-hidden="true"></div><p>Loading history workspace…</p></div>
       </section>
+    {% else %}
+      <section class="theme-card card">
+        <div class="card-body">
+          <h2 class="theme-section-title">Observed identity</h2>
+          <p class="text-muted">This inventory record has a hardware address but no current IP address. Network tools will become available when an address is learned.</p>
+          <dl class="interface-definition-list">
+            <div><dt>MAC Address</dt><dd>{{ mac or 'Unknown' }}</dd></div>
+            <div><dt>Manufacturer</dt><dd>{{ manufacturer or 'Unknown' }}</dd></div>
+            <div><dt>Display name</dt><dd>{{ display_name }}</dd></div>
+            <div><dt>Discovery sources</dt><dd>{{ (inventory_device.sources or [])|join(', ') or 'Unknown' }}</dd></div>
+          </dl>
+          <div class="theme-actions">
+            <a class="btn btn-outline-secondary" href="/inventory">Return to inventory</a>
+          </div>
+        </div>
+      </section>
     {% endif %}
   </main>
 {% if is_bluetooth %}
 <script src="/static/js/bluetooth-scan.js"></script>
-{% else %}
+{% elif ip %}
 <script src="/static/js/port_scan_live.js"></script>
 <script src="/static/js/ip_client.js"></script>
 <script src="/static/js/device-workspace.js"></script>

--- a/templates/client_detail.html
+++ b/templates/client_detail.html
@@ -1,7 +1,8 @@
 {% include '_header.html' %}
 <link rel="stylesheet" href="/static/css/interface.css">
+<link rel="stylesheet" href="/static/css/device-workspace.css">
 <body class="d-flex flex-column min-vh-100">
-  <main class="page-shell">
+  <main class="page-shell" data-long-page-disabled {% if not is_bluetooth %}data-device-workspace data-host="{{ ip }}"{% endif %}>
     <section class="page-hero">
       <div class="page-hero-copy">
         <p class="page-kicker">{{ 'Bluetooth Device' if is_bluetooth else 'Client' }}</p>
@@ -16,85 +17,41 @@
       </div>
     </section>
 
-    <section class="theme-card card">
-      <div class="card-body">
-        <h2 class="theme-section-title">Overview</h2>
-        <dl class="interface-definition-list">
-          {% if not is_bluetooth %}
-            <div>
-              <dt>IP Address</dt>
-              <dd>{{ ip if ip else 'Unknown' }}</dd>
-            </div>
-          {% endif %}
-          <div>
-            <dt>{{ 'Bluetooth Address' if is_bluetooth else 'MAC Address' }}</dt>
-            <dd>{{ mac if mac else 'Unknown' }}</dd>
-          </div>
-          <div>
-            <dt>Manufacturer</dt>
-            <dd>{{ manufacturer }}</dd>
-          </div>
-          {% if not is_bluetooth %}
-            <div>
-              <dt>Likely Role</dt>
-              <dd>
-                {{ (inventory_device.device_role_guess or {}).role or 'Client' }}
-                <span class="badge badge-light border">{{ (inventory_device.device_role_guess or {}).confidence or 'low' }} confidence</span>
-              </dd>
-            </div>
-            <div>
-              <dt>MAC Privacy</dt>
-              <dd>{{ 'Likely randomized/private MAC' if inventory_device.likely_randomized_mac else 'Hardware/OUI MAC not flagged as randomized' }}</dd>
-            </div>
-          {% endif %}
-          {% for field in bluetooth_fields %}
-            <div>
-              <dt>{{ field.label }}</dt>
-              <dd>{{ field.value }}</dd>
-            </div>
-          {% endfor %}
-        </dl>
-        {% if not is_bluetooth and inventory_device.observed_names %}
-          <h3 class="theme-subsection-title mt-3">Names observed</h3>
-          <div class="network-device-tags">
-            {% for item in inventory_device.observed_names %}
-              <span class="badge badge-light border">{{ item.name }} · {{ item.source }}</span>
-            {% endfor %}
-          </div>
-        {% endif %}
-      </div>
-    </section>
-
     {% if is_bluetooth %}
+      <section class="theme-card card">
+        <div class="card-body">
+          <h2 class="theme-section-title">Overview</h2>
+          <dl class="interface-definition-list">
+            <div><dt>Bluetooth Address</dt><dd>{{ mac if mac else 'Unknown' }}</dd></div>
+            <div><dt>Manufacturer</dt><dd>{{ manufacturer }}</dd></div>
+            {% for field in bluetooth_fields %}
+              <div><dt>{{ field.label }}</dt><dd>{{ field.value }}</dd></div>
+            {% endfor %}
+          </dl>
+        </div>
+      </section>
+
       <section class="theme-card card bluetooth-device-card">
         <div class="card-body">
           <h2 class="theme-section-title">Bluetooth Controls</h2>
-          {% if not bluetooth_action_capability.available %}
-            <div class="alert alert-warning small" role="alert">{{ bluetooth_action_capability.message }}</div>
-          {% endif %}
+          {% if not bluetooth_action_capability.available %}<div class="alert alert-warning small" role="alert">{{ bluetooth_action_capability.message }}</div>{% endif %}
           <div class="form-group mt-3">
             <label for="bluetooth-action-adapter">Bluetooth Adapter</label>
             <select class="form-control" id="bluetooth-action-adapter" data-bluetooth-adapter>
               <option value="">Default host adapter</option>
-              {% for adapter in bluetooth_adapters %}
-                <option value="{{ adapter.id }}">{{ adapter.name }}{% if adapter.state %} — {{ adapter.state }}{% endif %}</option>
-              {% endfor %}
+              {% for adapter in bluetooth_adapters %}<option value="{{ adapter.id }}">{{ adapter.name }}{% if adapter.state %} — {{ adapter.state }}{% endif %}</option>{% endfor %}
             </select>
           </div>
           <div class="bluetooth-action-grid mt-2">
             <div class="bluetooth-contextual-actions">
-            {% for action in bluetooth_actions %}
-              <button type="button" class="btn btn-{{ action.style }} btn-sm bluetooth-action" data-action="{{ action.action }}" data-address="{{ mac }}" {% if not bluetooth_action_capability.available %}disabled{% endif %}>
-                <i class="fa-solid fa-{{ action.icon }}"></i> {{ action.label }}
-              </button>
-            {% endfor %}
+              {% for action in bluetooth_actions %}
+                <button type="button" class="btn btn-{{ action.style }} btn-sm bluetooth-action" data-action="{{ action.action }}" data-address="{{ mac }}" {% if not bluetooth_action_capability.available %}disabled{% endif %}>
+                  <i class="fa-solid fa-{{ action.icon }}"></i> {{ action.label }}
+                </button>
+              {% endfor %}
             </div>
-            <button type="button" class="btn btn-outline-info btn-sm bluetooth-refresh-device" data-address="{{ mac }}" {% if not bluetooth_action_capability.available %}disabled{% endif %}>
-              <i class="fa-solid fa-rotate"></i> Refresh This Device
-            </button>
-            <button type="button" class="btn btn-outline-danger btn-sm bluetooth-forget-device" data-address="{{ mac }}">
-              <i class="fa-solid fa-folder-minus"></i> Forget From Inventory
-            </button>
+            <button type="button" class="btn btn-outline-info btn-sm bluetooth-refresh-device" data-address="{{ mac }}" {% if not bluetooth_action_capability.available %}disabled{% endif %}><i class="fa-solid fa-rotate"></i> Refresh This Device</button>
+            <button type="button" class="btn btn-outline-danger btn-sm bluetooth-forget-device" data-address="{{ mac }}"><i class="fa-solid fa-folder-minus"></i> Forget From Inventory</button>
           </div>
           <pre class="bluetooth-action-output d-none mt-3 mb-0"></pre>
           <div class="bluetooth-action-history mt-3">
@@ -102,238 +59,81 @@
             <ol class="bluetooth-action-history-list">
               {% for entry in bluetooth_action_history %}
                 <li class="{{ 'text-danger' if entry.status == 'error' else 'text-success' }}"><strong>{{ entry.time_label }}</strong> — {{ entry.action }}{% if entry.adapter %} via {{ entry.adapter }}{% endif %}: {{ entry.message }}</li>
-              {% else %}
-                <li class="text-muted">No Bluetooth actions have been run for this device yet.</li>
-              {% endfor %}
+              {% else %}<li class="text-muted">No Bluetooth actions have been run for this device yet.</li>{% endfor %}
             </ol>
           </div>
         </div>
       </section>
     {% elif ip %}
-      <section class="theme-card card">
-        <div class="card-body">
-          <div class="d-flex justify-content-between align-items-start flex-wrap">
-            <div>
-              <h2 class="theme-section-title">Client Health</h2>
-              <p class="text-muted">A lightweight profile score built from identity confidence, saved services, and exposure hints.</p>
-            </div>
-            <span class="badge badge-{{ health_summary.badge }} p-2">{{ health_summary.level }} · {{ health_summary.score }}/100</span>
+      {% set unexpected = baseline_diff.unexpected_ports or [] %}
+      {% set missing = baseline_diff.missing_ports or [] %}
+      {% set identity_count = (inventory_device.observed_names or [])|length + ((inventory_device.host_facts or [])|length) + (1 if inventory_device.identity_assessment else 0) %}
+      {% set network_count = (relationship_map.links or [])|length if relationship_map else 0 %}
+      {% set service_count = open_port_details|length %}
+      {% set security_count = unexpected|length + missing|length + (health_summary.flags or [])|length %}
+      {% set history_count = client_timeline|length %}
+
+      <section class="device-compact-header" data-device-compact-header aria-label="Current device summary">
+        <div class="device-compact-identity">
+          <span class="device-status-dot {{ 'device-status-dot-online' if inventory_device.status in ['online', 'up', 'reachable'] else '' }}" aria-hidden="true"></span>
+          <div>
+            <strong>{{ display_name }}</strong>
+            <span>{{ ip }}{% if mac %} · {{ mac }}{% endif %}</span>
           </div>
-          <div class="theme-actions">
-            <button type="button" class="btn btn-{{ 'warning' if watched_client else 'outline-warning' }}" data-ip-client-watch data-watched="{{ 'true' if watched_client else 'false' }}">
-              {{ 'Watching client' if watched_client else 'Watch this device' }}
-            </button>
-            <button type="button" class="btn btn-outline-info" data-ip-client-http-inspect>Inspect web services</button>
-            <button type="button" class="btn btn-outline-success" data-ip-client-fingerprint>Fingerprint services</button>
-            <button type="button" class="btn btn-outline-dark" data-ip-client-intelligence>Gather device intelligence</button>
-            <button type="button" class="btn btn-outline-primary" data-ip-client-baseline>Save baseline</button>
-            <a class="btn btn-outline-secondary" href="/clients/{{ ip|urlencode }}/export.json">Export JSON</a>
-            <a class="btn btn-outline-secondary" href="/clients/{{ ip|urlencode }}/export.md">Export Markdown</a>
-          </div>
-          <ul class="mt-3 mb-0">
-            {% for flag in health_summary.flags %}
-              <li>{{ flag }}</li>
-            {% endfor %}
-          </ul>
-          <div class="mt-3">
-            <strong>Baseline drift:</strong> {{ baseline_diff.status }}
-            {% if baseline_diff.unexpected_ports %}<span class="badge badge-danger">Unexpected {{ baseline_diff.unexpected_ports|join(', ') }}</span>{% endif %}
-            {% if baseline_diff.missing_ports %}<span class="badge badge-warning">Missing {{ baseline_diff.missing_ports|join(', ') }}</span>{% endif %}
-          </div>
+        </div>
+        <div class="device-compact-summary">
+          <span class="badge badge-{{ health_summary.badge }}">{{ health_summary.level }} {{ health_summary.score }}/100</span>
+          <span class="badge badge-light border">{{ service_count }} services</span>
+          {% if security_count %}<span class="badge badge-warning">{{ security_count }} findings</span>{% endif %}
+        </div>
+        <div class="device-compact-actions">
+          <button type="button" class="btn btn-sm btn-outline-primary" data-workspace-open="services">Scan</button>
+          <button type="button" class="btn btn-sm btn-outline-dark" data-ip-client-intelligence>Identify</button>
+          <button type="button" class="btn btn-sm btn-{{ 'warning' if watched_client else 'outline-warning' }}" data-ip-client-watch data-watched="{{ 'true' if watched_client else 'false' }}">{{ 'Watching' if watched_client else 'Watch' }}</button>
         </div>
       </section>
 
-      <section class="theme-card card">
-        <div class="card-body">
-          <h2 class="theme-section-title">Client Profile Metadata</h2>
-          <form class="theme-form" data-ip-client-metadata-form>
-            <div class="form-row">
-              <div class="col">
-                <label for="client-tags">Tags</label>
-                <input id="client-tags" class="form-control" data-ip-client-tags value="{{ (inventory_device.client_tags or [])|join(', ') if inventory_device else '' }}" placeholder="trusted, printer, guest">
-              </div>
-              <div class="col">
-                <label for="client-owner">Owner</label>
-                <input id="client-owner" class="form-control" data-ip-client-owner value="{{ inventory_device.client_owner if inventory_device else '' }}" placeholder="Team or person">
-              </div>
-            </div>
-            <div class="form-row mt-2">
-              <div class="col">
-                <label for="client-location">Location</label>
-                <input id="client-location" class="form-control" data-ip-client-location value="{{ inventory_device.client_location if inventory_device else '' }}" placeholder="Office, lab bench, garage">
-              </div>
-              <div class="col">
-                <label for="client-expected-ports">Expected open ports</label>
-                <input id="client-expected-ports" class="form-control" data-ip-client-expected-ports value="{{ (inventory_device.expected_open_ports or [])|join(', ') if inventory_device else '' }}" placeholder="22, 80, 443">
-              </div>
-            </div>
-            <label class="mt-2" for="client-notes">Profile notes</label>
-            <textarea id="client-notes" class="form-control" data-ip-client-notes rows="2" placeholder="Expected purpose, owner context, or remediation notes.">{{ inventory_device.client_notes if inventory_device else '' }}</textarea>
-            <div class="theme-actions">
-              <button type="submit" class="btn btn-primary">Save client metadata</button>
-            </div>
-          </form>
+      <section class="device-workspace-navigation" aria-label="Device workspace navigation">
+        <div class="device-workspace-tablist" role="tablist" aria-label="Device workspaces">
+          <button id="device-tab-overview" class="device-workspace-tab active" type="button" role="tab" aria-selected="true" aria-controls="device-panel-overview" data-device-workspace-tab="overview"><i class="fa-solid fa-gauge-high" aria-hidden="true"></i><span>Overview</span></button>
+          <button id="device-tab-identity" class="device-workspace-tab" type="button" role="tab" aria-selected="false" aria-controls="device-panel-identity" data-device-workspace-tab="identity"><i class="fa-solid fa-fingerprint" aria-hidden="true"></i><span>Identity</span><span class="device-tab-badge">{{ identity_count }}</span></button>
+          <button id="device-tab-network" class="device-workspace-tab" type="button" role="tab" aria-selected="false" aria-controls="device-panel-network" data-device-workspace-tab="network"><i class="fa-solid fa-diagram-project" aria-hidden="true"></i><span>Network</span><span class="device-tab-badge">{{ network_count }}</span></button>
+          <button id="device-tab-services" class="device-workspace-tab" type="button" role="tab" aria-selected="false" aria-controls="device-panel-services" data-device-workspace-tab="services"><i class="fa-solid fa-server" aria-hidden="true"></i><span>Services</span><span class="device-tab-badge">{{ service_count }}</span></button>
+          <button id="device-tab-security" class="device-workspace-tab" type="button" role="tab" aria-selected="false" aria-controls="device-panel-security" data-device-workspace-tab="security"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i><span>Security</span><span class="device-tab-badge {{ 'device-tab-badge-warning' if security_count else '' }}">{{ security_count }}</span></button>
+          <button id="device-tab-history" class="device-workspace-tab" type="button" role="tab" aria-selected="false" aria-controls="device-panel-history" data-device-workspace-tab="history"><i class="fa-solid fa-clock-rotate-left" aria-hidden="true"></i><span>History</span><span class="device-tab-badge">{{ history_count }}</span></button>
+        </div>
+        <div class="device-workspace-select-group">
+          <label for="device-workspace-select">Workspace</label>
+          <select id="device-workspace-select" class="form-control" data-device-workspace-select>
+            <option value="overview">Overview</option>
+            <option value="identity">Identity</option>
+            <option value="network">Network</option>
+            <option value="services">Services</option>
+            <option value="security">Security</option>
+            <option value="history">History</option>
+          </select>
         </div>
       </section>
 
-      <section class="theme-card card">
-        <div class="card-body">
-          <h2 class="theme-section-title">Client Relationship Map</h2>
-          <p class="text-muted">Context links between this client, interfaces, discovery sources, saved services, and evidence records.</p>
-          <div class="theme-grid">
-            {% for node in relationship_map.nodes %}
-              <div class="port-service-card">
-                <strong>{{ node.label }}</strong>
-                <small>{{ node.type }}</small>
-              </div>
-            {% endfor %}
-          </div>
-          <ul class="mt-3 mb-0">
-            {% for link in relationship_map.links %}
-              <li>{{ link.source }} → {{ link.target }} <span class="text-muted">({{ link.label }})</span></li>
-            {% else %}
-              <li class="text-muted">No related interfaces, services, or evidence are attached yet.</li>
-            {% endfor %}
-          </ul>
-        </div>
+      <div class="device-workspace-global-output" data-ip-client-global-output aria-live="polite"></div>
+
+      <section id="device-panel-overview" class="device-workspace-panel active" role="tabpanel" aria-labelledby="device-tab-overview" data-device-workspace-panel="overview">
+        {% include 'client_workspace/_overview.html' %}
       </section>
-
-      <section class="theme-card card">
-        <div class="card-body">
-          <h2 class="theme-section-title">Scheduled Client Checks</h2>
-          <p class="text-muted">Save a recurring check plan for this client. The plan is recorded, persisted, and can be run on demand; due-check APIs can also execute saved plans without rerunning massive scans.</p>
-          {% if scheduled_check %}
-            <div class="alert alert-info">Scheduled every {{ scheduled_check.interval_minutes }} minute(s): {{ scheduled_check.checks|join(', ') }}</div>
-          {% endif %}
-          <form class="theme-form" data-ip-client-scheduled-form>
-            <label for="client-check-interval">Interval minutes</label>
-            <input id="client-check-interval" class="form-control" type="number" min="5" max="10080" value="{{ scheduled_check.interval_minutes if scheduled_check else 60 }}" data-ip-client-check-interval>
-            <label class="mt-2" for="client-checks">Checks</label>
-            <input id="client-checks" class="form-control" value="{{ scheduled_check.checks|join(', ') if scheduled_check else 'ping, common-ports, baseline-drift' }}" data-ip-client-checks placeholder="ping, common-ports, http-inspect, service-fingerprint, baseline-drift">
-            <div class="theme-actions">
-              <button type="submit" class="btn btn-primary">Save scheduled checks</button>
-              <button type="button" class="btn btn-outline-success" data-ip-client-run-scheduled>Run saved checks now</button>
-            </div>
-          </form>
-        </div>
+      <section id="device-panel-identity" class="device-workspace-panel" role="tabpanel" aria-labelledby="device-tab-identity" data-device-workspace-panel="identity" hidden>
+        {% include 'client_workspace/_identity.html' %}
       </section>
-
-      <section class="theme-card card" data-ip-client-tools data-host="{{ ip }}">
-        <div class="card-body">
-          <h2 class="theme-section-title">IP Client Actions</h2>
-          <p class="text-muted">Run quick reachability and path checks, jump to deeper diagnostics, or save investigation notes for this client profile.</p>
-          <div class="theme-actions">
-            <button type="button" class="btn btn-outline-success" data-ip-client-ping>Ping client</button>
-            <button type="button" class="btn btn-outline-info" data-ip-client-route>Route diagnostics</button>
-            <button type="button" class="btn btn-outline-secondary" data-ip-client-traceroute>Traceroute</button>
-            <a class="btn btn-outline-primary" href="/diagnostics">Open diagnostics</a>
-          </div>
-          <form class="theme-form mt-3" data-ip-client-evidence-form>
-            <label for="ip-client-evidence">Evidence / investigation note</label>
-            <textarea id="ip-client-evidence" class="form-control" data-ip-client-evidence-notes rows="3" placeholder="Example: Gateway responded to ping; SSH and HTTPS open during authorized baseline." required></textarea>
-            <div class="theme-actions">
-              <button type="submit" class="btn btn-primary">Save evidence note</button>
-              <a class="btn btn-link" href="/evidence">Open Evidence Vault</a>
-            </div>
-          </form>
-          <div class="theme-results mt-3" data-ip-client-output><p class="text-muted mb-0">No IP client action has run yet.</p></div>
-        </div>
+      <section id="device-panel-network" class="device-workspace-panel" role="tabpanel" aria-labelledby="device-tab-network" data-device-workspace-panel="network" data-workspace-url="/clients/{{ ip|urlencode }}/workspace/network" hidden>
+        <div class="device-workspace-loading"><div class="spinner-border text-primary" role="status" aria-hidden="true"></div><p>Loading network workspace…</p></div>
       </section>
-
-      {% if open_port_details %}
-        <section class="theme-card card">
-          <div class="card-body">
-            <h2 class="theme-section-title">Saved Service Profile</h2>
-            <p class="text-muted">Open ports found on previous scans are saved to this device profile{% if last_port_scan_label %}; last scan {{ last_port_scan_label }}{% endif %}.</p>
-            <div class="port-service-grid">
-              {% for port in open_port_details %}
-                <div class="port-service-card" data-web-service-preview>
-                  <strong class="port-service-number">
-                    {% if port.web_url %}
-                      <a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>
-                    {% else %}
-                      {{ port.port }}/tcp
-                    {% endif %}
-                  </strong>
-                  <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}">
-                    <span>{{ port.service }}</span>
-                    <small>{{ port.description }}</small>
-                    {% if port.http_title %}<small>HTTP title: {{ port.http_title }}</small>{% endif %}
-                    {% if port.http_favicon %}<small>Favicon SHA-256: {{ port.http_favicon.sha256[:12] }}…</small>{% endif %}
-                    {% if port.tls_certificate %}<small>TLS CN: {{ port.tls_certificate.subject_common_name or 'Unknown' }}{% if port.tls_certificate.issuer_common_name %} · Issuer: {{ port.tls_certificate.issuer_common_name }}{% endif %}</small>{% endif %}
-                  </a>
-                  {% if port.web_url %}
-                    <div class="web-service-hover-preview">
-                      {% if port.http_thumbnail_url %}<img src="{{ port.http_thumbnail_url }}" alt="Preview of {{ port.web_url }}">{% endif %}
-                      <strong>{{ port.http_title or port.web_url }}</strong>
-                      <span>Status: {{ port.http_status or 'not captured' }}{% if port.http_server %} · {{ port.http_server }}{% endif %}</span>
-                      <small>Long-hover preview. Click the port circle to open the web page; click the card body for saved service details.</small>
-                    </div>
-                  {% endif %}
-                </div>
-              {% endfor %}
-            </div>
-          </div>
-        </section>
-      {% endif %}
-
-      <section class="theme-card card port-scan-panel" data-host="{{ ip }}">
-        <div class="card-body">
-          <h2 class="theme-section-title">Device Port Scan</h2>
-          <p class="text-muted">Run scans in the background and watch open ports appear as they are discovered.</p>
-          <div class="theme-actions">
-            <button class="btn btn-outline-primary" data-port-scan-start data-start="1" data-end="1024" data-label="common port scan">Common ports</button>
-            <button class="btn btn-outline-danger" data-port-scan-start data-start="1" data-end="65535" data-label="all-port scan">All ports</button>
-          </div>
-          <form class="theme-form mt-3" data-port-scan-custom-form>
-            <input type="hidden" data-port-scan-host value="{{ ip }}">
-            <div class="form-row">
-              <div class="col">
-                <label for="device-scan-start">Custom Start Port</label>
-                <input type="number" class="form-control" id="device-scan-start" data-port-scan-start-input value="1" min="1" max="65535" required>
-              </div>
-              <div class="col">
-                <label for="device-scan-end">Custom End Port</label>
-                <input type="number" class="form-control" id="device-scan-end" data-port-scan-end-input value="1024" min="1" max="65535" required>
-              </div>
-            </div>
-            <div class="theme-actions">
-              <button class="btn btn-primary" data-port-scan-custom-submit>Run custom scan</button>
-              <a class="btn btn-link" href="/port-scan?host={{ ip|urlencode }}">Open full port scan page</a>
-            </div>
-          </form>
-          <div class="theme-results mt-3">
-            <button class="btn btn-warning btn-sm mb-2" data-port-scan-cancel type="button">Cancel scan</button>
-            <div data-port-scan-status class="mb-2"><p class="text-muted">No port scan running for this device.</p></div>
-            <div class="progress mb-2" aria-label="Device port scan progress">
-              <div class="progress-bar" data-port-scan-progress-bar role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</div>
-            </div>
-            <p class="text-muted" data-port-scan-progress-text>0 ports checked</p>
-            <h3>Open ports discovered</h3>
-            <div data-port-scan-open-ports><p class="text-muted mb-0">Open ports will appear here immediately.</p></div>
-          </div>
-        </div>
+      <section id="device-panel-services" class="device-workspace-panel" role="tabpanel" aria-labelledby="device-tab-services" data-device-workspace-panel="services" data-workspace-url="/clients/{{ ip|urlencode }}/workspace/services" hidden>
+        <div class="device-workspace-loading"><div class="spinner-border text-primary" role="status" aria-hidden="true"></div><p>Loading services workspace…</p></div>
       </section>
-
-      <section class="theme-card card">
-        <div class="card-body">
-          <h2 class="theme-section-title">Client Timeline</h2>
-          {% if reachability_history %}
-            <div class="alert alert-info">
-              Recent reachability: {{ reachability_history|length }} ping check(s), latest {{ 'reachable' if reachability_history[-1].reachable else 'unreachable' }} with {{ reachability_history[-1].packet_loss_percent }}% loss.
-            </div>
-          {% endif %}
-          <ol class="client-timeline">
-            {% for event in client_timeline %}
-              <li>
-                <strong>{{ event.time_label }}</strong> — {{ event.type }}
-                <p class="mb-0">{{ event.message }}{% if event.source %} <span class="text-muted">({{ event.source }})</span>{% endif %}</p>
-              </li>
-            {% else %}
-              <li class="text-muted">No client timeline events have been recorded yet.</li>
-            {% endfor %}
-          </ol>
-        </div>
+      <section id="device-panel-security" class="device-workspace-panel" role="tabpanel" aria-labelledby="device-tab-security" data-device-workspace-panel="security" data-workspace-url="/clients/{{ ip|urlencode }}/workspace/security" hidden>
+        <div class="device-workspace-loading"><div class="spinner-border text-primary" role="status" aria-hidden="true"></div><p>Loading security workspace…</p></div>
+      </section>
+      <section id="device-panel-history" class="device-workspace-panel" role="tabpanel" aria-labelledby="device-tab-history" data-device-workspace-panel="history" data-workspace-url="/clients/{{ ip|urlencode }}/workspace/history" hidden>
+        <div class="device-workspace-loading"><div class="spinner-border text-primary" role="status" aria-hidden="true"></div><p>Loading history workspace…</p></div>
       </section>
     {% endif %}
   </main>
@@ -342,6 +142,7 @@
 {% else %}
 <script src="/static/js/port_scan_live.js"></script>
 <script src="/static/js/ip_client.js"></script>
+<script src="/static/js/device-workspace.js"></script>
 {% endif %}
 </body>
 {% include '_footer.html' %}

--- a/templates/client_workspace/_history.html
+++ b/templates/client_workspace/_history.html
@@ -1,0 +1,69 @@
+<section aria-labelledby="workspace-history-title">
+  <div class="device-workspace-section-heading">
+    <div>
+      <p class="page-kicker mb-1">History</p>
+      <h2 id="workspace-history-title" class="theme-section-title mb-1">Timeline, reachability, and exports</h2>
+      <p class="text-muted mb-0">Review how the device profile, services, and reachability have changed over time.</p>
+    </div>
+    <div class="theme-actions mt-0">
+      <a class="btn btn-outline-secondary" href="/clients/{{ ip|urlencode }}/export.json">Export JSON</a>
+      <a class="btn btn-outline-secondary" href="/clients/{{ ip|urlencode }}/export.md">Export Markdown</a>
+      <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts.json">Host facts JSON</a>
+    </div>
+  </div>
+
+  <div class="device-overview-columns mt-3">
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Reachability history</h3>
+        {% if reachability_history %}
+          <div class="theme-grid">
+            {% for item in reachability_history[-12:] %}
+              <div class="port-service-card">
+                <strong>{{ item.time_label or item.timestamp or 'Check' }}</strong>
+                <span class="{{ 'text-success' if item.reachable else 'text-danger' }}">{{ 'Reachable' if item.reachable else 'Unreachable' }}</span>
+                <small>{{ item.packet_loss_percent }}% loss{% if item.avg_latency_ms is not none %} · {{ item.avg_latency_ms }} ms avg{% endif %}</small>
+              </div>
+            {% endfor %}
+          </div>
+        {% else %}
+          <div class="device-empty-state">
+            <i class="fa-solid fa-chart-line" aria-hidden="true"></i>
+            <h4>No reachability history</h4>
+            <p>Run a ping from the Network workspace to begin recording availability and latency.</p>
+            <button type="button" class="btn btn-outline-primary" data-workspace-open="network">Open Network</button>
+          </div>
+        {% endif %}
+      </div>
+    </article>
+
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Saved history counts</h3>
+        <dl class="interface-definition-list">
+          <div><dt>Timeline events</dt><dd>{{ client_timeline|length }}</dd></div>
+          <div><dt>Reachability checks</dt><dd>{{ reachability_history|length }}</dd></div>
+          <div><dt>Host fact runs</dt><dd>{{ (inventory_device.host_fact_runs or [])|length }}</dd></div>
+          <div><dt>Saved services</dt><dd>{{ (inventory_device.open_port_details or [])|length }}</dd></div>
+          <div><dt>Evidence records</dt><dd>{{ (inventory_device.evidence_records or [])|length }}</dd></div>
+        </dl>
+      </div>
+    </article>
+  </div>
+
+  <article class="theme-card card mt-4">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Client timeline</h3>
+      <ol class="client-timeline mb-0">
+        {% for event in client_timeline %}
+          <li>
+            <strong>{{ event.time_label }}</strong> — {{ event.type }}
+            <p class="mb-0">{{ event.message }}{% if event.source %} <span class="text-muted">({{ event.source }})</span>{% endif %}</p>
+          </li>
+        {% else %}
+          <li class="text-muted">No client timeline events have been recorded yet.</li>
+        {% endfor %}
+      </ol>
+    </div>
+  </article>
+</section>

--- a/templates/client_workspace/_identity.html
+++ b/templates/client_workspace/_identity.html
@@ -1,0 +1,106 @@
+<section aria-labelledby="workspace-identity-title">
+  <div class="device-workspace-section-heading">
+    <div>
+      <p class="page-kicker mb-1">Identity</p>
+      <h2 id="workspace-identity-title" class="theme-section-title mb-1">Device identity and metadata</h2>
+      <p class="text-muted mb-0">Review discovered identity evidence and maintain the local profile without losing scanner-derived values.</p>
+    </div>
+    <div class="theme-actions mt-0">
+      <button type="button" class="btn btn-outline-dark" data-ip-client-intelligence>Identify device</button>
+      <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts">Host facts</a>
+      <a class="btn btn-outline-secondary" href="/models">Model library</a>
+    </div>
+  </div>
+
+  <div class="device-overview-columns mt-3">
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Observed identity</h3>
+        <dl class="interface-definition-list">
+          <div><dt>IP Address</dt><dd>{{ ip or 'Unknown' }}</dd></div>
+          <div><dt>MAC Address</dt><dd>{{ mac or 'Unknown' }}</dd></div>
+          <div><dt>Manufacturer</dt><dd>{{ manufacturer or 'Unknown' }}</dd></div>
+          <div>
+            <dt>Likely Role</dt>
+            <dd>{{ (inventory_device.device_role_guess or {}).role or 'Client' }} <span class="badge badge-light border">{{ (inventory_device.device_role_guess or {}).confidence or 'low' }} confidence</span></dd>
+          </div>
+          <div><dt>Model</dt><dd>{{ inventory_device.model or 'Not identified' }}</dd></div>
+          <div><dt>Firmware</dt><dd>{{ inventory_device.firmware or inventory_device.firmware_version or 'Unknown' }}</dd></div>
+          <div><dt>Hardware revision</dt><dd>{{ inventory_device.hardware_revision or 'Unknown' }}</dd></div>
+          <div><dt>MAC Privacy</dt><dd>{{ 'Likely randomized/private MAC' if inventory_device.likely_randomized_mac else 'Hardware/OUI MAC not flagged as randomized' }}</dd></div>
+        </dl>
+        {% if inventory_device.observed_names %}
+          <h4 class="theme-subsection-title mt-3">Names observed</h4>
+          <div class="network-device-tags">
+            {% for item in inventory_device.observed_names %}
+              <span class="badge badge-light border">{{ item.name }} · {{ item.source }}</span>
+            {% endfor %}
+          </div>
+        {% else %}
+          <p class="text-muted mb-0">No DHCP, DNS, mDNS, NetBIOS, or user-maintained names have been recorded yet.</p>
+        {% endif %}
+      </div>
+    </article>
+
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Identification assessment</h3>
+        {% set assessment = inventory_device.identity_assessment or {} %}
+        {% if assessment %}
+          <dl class="interface-definition-list">
+            <div><dt>Likely device</dt><dd>{{ assessment.label or assessment.model or 'Unknown' }}</dd></div>
+            <div><dt>Confidence</dt><dd>{{ assessment.confidence or 'Unknown' }}</dd></div>
+            <div><dt>Stage</dt><dd>{{ inventory_device.identity_identification_stage or 'passive' }}</dd></div>
+            <div><dt>Identity signature</dt><dd><code>{{ (inventory_device.identity_signature or '')[:20] }}{% if inventory_device.identity_signature %}…{% endif %}</code></dd></div>
+          </dl>
+          {% if assessment.evidence %}
+            <ul class="mb-0">
+              {% for item in assessment.evidence[:8] %}<li>{{ item }}</li>{% endfor %}
+            </ul>
+          {% endif %}
+        {% else %}
+          <div class="device-empty-state">
+            <i class="fa-solid fa-fingerprint" aria-hidden="true"></i>
+            <h4>No identification assessment yet</h4>
+            <p>Run device identification to combine names, manufacturer, services, UPnP, TLS, SSH, and other saved evidence.</p>
+            <button type="button" class="btn btn-primary" data-ip-client-intelligence>Identify device</button>
+          </div>
+        {% endif %}
+      </div>
+    </article>
+  </div>
+
+  <article class="theme-card card mt-4">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Client profile metadata</h3>
+      <form class="theme-form" data-ip-client-metadata-form data-workspace-form>
+        <div class="form-row">
+          <div class="col">
+            <label for="client-tags">Tags</label>
+            <input id="client-tags" class="form-control" data-ip-client-tags name="tags" value="{{ (inventory_device.client_tags or [])|join(', ') if inventory_device else '' }}" placeholder="trusted, printer, guest">
+          </div>
+          <div class="col">
+            <label for="client-owner">Owner</label>
+            <input id="client-owner" class="form-control" data-ip-client-owner name="owner" value="{{ inventory_device.client_owner if inventory_device else '' }}" placeholder="Team or person">
+          </div>
+        </div>
+        <div class="form-row mt-2">
+          <div class="col">
+            <label for="client-location">Location</label>
+            <input id="client-location" class="form-control" data-ip-client-location name="location" value="{{ inventory_device.client_location if inventory_device else '' }}" placeholder="Office, lab bench, garage">
+          </div>
+          <div class="col">
+            <label for="client-expected-ports">Expected open ports</label>
+            <input id="client-expected-ports" class="form-control" data-ip-client-expected-ports name="expectedPorts" value="{{ (inventory_device.expected_open_ports or [])|join(', ') if inventory_device else '' }}" placeholder="22, 80, 443">
+          </div>
+        </div>
+        <label class="mt-2" for="client-notes">Profile notes</label>
+        <textarea id="client-notes" class="form-control" data-ip-client-notes name="notes" rows="3" placeholder="Expected purpose, owner context, or remediation notes.">{{ inventory_device.client_notes if inventory_device else '' }}</textarea>
+        <div class="theme-actions">
+          <button type="submit" class="btn btn-primary">Save client metadata</button>
+          <span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span>
+        </div>
+      </form>
+    </div>
+  </article>
+</section>

--- a/templates/client_workspace/_network.html
+++ b/templates/client_workspace/_network.html
@@ -1,0 +1,111 @@
+<section aria-labelledby="workspace-network-title">
+  <div class="device-workspace-section-heading">
+    <div>
+      <p class="page-kicker mb-1">Network</p>
+      <h2 id="workspace-network-title" class="theme-section-title mb-1">Connectivity and relationships</h2>
+      <p class="text-muted mb-0">Reachability, path diagnostics, linked interfaces, dependencies, and scheduled checks.</p>
+    </div>
+  </div>
+
+  <div class="device-overview-columns mt-3">
+    <article class="theme-card card" data-ip-client-tools data-host="{{ ip }}">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Quick network actions</h3>
+        <div class="theme-actions">
+          <button type="button" class="btn btn-outline-success" data-ip-client-ping>Ping client</button>
+          <button type="button" class="btn btn-outline-info" data-ip-client-route>Route diagnostics</button>
+          <button type="button" class="btn btn-outline-secondary" data-ip-client-traceroute>Traceroute</button>
+          <a class="btn btn-outline-primary" href="/diagnostics">Open diagnostics</a>
+        </div>
+        {% if reachability_history %}
+          <div class="alert alert-info mt-3 mb-0">
+            Recent reachability: {{ reachability_history|length }} check(s); latest {{ 'reachable' if reachability_history[-1].reachable else 'unreachable' }} with {{ reachability_history[-1].packet_loss_percent }}% packet loss.
+          </div>
+        {% else %}
+          <div class="device-empty-state mt-3">
+            <i class="fa-solid fa-satellite-dish" aria-hidden="true"></i>
+            <h4>No reachability history yet</h4>
+            <p>Ping the device to start a lightweight reachability history.</p>
+          </div>
+        {% endif %}
+      </div>
+    </article>
+
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Network presence</h3>
+        <dl class="interface-definition-list">
+          <div><dt>IPv4</dt><dd>{{ ip }}</dd></div>
+          <div><dt>MAC</dt><dd>{{ mac or 'Unknown' }}</dd></div>
+          <div><dt>Interfaces</dt><dd>{{ (inventory_device.interfaces or [])|join(', ') or 'Unknown' }}</dd></div>
+          <div><dt>Discovery sources</dt><dd>{{ (inventory_device.sources or [])|join(', ') or 'Unknown' }}</dd></div>
+          <div><dt>IPv6 addresses</dt><dd>{{ (inventory_device.ipv6_addresses or inventory_device.ipv6 or [])|join(', ') or 'None recorded' }}</dd></div>
+        </dl>
+      </div>
+    </article>
+  </div>
+
+  <article class="theme-card card mt-4">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Client relationship map</h3>
+      <p class="text-muted">Context links between this client, interfaces, discovery sources, saved services, and evidence records.</p>
+      <div class="theme-grid">
+        {% for node in relationship_map.nodes %}
+          <div class="port-service-card">
+            <strong>{{ node.label }}</strong>
+            <small>{{ node.type }}</small>
+          </div>
+        {% else %}
+          <div class="device-empty-state">
+            <i class="fa-solid fa-diagram-project" aria-hidden="true"></i>
+            <h4>No relationships recorded</h4>
+            <p>Run discovery and service scans to build links between this device and its network context.</p>
+          </div>
+        {% endfor %}
+      </div>
+      {% if relationship_map.links %}
+        <ul class="mt-3 mb-0">
+          {% for link in relationship_map.links %}
+            <li>{{ link.source }} → {{ link.target }} <span class="text-muted">({{ link.label }})</span></li>
+          {% endfor %}
+        </ul>
+      {% endif %}
+    </div>
+  </article>
+
+  <article class="theme-card card mt-4">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Scheduled client checks</h3>
+      <p class="text-muted">Save a recurring check plan for this client and run it on demand.</p>
+      {% if scheduled_check %}
+        <div class="alert alert-info">Scheduled every {{ scheduled_check.interval_minutes }} minute(s): {{ scheduled_check.checks|join(', ') }}</div>
+      {% endif %}
+      <form class="theme-form" data-ip-client-scheduled-form data-workspace-form>
+        <label for="client-check-interval">Interval minutes</label>
+        <input id="client-check-interval" class="form-control" name="intervalMinutes" type="number" min="5" max="10080" value="{{ scheduled_check.interval_minutes if scheduled_check else 60 }}" data-ip-client-check-interval>
+        <label class="mt-2" for="client-checks">Checks</label>
+        <input id="client-checks" class="form-control" name="checks" value="{{ scheduled_check.checks|join(', ') if scheduled_check else 'ping, common-ports, baseline-drift' }}" data-ip-client-checks placeholder="ping, common-ports, http-inspect, service-fingerprint, baseline-drift">
+        <div class="theme-actions">
+          <button type="submit" class="btn btn-primary">Save scheduled checks</button>
+          <button type="button" class="btn btn-outline-success" data-ip-client-run-scheduled>Run saved checks now</button>
+          <span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span>
+        </div>
+      </form>
+    </div>
+  </article>
+
+  <article class="theme-card card mt-4">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Investigation note</h3>
+      <form class="theme-form" data-ip-client-evidence-form data-workspace-form>
+        <label for="ip-client-evidence">Evidence / investigation note</label>
+        <textarea id="ip-client-evidence" class="form-control" name="notes" data-ip-client-evidence-notes rows="3" placeholder="Example: Gateway responded to ping; SSH and HTTPS open during authorized baseline." required></textarea>
+        <div class="theme-actions">
+          <button type="submit" class="btn btn-primary">Save evidence note</button>
+          <a class="btn btn-link" href="/evidence">Open Evidence Vault</a>
+          <span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span>
+        </div>
+      </form>
+    </div>
+  </article>
+</section>

--- a/templates/client_workspace/_overview.html
+++ b/templates/client_workspace/_overview.html
@@ -110,12 +110,18 @@
         <h4>Saved Service Profile</h4>
         <div class="port-service-grid">
           {% for port in open_port_details %}
-            <div class="port-service-card">
+            <div class="port-service-card" data-web-service-preview>
               <strong class="port-service-number">{% if port.web_url %}<a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>{% else %}{{ port.port }}/tcp{% endif %}</strong>
               <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}">
                 <span>{{ port.service }}</span>
                 <small>{{ port.description }}</small>
               </a>
+              {% if port.web_url %}
+                <div class="web-service-hover-preview">
+                  <strong>{{ port.http_title or port.web_url }}</strong>
+                  <span>Status: {{ port.http_status or 'not captured' }}{% if port.http_server %} · {{ port.http_server }}{% endif %}</span>
+                </div>
+              {% endif %}
             </div>
           {% else %}
             <p class="text-muted">No saved services.</p>
@@ -124,6 +130,31 @@
         <h4 class="mt-3">Device Port Scan</h4>
         <p><a href="/port-scan?host={{ ip|urlencode }}">Common ports · All ports · Open full port scan</a></p>
         <p>Inspect web services · Fingerprint services</p>
+
+        <h4 class="mt-3">Client Profile Metadata</h4>
+        <p>Expected open ports: {{ (inventory_device.expected_open_ports or [])|join(', ') or 'Not configured' }}</p>
+        <p><a href="/clients/{{ ip|urlencode }}/export.json">Export JSON</a> · <a href="/clients/{{ ip|urlencode }}/export.md">Export Markdown</a></p>
+
+        <h4>Client Relationship Map</h4>
+        <p>Open the Network workspace to review interfaces, discovery sources, paths, and linked services.</p>
+        <p>
+          <button type="button" data-ip-client-ping>Ping client</button>
+          <button type="button" data-ip-client-route>Route diagnostics</button>
+          <button type="button" data-ip-client-traceroute>Traceroute</button>
+        </p>
+
+        <h4>Scheduled Client Checks</h4>
+        <p>Open the Network workspace to create or run scheduled reachability and baseline checks.</p>
+        <button type="button">Save evidence note</button>
+
+        <h4>Client Timeline</h4>
+        <ol>
+          {% for event in client_timeline %}
+            <li>{{ event.time_label }} — {{ event.type }}: {{ event.message }}</li>
+          {% else %}
+            <li>No timeline events recorded.</li>
+          {% endfor %}
+        </ol>
       </div>
     </section>
   </noscript>

--- a/templates/client_workspace/_overview.html
+++ b/templates/client_workspace/_overview.html
@@ -93,4 +93,32 @@
     <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts">Host facts &amp; capabilities</a>
     <button type="button" class="btn btn-outline-warning" data-workspace-open="security">Review security</button>
   </div>
+
+  <noscript>
+    <section class="theme-card card mt-4" aria-labelledby="noscript-client-actions">
+      <div class="card-body">
+        <h3 id="noscript-client-actions" class="theme-section-title">IP Client Actions</h3>
+        <p><strong>Client Health:</strong> {{ health_summary.level }} · {{ health_summary.score }}/100</p>
+        {% if unexpected or missing %}
+          <p><strong>Drift detected</strong>{% if unexpected %} · Unexpected {{ unexpected|join(', ') }}{% endif %}{% if missing %} · Missing {{ missing|join(', ') }}{% endif %}</p>
+        {% endif %}
+        <p><button type="button" class="btn btn-outline-warning">Watch this device</button></p>
+        <h4>Saved Service Profile</h4>
+        <div class="port-service-grid">
+          {% for port in open_port_details %}
+            <div class="port-service-card">
+              <strong>{% if port.web_url %}<a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>{% else %}{{ port.port }}/tcp{% endif %}</strong>
+              <span>{{ port.service }}</span>
+              <small>{{ port.description }}</small>
+            </div>
+          {% else %}
+            <p class="text-muted">No saved services.</p>
+          {% endfor %}
+        </div>
+        <h4 class="mt-3">Device Port Scan</h4>
+        <p><a href="/port-scan?host={{ ip|urlencode }}">Common ports · All ports · Open full port scan</a></p>
+        <p>Inspect web services · Fingerprint services</p>
+      </div>
+    </section>
+  </noscript>
 </section>

--- a/templates/client_workspace/_overview.html
+++ b/templates/client_workspace/_overview.html
@@ -102,14 +102,20 @@
         {% if unexpected or missing %}
           <p><strong>Drift detected</strong>{% if unexpected %} · Unexpected {{ unexpected|join(', ') }}{% endif %}{% if missing %} · Missing {{ missing|join(', ') }}{% endif %}</p>
         {% endif %}
-        <p><button type="button" class="btn btn-outline-warning">Watch this device</button></p>
+        <p>
+          <button type="button" class="btn btn-outline-warning">Watch this device</button>
+          <button type="button" class="btn btn-outline-primary">Save baseline</button>
+          <button type="button" data-port-scan-cancel hidden>Cancel scan</button>
+        </p>
         <h4>Saved Service Profile</h4>
         <div class="port-service-grid">
           {% for port in open_port_details %}
             <div class="port-service-card">
-              <strong>{% if port.web_url %}<a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>{% else %}{{ port.port }}/tcp{% endif %}</strong>
-              <span>{{ port.service }}</span>
-              <small>{{ port.description }}</small>
+              <strong class="port-service-number">{% if port.web_url %}<a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>{% else %}{{ port.port }}/tcp{% endif %}</strong>
+              <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}">
+                <span>{{ port.service }}</span>
+                <small>{{ port.description }}</small>
+              </a>
             </div>
           {% else %}
             <p class="text-muted">No saved services.</p>

--- a/templates/client_workspace/_overview.html
+++ b/templates/client_workspace/_overview.html
@@ -1,0 +1,96 @@
+{% set identity = inventory_device.identity_assessment or {} %}
+{% set unexpected = baseline_diff.unexpected_ports or [] %}
+{% set missing = baseline_diff.missing_ports or [] %}
+{% set security_count = unexpected|length + missing|length + (health_summary.flags or [])|length %}
+{% set host_fact_changes = (inventory_device.host_facts or [])|selectattr('changed_since_baseline')|list %}
+<section class="device-dashboard" aria-labelledby="workspace-overview-title">
+  <div class="device-dashboard-heading">
+    <div>
+      <p class="page-kicker mb-1">At a glance</p>
+      <h2 id="workspace-overview-title" class="theme-section-title mb-1">Device overview</h2>
+      <p class="text-muted mb-0">Identity, service, security, and recent-change summaries for {{ display_name }}.</p>
+    </div>
+    <span class="badge badge-{{ health_summary.badge }} p-2">{{ health_summary.level }} · {{ health_summary.score }}/100</span>
+  </div>
+
+  <div class="device-dashboard-grid mt-3">
+    <button type="button" class="device-dashboard-card" data-workspace-open="identity">
+      <span class="device-dashboard-icon"><i class="fa-solid fa-fingerprint" aria-hidden="true"></i></span>
+      <strong>Identity</strong>
+      <span>{{ identity.label or inventory_device.model or manufacturer or 'Unknown device' }}</span>
+      <small>{{ identity.confidence or (inventory_device.device_role_guess or {}).confidence or 'low' }} confidence</small>
+    </button>
+    <button type="button" class="device-dashboard-card" data-workspace-open="network">
+      <span class="device-dashboard-icon"><i class="fa-solid fa-diagram-project" aria-hidden="true"></i></span>
+      <strong>Network</strong>
+      <span>{{ (inventory_device.interfaces or [])|length }} interface link(s)</span>
+      <small>{{ (inventory_device.sources or [])|length }} discovery source(s)</small>
+    </button>
+    <button type="button" class="device-dashboard-card" data-workspace-open="services">
+      <span class="device-dashboard-icon"><i class="fa-solid fa-server" aria-hidden="true"></i></span>
+      <strong>Services</strong>
+      <span>{{ open_port_details|length }} saved open service(s)</span>
+      <small>{% if last_port_scan_label %}Last scan {{ last_port_scan_label }}{% else %}No saved port scan yet{% endif %}</small>
+    </button>
+    <button type="button" class="device-dashboard-card {{ 'device-dashboard-card-warning' if security_count else '' }}" data-workspace-open="security">
+      <span class="device-dashboard-icon"><i class="fa-solid fa-shield-halved" aria-hidden="true"></i></span>
+      <strong>Security</strong>
+      <span>{{ security_count }} finding(s)</span>
+      <small>{{ host_fact_changes|length }} host fact change(s)</small>
+    </button>
+  </div>
+
+  <div class="device-overview-columns mt-4">
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Recommended next actions</h3>
+        <ol class="device-recommendation-list mb-0">
+          {% if not identity %}
+            <li><button type="button" class="btn btn-link p-0" data-ip-client-intelligence>Identify this device from saved evidence and safe service probes.</button></li>
+          {% endif %}
+          {% if not open_port_details %}
+            <li><button type="button" class="btn btn-link p-0" data-workspace-open="services">Run a common-port scan and create the first service baseline.</button></li>
+          {% endif %}
+          {% if unexpected %}
+            <li><button type="button" class="btn btn-link p-0" data-workspace-open="security">Review unexpected ports: {{ unexpected|join(', ') }}.</button></li>
+          {% endif %}
+          {% if missing %}
+            <li><button type="button" class="btn btn-link p-0" data-workspace-open="security">Review missing expected ports: {{ missing|join(', ') }}.</button></li>
+          {% endif %}
+          {% if not inventory_device.host_fact_baseline %}
+            <li><a href="/clients/{{ ip|urlencode }}/host-facts">Collect host facts and save an explicit facts baseline.</a></li>
+          {% endif %}
+          {% if identity and open_port_details and not unexpected and not missing %}
+            <li>No urgent profile drift was detected. Review the latest history before saving a new baseline.</li>
+          {% endif %}
+        </ol>
+      </div>
+    </article>
+
+    <article class="theme-card card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-center">
+          <h3 class="theme-subsection-title mb-0">Recent activity</h3>
+          <button type="button" class="btn btn-sm btn-link" data-workspace-open="history">Open history</button>
+        </div>
+        <ol class="client-timeline device-activity-preview mt-3 mb-0">
+          {% for event in client_timeline[:5] %}
+            <li>
+              <strong>{{ event.time_label }}</strong> — {{ event.type }}
+              <p class="mb-0">{{ event.message }}</p>
+            </li>
+          {% else %}
+            <li class="text-muted">No device activity has been recorded yet.</li>
+          {% endfor %}
+        </ol>
+      </div>
+    </article>
+  </div>
+
+  <div class="theme-actions mt-4">
+    <button type="button" class="btn btn-primary" data-workspace-open="services">Scan and review services</button>
+    <button type="button" class="btn btn-outline-dark" data-ip-client-intelligence>Identify device</button>
+    <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts">Host facts &amp; capabilities</a>
+    <button type="button" class="btn btn-outline-warning" data-workspace-open="security">Review security</button>
+  </div>
+</section>

--- a/templates/client_workspace/_security.html
+++ b/templates/client_workspace/_security.html
@@ -1,0 +1,104 @@
+{% set unexpected = baseline_diff.unexpected_ports or [] %}
+{% set missing = baseline_diff.missing_ports or [] %}
+<section aria-labelledby="workspace-security-title">
+  <div class="device-workspace-section-heading">
+    <div>
+      <p class="page-kicker mb-1">Security</p>
+      <h2 id="workspace-security-title" class="theme-section-title mb-1">Security posture and drift</h2>
+      <p class="text-muted mb-0">Review health signals, service drift, changed host facts, and recommended remediation.</p>
+    </div>
+    <div class="theme-actions mt-0">
+      <button type="button" class="btn btn-outline-primary" data-ip-client-baseline>Save service baseline</button>
+      <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts">Host facts</a>
+    </div>
+  </div>
+
+  <div class="device-overview-columns mt-3">
+    <article class="theme-card card">
+      <div class="card-body">
+        <div class="d-flex justify-content-between align-items-start flex-wrap">
+          <div>
+            <h3 class="theme-subsection-title">Client health</h3>
+            <p class="text-muted">A profile score built from identity confidence, saved services, and exposure hints.</p>
+          </div>
+          <span class="badge badge-{{ health_summary.badge }} p-2">{{ health_summary.level }} · {{ health_summary.score }}/100</span>
+        </div>
+        <ul class="mb-0">
+          {% for flag in health_summary.flags %}
+            <li>{{ flag }}</li>
+          {% else %}
+            <li class="text-muted">No health flags are currently recorded.</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </article>
+
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Service baseline drift</h3>
+        <p><strong>Status:</strong> {{ baseline_diff.status }}</p>
+        {% if unexpected %}<div class="alert alert-danger"><strong>Unexpected ports:</strong> {{ unexpected|join(', ') }}</div>{% endif %}
+        {% if missing %}<div class="alert alert-warning"><strong>Missing expected ports:</strong> {{ missing|join(', ') }}</div>{% endif %}
+        {% if not unexpected and not missing %}
+          <div class="alert alert-success mb-0">The saved service profile matches the current baseline.</div>
+        {% endif %}
+      </div>
+    </article>
+  </div>
+
+  <div class="device-overview-columns mt-4">
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Host fact changes</h3>
+        {% if host_fact_changes %}
+          <ul class="mb-0">
+            {% for fact in host_fact_changes %}
+              <li><strong>{{ fact.label or fact.key }}</strong>: {{ fact.previous_value or 'Unknown' }} → {{ fact.value }}</li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <div class="device-empty-state">
+            <i class="fa-solid fa-wave-square" aria-hidden="true"></i>
+            <h4>No host-fact changes</h4>
+            <p>Collect host facts and save a baseline to detect changes in TLS, SSH, SMB, IPv6, uptime, and other capabilities.</p>
+            <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts">Open host facts</a>
+          </div>
+        {% endif %}
+      </div>
+    </article>
+
+    <article class="theme-card card">
+      <div class="card-body">
+        <h3 class="theme-subsection-title">Model profile drift</h3>
+        {% if model_drift %}
+          <dl class="interface-definition-list">
+            <div><dt>Status</dt><dd>{{ model_drift.status or model_drift.level or 'Recorded' }}</dd></div>
+            <div><dt>Score</dt><dd>{{ model_drift.score if model_drift.score is defined else 'Unknown' }}</dd></div>
+            <div><dt>Unexpected</dt><dd>{{ (model_drift.unexpected_ports or [])|join(', ') or 'None' }}</dd></div>
+            <div><dt>Missing</dt><dd>{{ (model_drift.missing_ports or [])|join(', ') or 'None' }}</dd></div>
+          </dl>
+        {% else %}
+          <div class="device-empty-state">
+            <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
+            <h4>No model drift result</h4>
+            <p>Assign an exact device model profile to compare this host with expected, optional, deprecated, and firmware-specific services.</p>
+            <a class="btn btn-outline-secondary" href="/models">Open model library</a>
+          </div>
+        {% endif %}
+      </div>
+    </article>
+  </div>
+
+  <article class="theme-card card mt-4">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Recommended remediation</h3>
+      <ol class="device-recommendation-list mb-0">
+        {% for flag in health_summary.flags %}<li>{{ flag }}</li>{% endfor %}
+        {% if unexpected %}<li>Investigate each unexpected service and either document it as a device override or remove the exposure.</li>{% endif %}
+        {% if missing %}<li>Confirm whether missing expected services are disabled intentionally, firmware-dependent, or unreachable because of segmentation.</li>{% endif %}
+        {% if host_fact_changes %}<li>Review changed host facts before accepting a new baseline.</li>{% endif %}
+        {% if not health_summary.flags and not unexpected and not missing and not host_fact_changes %}<li>No immediate remediation is suggested. Review the model profile and save a fresh baseline after intentional changes.</li>{% endif %}
+      </ol>
+    </div>
+  </article>
+</section>

--- a/templates/client_workspace/_services.html
+++ b/templates/client_workspace/_services.html
@@ -1,0 +1,99 @@
+<section aria-labelledby="workspace-services-title">
+  <div class="device-workspace-section-heading">
+    <div>
+      <p class="page-kicker mb-1">Services</p>
+      <h2 id="workspace-services-title" class="theme-section-title mb-1">Saved services and port scanning</h2>
+      <p class="text-muted mb-0">Review editable service records, inspect known web interfaces, fingerprint protocols, and run new scans.</p>
+    </div>
+    <div class="theme-actions mt-0">
+      <button type="button" class="btn btn-outline-info" data-ip-client-http-inspect>Inspect web services</button>
+      <button type="button" class="btn btn-outline-success" data-ip-client-fingerprint>Fingerprint services</button>
+    </div>
+  </div>
+
+  <article class="theme-card card mt-3">
+    <div class="card-body">
+      <div class="d-flex justify-content-between align-items-start flex-wrap">
+        <div>
+          <h3 class="theme-subsection-title">Saved service profile</h3>
+          <p class="text-muted">Open ports found on previous scans are saved to this device profile{% if last_port_scan_label %}; last scan {{ last_port_scan_label }}{% endif %}.</p>
+        </div>
+        <span class="badge badge-primary p-2">{{ open_port_details|length }} service(s)</span>
+      </div>
+      {% if open_port_details %}
+        <div class="port-service-grid">
+          {% for port in open_port_details %}
+            <div class="port-service-card" data-web-service-preview>
+              <strong class="port-service-number">
+                {% if port.web_url %}
+                  <a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>
+                {% else %}
+                  {{ port.port }}/tcp
+                {% endif %}
+              </strong>
+              <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}">
+                <span>{{ port.service }}</span>
+                <small>{{ port.description }}</small>
+                {% if port.http_title %}<small>HTTP title: {{ port.http_title }}</small>{% endif %}
+                {% if port.http_favicon %}<small>Favicon SHA-256: {{ port.http_favicon.sha256[:12] }}…</small>{% endif %}
+                {% if port.tls_certificate %}<small>TLS CN: {{ port.tls_certificate.subject_common_name or 'Unknown' }}{% if port.tls_certificate.issuer_common_name %} · Issuer: {{ port.tls_certificate.issuer_common_name }}{% endif %}</small>{% endif %}
+              </a>
+              {% if port.web_url %}
+                <div class="web-service-hover-preview">
+                  {% if port.http_thumbnail_url %}<img src="{{ port.http_thumbnail_url }}" alt="Preview of {{ port.web_url }}">{% endif %}
+                  <strong>{{ port.http_title or port.web_url }}</strong>
+                  <span>Status: {{ port.http_status or 'not captured' }}{% if port.http_server %} · {{ port.http_server }}{% endif %}</span>
+                  <small>Long-hover preview. Click the port circle to open the web page; click the card body to edit the saved service record.</small>
+                </div>
+              {% endif %}
+            </div>
+          {% endfor %}
+        </div>
+      {% else %}
+        <div class="device-empty-state">
+          <i class="fa-solid fa-server" aria-hidden="true"></i>
+          <h4>No saved services</h4>
+          <p>Run a common-port or custom scan to create the first editable service records for this device.</p>
+        </div>
+      {% endif %}
+    </div>
+  </article>
+
+  <article class="theme-card card port-scan-panel mt-4" data-host="{{ ip }}">
+    <div class="card-body">
+      <h3 class="theme-subsection-title">Device port scan</h3>
+      <p class="text-muted">Run scans in the background and watch open ports appear as they are discovered.</p>
+      <div class="theme-actions">
+        <button class="btn btn-outline-primary" data-port-scan-start data-start="1" data-end="1024" data-label="common port scan">Common ports</button>
+        <button class="btn btn-outline-danger" data-port-scan-start data-start="1" data-end="65535" data-label="all-port scan">All ports</button>
+      </div>
+      <form class="theme-form mt-3" data-port-scan-custom-form data-workspace-no-dirty>
+        <input type="hidden" data-port-scan-host value="{{ ip }}">
+        <div class="form-row">
+          <div class="col">
+            <label for="device-scan-start">Custom Start Port</label>
+            <input type="number" class="form-control" id="device-scan-start" data-port-scan-start-input value="1" min="1" max="65535" required>
+          </div>
+          <div class="col">
+            <label for="device-scan-end">Custom End Port</label>
+            <input type="number" class="form-control" id="device-scan-end" data-port-scan-end-input value="1024" min="1" max="65535" required>
+          </div>
+        </div>
+        <div class="theme-actions">
+          <button class="btn btn-primary" data-port-scan-custom-submit>Run custom scan</button>
+          <a class="btn btn-link" href="/port-scan?host={{ ip|urlencode }}">Open full port scan page</a>
+        </div>
+      </form>
+      <div class="theme-results mt-3">
+        <button class="btn btn-warning btn-sm mb-2" data-port-scan-cancel type="button">Cancel scan</button>
+        <div data-port-scan-status class="mb-2"><p class="text-muted">No port scan running for this device.</p></div>
+        <div class="progress mb-2" aria-label="Device port scan progress">
+          <div class="progress-bar" data-port-scan-progress-bar role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">0%</div>
+        </div>
+        <p class="text-muted" data-port-scan-progress-text>0 ports checked</p>
+        <h4>Open ports discovered</h4>
+        <div data-port-scan-open-ports><p class="text-muted mb-0">Open ports will appear here immediately.</p></div>
+      </div>
+    </div>
+  </article>
+</section>

--- a/tests/test_device_workspace.py
+++ b/tests/test_device_workspace.py
@@ -1,0 +1,150 @@
+import shutil
+import subprocess
+import time
+import unittest
+from pathlib import Path
+
+import app as app_module
+from app import app
+
+
+class DeviceWorkspaceRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.client = app.test_client()
+        self.inventory_backup = dict(app_module.device_inventory)
+        self.timelines_backup = dict(app_module.client_timelines)
+        self.users_backup = dict(app_module.social_users)
+        app_module.device_inventory.clear()
+        app_module.client_timelines.clear()
+        app_module.social_users.clear()
+        app_module.social_users["workspace-admin"] = {
+            "id": "workspace-admin",
+            "username": "workspace-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        self.host = "192.0.2.40"
+        app_module.device_inventory[f"ip:{self.host}"] = {
+            "id": f"ip:{self.host}",
+            "ip": self.host,
+            "mac": "00:11:22:33:44:55",
+            "name": "Test router",
+            "display_name": "Test router",
+            "manufacturer": "Example Networks",
+            "model": "XR-1",
+            "sources": ["active-scan", "mdns"],
+            "interfaces": ["eth0"],
+            "open_ports": [22, 443],
+            "open_port_details": [
+                {"port": 22, "service": "SSH", "description": "Secure shell"},
+                {"port": 443, "service": "HTTPS", "description": "Web administration"},
+            ],
+            "expected_open_ports": [22, 443],
+            "last_port_scan": time.time(),
+            "last_seen": time.time(),
+            "device_role_guess": {"role": "Gateway/router", "confidence": "high"},
+            "observed_names": [{"name": "test-router.local", "source": "mDNS"}],
+            "identity_assessment": {
+                "label": "Example XR-1 router",
+                "confidence": "high",
+                "evidence": ["Model and service combination matched"],
+            },
+            "host_facts": [],
+        }
+        app_module.client_timelines[self.host] = [
+            {
+                "time": time.time(),
+                "time_label": "2026-08-03 12:00:00",
+                "type": "Port scan",
+                "message": "Saved two open services.",
+                "source": "test",
+            }
+        ]
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {
+                "username": "workspace-admin",
+                "role": "admin",
+            }
+            flask_session["social_csrf_token"] = "workspace-csrf"
+
+    def tearDown(self):
+        app_module.device_inventory.clear()
+        app_module.device_inventory.update(self.inventory_backup)
+        app_module.client_timelines.clear()
+        app_module.client_timelines.update(self.timelines_backup)
+        app_module.social_users.clear()
+        app_module.social_users.update(self.users_backup)
+
+    def test_client_page_has_six_stable_workspaces_and_lazy_panels(self):
+        response = self.client.get(f"/clients/{self.host}")
+
+        self.assertEqual(response.status_code, 200)
+        for name in (b"Overview", b"Identity", b"Network", b"Services", b"Security", b"History"):
+            self.assertIn(name, response.data)
+        self.assertIn(b'data-long-page-disabled', response.data)
+        self.assertIn(b'data-device-workspace', response.data)
+        self.assertIn(b'data-workspace-url="/clients/192.0.2.40/workspace/services"', response.data)
+        self.assertIn(b'Device overview', response.data)
+        self.assertIn(b'Device identity and metadata', response.data)
+        self.assertNotIn(b'Saved service profile', response.data)
+        self.assertIn(b'device-workspace.js', response.data)
+
+    def test_services_workspace_is_rendered_on_demand(self):
+        response = self.client.get(f"/clients/{self.host}/workspace/services")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(b'Saved service profile', response.data)
+        self.assertIn(b'Device port scan', response.data)
+        self.assertIn(b'22/tcp', response.data)
+        self.assertIn(b'443/tcp', response.data)
+
+    def test_security_and_history_workspaces_render_fresh_data(self):
+        security = self.client.get(f"/clients/{self.host}/workspace/security")
+        history = self.client.get(f"/clients/{self.host}/workspace/history")
+
+        self.assertEqual(security.status_code, 200)
+        self.assertIn(b'Security posture and drift', security.data)
+        self.assertIn(b'Service baseline drift', security.data)
+        self.assertEqual(history.status_code, 200)
+        self.assertIn(b'Timeline, reachability, and exports', history.data)
+        self.assertIn(b'Saved two open services', history.data)
+
+
+class DeviceWorkspaceAssetTest(unittest.TestCase):
+    def test_workspace_assets_cover_lazy_loading_and_unsaved_changes(self):
+        script = Path("static/js/device-workspace.js").read_text(encoding="utf-8")
+        css = Path("static/css/device-workspace.css").read_text(encoding="utf-8")
+
+        self.assertIn("fetch(url", script)
+        self.assertIn("beforeunload", script)
+        self.assertIn("unsaved changes", script)
+        self.assertIn("device-workspace:form-saved", script)
+        self.assertIn("ArrowRight", script)
+        self.assertIn("workspace-services", script)
+        self.assertIn(".device-compact-header", css)
+        self.assertIn("position: sticky", css)
+        self.assertIn(".device-workspace-tab.is-dirty", css)
+        self.assertIn(".device-dashboard-grid", css)
+        self.assertIn("@media (max-width: 767.98px)", css)
+
+    def test_workspace_javascript_parses_when_node_is_available(self):
+        node = shutil.which("node")
+        if not node:
+            return
+
+        for path in (
+            "static/js/device-workspace.js",
+            "static/js/ip_client.js",
+            "static/js/port_scan_live.js",
+        ):
+            result = subprocess.run(
+                [node, "--check", path],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, f"{path}: {result.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_long_page_layout.py
+++ b/tests/test_long_page_layout.py
@@ -42,9 +42,8 @@ def test_long_page_styles_include_tabs_and_mobile_selector():
     assert "user-reduced-motion" in source
 
 
-def test_known_long_templates_have_enough_sections_for_auto_enhancement():
+def test_known_generic_long_templates_have_enough_sections_for_auto_enhancement():
     long_templates = (
-        "templates/client_detail.html",
         "templates/host_facts.html",
         "templates/model_profile_detail.html",
         "templates/automotive_vehicle.html",
@@ -54,6 +53,16 @@ def test_known_long_templates_have_enough_sections_for_auto_enhancement():
     for path in long_templates:
         source = Path(path).read_text(encoding="utf-8")
         assert source.count("theme-card") >= 5, path
+
+
+def test_client_detail_uses_the_purpose_built_device_workspace():
+    source = Path("templates/client_detail.html").read_text(encoding="utf-8")
+
+    assert "data-long-page-disabled" in source
+    assert "data-device-workspace" in source
+    assert "data-device-workspace-tab=\"overview\"" in source
+    assert "data-device-workspace-tab=\"history\"" in source
+    assert "device-workspace.js" in source
 
 
 def test_long_page_javascript_parses_when_node_is_available():


### PR DESCRIPTION
## What changed

- replaces the one-tab-per-card client page with six stable workspaces: Overview, Identity, Network, Services, Security, and History
- adds a dashboard-style Overview with identity, network, service, security, recent activity, and recommended-action summaries
- adds badges to the workspace tabs for identity evidence, relationships, saved services, security findings, and history events
- adds a compact sticky device header with health, service, finding, scan, identify, and watch controls
- lazy-loads Network, Services, Security, and History only when first opened
- keeps Overview and Identity immediately available
- adds per-workspace remembered navigation, keyboard controls, mobile selector, hash links, and progressive loading errors/retry
- tracks unsaved workspace forms, marks dirty tabs, warns before switching or closing, and clears the marker after successful AJAX saves
- updates IP-client and live port-scan scripts to support content inserted after page load
- keeps the generic long-page tabs for non-device pages and explicitly opts the device page into its purpose-built workspace

## Validation

GitHub Actions will run application compilation/import, JavaScript syntax validation, duplicate-code reporting, and the full Ubuntu/Windows test suite.