### PR TITLE
Add VLAN investigations and prominent network tags

### DIFF
--- a/app_support/navigation.py
+++ b/app_support/navigation.py
@@ -13,6 +13,7 @@ STATIC_SEARCH_ITEMS = (
     ('Advanced Diagnostics', '/advanced-diagnostics', 'advanced troubleshooting'),
     ('Jobs', '/jobs', 'background jobs scans'),
     ('Device Inventory', '/inventory', 'devices clients records'),
+    ('VLAN Investigations', '/vlans', 'vlan tags subnets segmentation pfsense probes'),
     ('Alerts', '/alerts', 'notifications devices'),
     ('Reports', '/reports', 'reports exports'),
     ('Evidence Vault', '/evidence', 'evidence notes artifacts'),
@@ -73,6 +74,8 @@ def _breadcrumb_items(path, title, technologies):
         items.append(_current_item('Automotive', None if path == '/automotive' else '/automotive'))
     elif lower_path.startswith('/clients/'):
         items.extend((_current_item('Records'), _current_item('Device Inventory', '/inventory')))
+    elif lower_path.startswith('/vlans'):
+        items.extend((_current_item('Records'), _current_item('VLAN Investigations', None if path == '/vlans' else '/vlans')))
     elif lower_path in {'/inventory', '/alerts', '/reports', '/evidence', '/social-engineering'}:
         items.append(_current_item('Records'))
     elif lower_path in {'/network-scan', '/service-discovery', '/port-scan', '/traceroute', '/diagnostics', '/advanced-diagnostics', '/jobs', '/red-team', '/minecraft-attack', '/train-controller'}:

--- a/docs/VLAN_INVESTIGATIONS.md
+++ b/docs/VLAN_INVESTIGATIONS.md
@@ -1,0 +1,121 @@
+# VLAN Investigations
+
+Mobile Router provides a VLAN and routed-network workspace at `/vlans`. The
+feature stores definitions in `instance/vlan_investigations.sqlite3` and makes a
+known network label visible throughout the device inventory and device pages.
+
+## VLAN labels
+
+When an 802.1Q tag is known, the application displays a prominent label such as:
+
+```text
+VLAN 20 · Users
+```
+
+When only a routed subnet is known, the label uses the network name and CIDR
+without claiming that a tag was observed. Device assignment uses the
+most-specific matching saved subnet. An explicit device assignment retained from
+an investigation or infrastructure import takes precedence over inference.
+
+## Visibility levels
+
+A routed investigation can identify IP reachability, route context, reverse DNS,
+and selected listening TCP services when the firewall permits them. It cannot
+normally see ARP, DHCP broadcasts, mDNS, SSDP, or other link-local/layer-2
+activity in another VLAN.
+
+Use one of these sources for deeper visibility:
+
+- read-only pfSense or infrastructure records;
+- a Mobile Router host with a local address in the VLAN;
+- the restricted remote probe in `scripts/vlan_probe_agent.py`.
+
+The UI labels every result as routed, infrastructure, or local layer-2 evidence.
+
+## Safety limits
+
+- IPv4 CIDRs are supported in the first release.
+- Saved VLAN subnets and explicit tags cannot overlap or conflict.
+- Routed investigations are limited to 1,024 usable addresses.
+- Optional service checks are limited to 16 selected TCP ports.
+- Infrastructure responses/imports are limited to 2 MiB.
+- Remote-probe submissions are limited to 1 MiB and 4,096 device records.
+- Definitions, scans, integrations, probes, and segmentation tests require an
+  administrator, a valid CSRF token, and explicit scan authorisation.
+
+## pfSense integration
+
+The pfSense adapter is deliberately read-only and configurable because endpoint
+paths vary between API packages and deployments. The VLAN page accepts a JSON
+export containing `vlans` or `interfaces`, plus optional `leases`,
+`dhcp_leases`, `arp`, `arp_table`, or `devices` collections.
+
+A live integration stores only:
+
+- HTTPS base URL;
+- endpoint paths;
+- authentication-header name and prefix;
+- environment-variable reference;
+- TLS verification preference.
+
+The token itself remains in the environment, for example:
+
+```bash
+export MOBILE_ROUTER_PFSENSE_TOKEN='replace-with-read-only-token'
+python app.py
+```
+
+TLS certificate verification is enabled by default. Disabling verification is
+an explicit administrator choice intended only for a known local appliance with
+a self-signed certificate.
+
+## Remote probe
+
+Create a probe from a VLAN detail page, then set the named secret environment
+variable on both the main application host and the probe host:
+
+```bash
+export MOBILE_ROUTER_VLAN50_PROBE_KEY='replace-with-long-random-secret'
+```
+
+Run the dependency-free agent from inside the VLAN:
+
+```bash
+python scripts/vlan_probe_agent.py \
+  --server https://mobile-router.example.internal \
+  --probe-id PROBE_ID_FROM_CONFIG \
+  --subnet 10.50.0.0/24 \
+  --secret-env MOBILE_ROUTER_VLAN50_PROBE_KEY
+```
+
+Use `--dry-run` to inspect the payload without submitting it. The agent performs
+only a bounded ping sweep and reads the local neighbour table. It does not
+capture payloads, scan ports, attempt authentication, or alter endpoints.
+
+Every submission includes:
+
+- HMAC-SHA256 over the exact request body, timestamp, and nonce;
+- a timestamp accepted only within five minutes;
+- a one-time nonce rejected on replay;
+- the configured probe identity and VLAN association.
+
+The application stores the environment-variable name but never exports or logs
+the secret value.
+
+## Segmentation matrix
+
+A segmentation expectation records:
+
+- source VLAN;
+- optional destination VLAN;
+- destination host;
+- TCP, UDP, or ICMP;
+- destination port where applicable;
+- expected `allow` or `block` result;
+- optional source remote probe.
+
+Main-host TCP and ICMP tests are clearly marked as a routed perspective. A saved
+source address may bind the TCP socket when the Mobile Router host actually has
+that address. UDP is reported as indeterminate from the main host unless a
+protocol-specific or remote-probe observation is supplied. A result is flagged
+when observed access differs from the saved expectation.

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -11,6 +11,7 @@ from .service_records import create_service_records_blueprint
 from .host_facts import create_host_facts_blueprint
 from .client_workspace import create_client_workspace_blueprint
 from .vlan_investigations import create_vlan_investigations_blueprint
+from .vlan_context import create_vlan_context_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -27,3 +28,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_host_facts_blueprint(context_provider))
     app.register_blueprint(create_client_workspace_blueprint(context_provider))
     app.register_blueprint(create_vlan_investigations_blueprint(context_provider))
+    app.register_blueprint(create_vlan_context_blueprint(context_provider))

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -12,6 +12,7 @@ from .host_facts import create_host_facts_blueprint
 from .client_workspace import create_client_workspace_blueprint
 from .vlan_investigations import create_vlan_investigations_blueprint
 from .vlan_context import create_vlan_context_blueprint
+from .vlan_lookup import create_vlan_lookup_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -29,3 +30,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_client_workspace_blueprint(context_provider))
     app.register_blueprint(create_vlan_investigations_blueprint(context_provider))
     app.register_blueprint(create_vlan_context_blueprint(context_provider))
+    app.register_blueprint(create_vlan_lookup_blueprint(context_provider))

--- a/routes/__init__.py
+++ b/routes/__init__.py
@@ -10,6 +10,7 @@ from .model_profiles import create_model_profiles_blueprint
 from .service_records import create_service_records_blueprint
 from .host_facts import create_host_facts_blueprint
 from .client_workspace import create_client_workspace_blueprint
+from .vlan_investigations import create_vlan_investigations_blueprint
 
 
 def register_blueprints(app, context_provider):
@@ -25,3 +26,4 @@ def register_blueprints(app, context_provider):
     app.register_blueprint(create_service_records_blueprint(context_provider))
     app.register_blueprint(create_host_facts_blueprint(context_provider))
     app.register_blueprint(create_client_workspace_blueprint(context_provider))
+    app.register_blueprint(create_vlan_investigations_blueprint(context_provider))

--- a/routes/vlan_context.py
+++ b/routes/vlan_context.py
@@ -1,0 +1,22 @@
+"""Template helpers for showing first-class VLAN metadata consistently."""
+
+from pathlib import Path
+
+from flask import Blueprint, current_app
+
+from services import vlan_investigations as vlan_service
+
+
+def create_vlan_context_blueprint(_context_provider):
+    blueprint = Blueprint("vlan_context", __name__)
+
+    @blueprint.app_context_processor
+    def inject_vlan_helpers():
+        database_path = Path(current_app.instance_path) / "vlan_investigations.sqlite3"
+
+        def vlan_device(device):
+            return vlan_service.decorate_device(database_path, device or {})
+
+        return {"vlan_device": vlan_device}
+
+    return blueprint

--- a/routes/vlan_investigations.py
+++ b/routes/vlan_investigations.py
@@ -1,0 +1,584 @@
+"""VLAN inventory, routed investigation, segmentation, and probe routes."""
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from functools import wraps
+import ipaddress
+import json
+from pathlib import Path
+import secrets
+import socket
+import time
+
+from flask import Blueprint, Response, current_app, jsonify, render_template, request, session
+
+from services import vlan_investigations as vlan_service
+
+
+def _database_path():
+    return Path(current_app.instance_path) / "vlan_investigations.sqlite3"
+
+
+def _error(message, status=400):
+    return jsonify({"status": "error", "message": str(message)}), status
+
+
+def _login_required(view):
+    @wraps(view)
+    def wrapped(*args, **kwargs):
+        if not session.get("social_user"):
+            return _error("Login required", 401)
+        return view(*args, **kwargs)
+
+    return wrapped
+
+
+def _write_required(admin=True):
+    def decorator(view):
+        @wraps(view)
+        def wrapped(*args, **kwargs):
+            user = session.get("social_user") or {}
+            if not user:
+                return _error("Login required", 401)
+            if admin and user.get("role") != "admin":
+                return _error("Administrator role required", 403)
+            expected = str(session.get("social_csrf_token") or "")
+            supplied = str(
+                request.form.get("csrf_token")
+                or request.headers.get("X-CSRF-Token")
+                or ""
+            )
+            if not expected or not secrets.compare_digest(expected, supplied):
+                return _error("Invalid CSRF token", 400)
+            return view(*args, **kwargs)
+
+        return wrapped
+
+    return decorator
+
+
+def _actor():
+    return (session.get("social_user") or {}).get("username") or "unknown"
+
+
+def _inventory_records(app_module):
+    return app_module.inventory_records() if hasattr(app_module, "inventory_records") else []
+
+
+def _persist_vlan_assignments(app_module):
+    changed = 0
+    with app_module.device_inventory_lock:
+        for key, original in list(app_module.device_inventory.items()):
+            decorated = vlan_service.decorate_device(_database_path(), original)
+            vlan_fields = {
+                name: decorated.get(name)
+                for name in (
+                    "vlan_id", "vlan_tag", "vlan_name", "vlan_subnet", "vlan_gateway",
+                    "vlan_interface", "vlan_label", "vlan_assignment_source", "vlan_confidence",
+                )
+                if decorated.get(name) not in (None, "")
+            }
+            if any(original.get(name) != value for name, value in vlan_fields.items()):
+                updated = dict(original)
+                updated.update(vlan_fields)
+                app_module.device_inventory[key] = updated
+                changed += 1
+    if changed:
+        app_module.save_runtime_state("vlan-assignments")
+    return changed
+
+
+def _record_devices(app_module, vlan, devices, source):
+    normalized = []
+    for record in devices or []:
+        if not isinstance(record, dict):
+            continue
+        item = dict(record)
+        if not item.get("ip") and not item.get("mac"):
+            continue
+        item.update(
+            vlan_id=vlan["id"],
+            vlan_tag=vlan.get("tag"),
+            vlan_name=vlan["name"],
+            vlan_subnet=vlan["subnet"],
+            vlan_gateway=vlan.get("gateway"),
+            vlan_interface=vlan.get("interface_name"),
+            vlan_label=vlan["label"],
+            vlan_assignment_source=source,
+            vlan_confidence="high",
+        )
+        normalized.append(item)
+    if normalized:
+        app_module.record_inventory_devices(
+            normalized,
+            source,
+            vlan.get("interface_name") or None,
+        )
+        _persist_vlan_assignments(app_module)
+    return normalized
+
+
+def _scan_host(app_module, host):
+    try:
+        result = app_module.run_ping_check(str(host), count=1, timeout=1)
+    except Exception as exc:  # Individual hosts must not abort the bounded investigation.
+        return {
+            "host": str(host),
+            "reachable": False,
+            "packet_loss_percent": 100.0,
+            "latency": {},
+            "output": str(exc),
+            "checked_at": time.time(),
+        }
+    return result
+
+
+def _reverse_name(address):
+    try:
+        return socket.gethostbyaddr(str(address))[0]
+    except (OSError, socket.herror, socket.gaierror):
+        return ""
+
+
+def _routed_investigation(app_module, vlan, ports):
+    network = vlan_service.bounded_investigation_network(vlan["subnet"])
+    hosts = list(network.hosts())
+    started = time.time()
+    results = []
+    workers = min(32, max(1, len(hosts)))
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="vlan-ping") as executor:
+        futures = {executor.submit(_scan_host, app_module, host): str(host) for host in hosts}
+        for future in as_completed(futures):
+            results.append(future.result())
+    results.sort(key=lambda item: ipaddress.ip_address(item["host"]))
+
+    reachable = [item for item in results if item.get("reachable")]
+    for item in reachable:
+        item["hostname"] = _reverse_name(item["host"])
+        item["services"] = vlan_service.safe_tcp_check(
+            item["host"], ports, timeout=0.35, source_ip=vlan.get("source_ip") or None
+        ) if ports else []
+
+    route = app_module.build_route_diagnostics(
+        vlan.get("gateway") or (str(hosts[0]) if hosts else None)
+    )
+    devices = [
+        {
+            "ip": item["host"],
+            "hostname": item.get("hostname"),
+            "name": item.get("hostname"),
+            "open_ports": [probe["port"] for probe in item.get("services", []) if probe.get("open")],
+            "open_port_details": [
+                {
+                    "port": probe["port"],
+                    "service": "Detected TCP service",
+                    "description": "Port accepted a bounded VLAN investigation connection",
+                }
+                for probe in item.get("services", []) if probe.get("open")
+            ],
+        }
+        for item in reachable
+    ]
+    recorded = _record_devices(app_module, vlan, devices, "vlan-routed-investigation")
+    summary = {
+        "total_hosts": len(results),
+        "reachable_hosts": len(reachable),
+        "unreachable_hosts": len(results) - len(reachable),
+        "selected_ports": ports,
+        "recorded_devices": len(recorded),
+        "visibility": "routed",
+        "duration_seconds": round(time.time() - started, 2),
+    }
+    return route, results, summary
+
+
+def _import_pfsense(app_module, payload):
+    parsed = vlan_service.parse_pfsense_payload(payload)
+    saved = []
+    existing = vlan_service.list_vlans(_database_path())
+    for candidate in parsed["vlans"]:
+        match = next(
+            (
+                item for item in existing
+                if item["subnet"] == candidate["subnet"]
+                or (
+                    candidate.get("tag") is not None
+                    and item.get("tag") is not None
+                    and int(item["tag"]) == int(candidate["tag"])
+                )
+            ),
+            None,
+        )
+        saved_item = vlan_service.save_vlan(
+            _database_path(), candidate, vlan_id=match["id"] if match else None
+        )
+        saved.append(saved_item)
+        existing = vlan_service.list_vlans(_database_path())
+
+    devices = []
+    for record in parsed["devices"]:
+        vlan = None
+        raw_tag = record.get("vlan_tag")
+        if raw_tag not in (None, ""):
+            vlan = next(
+                (item for item in saved if item.get("tag") is not None and str(item["tag"]) == str(raw_tag)),
+                None,
+            )
+        if vlan is None and record.get("ip"):
+            vlan = vlan_service.vlan_for_ip(_database_path(), record["ip"])
+        if vlan:
+            devices.extend(_record_devices(app_module, vlan, [record], "pfsense-import"))
+        else:
+            devices.append(record)
+    if devices:
+        app_module.record_inventory_devices(devices, "pfsense-import")
+        _persist_vlan_assignments(app_module)
+    return {"vlans": saved, "devices": devices}
+
+
+def create_vlan_investigations_blueprint(context_provider):
+    blueprint = Blueprint("vlan_investigations", __name__)
+
+    @blueprint.get("/vlans")
+    @_login_required
+    def vlan_index():
+        import app as app_module
+
+        _persist_vlan_assignments(app_module)
+        vlans = vlan_service.list_vlans(_database_path())
+        devices = vlan_service.decorate_devices(_database_path(), _inventory_records(app_module))
+        counts = {item["id"]: 0 for item in vlans}
+        for device in devices:
+            if device.get("vlan_id") in counts:
+                counts[device["vlan_id"]] += 1
+        return render_template(
+            "vlans.html",
+            title="VLAN Investigations",
+            vlans=vlans,
+            device_counts=counts,
+            integrations=vlan_service.list_integrations(_database_path()),
+            probes=vlan_service.list_remote_probes(_database_path()),
+            csrf_token=session.get("social_csrf_token"),
+            **context_provider(),
+        )
+
+    @blueprint.post("/vlans")
+    @_write_required(admin=True)
+    def create_vlan():
+        import app as app_module
+
+        try:
+            vlan = vlan_service.save_vlan(_database_path(), request.form)
+            changed = _persist_vlan_assignments(app_module)
+        except ValueError as exc:
+            return _error(exc)
+        app_module.record_social_audit(
+            "vlan.create", detail=f"{vlan['label']} ({vlan['subnet']})"
+        )
+        return jsonify({"status": "success", "vlan": vlan, "assigned_devices": changed})
+
+    @blueprint.get("/vlans/<vlan_id>")
+    @_login_required
+    def vlan_detail(vlan_id):
+        import app as app_module
+
+        vlan = vlan_service.get_vlan(_database_path(), vlan_id)
+        if not vlan:
+            return render_template(
+                "vlan_detail.html", title="VLAN not found", vlan=None, **context_provider()
+            ), 404
+        devices = [
+            item for item in vlan_service.decorate_devices(_database_path(), _inventory_records(app_module))
+            if item.get("vlan_id") == vlan_id
+        ]
+        return render_template(
+            "vlan_detail.html",
+            title=vlan["label"],
+            vlan=vlan,
+            devices=devices,
+            investigations=vlan_service.list_investigations(_database_path(), vlan_id),
+            matrix=vlan_service.segmentation_matrix(_database_path()),
+            all_vlans=vlan_service.list_vlans(_database_path()),
+            integrations=vlan_service.list_integrations(_database_path()),
+            probes=vlan_service.list_remote_probes(_database_path(), vlan_id=vlan_id),
+            csrf_token=session.get("social_csrf_token"),
+            **context_provider(),
+        )
+
+    @blueprint.post("/vlans/<vlan_id>/update")
+    @_write_required(admin=True)
+    def update_vlan(vlan_id):
+        import app as app_module
+
+        try:
+            vlan = vlan_service.save_vlan(_database_path(), request.form, vlan_id=vlan_id)
+            changed = _persist_vlan_assignments(app_module)
+        except ValueError as exc:
+            return _error(exc)
+        app_module.record_social_audit("vlan.update", detail=vlan["label"])
+        return jsonify({"status": "success", "vlan": vlan, "assigned_devices": changed})
+
+    @blueprint.post("/vlans/<vlan_id>/delete")
+    @_write_required(admin=True)
+    def delete_vlan(vlan_id):
+        import app as app_module
+
+        vlan = vlan_service.get_vlan(_database_path(), vlan_id)
+        if not vlan_service.delete_vlan(_database_path(), vlan_id):
+            return _error("VLAN definition was not found", 404)
+        app_module.record_social_audit(
+            "vlan.delete", detail=(vlan or {}).get("label") or vlan_id
+        )
+        return jsonify({"status": "success", "message": "VLAN definition deleted"})
+
+    @blueprint.post("/vlans/<vlan_id>/investigate")
+    @_write_required(admin=True)
+    def investigate_vlan(vlan_id):
+        import app as app_module
+
+        vlan = vlan_service.get_vlan(_database_path(), vlan_id)
+        if not vlan:
+            return _error("VLAN definition was not found", 404)
+        if request.form.get("authorised") != "on":
+            return _error("Confirm that this routed VLAN investigation is authorised")
+        try:
+            ports = vlan_service.parse_ports(request.form.get("ports"))
+            route, hosts, summary = _routed_investigation(app_module, vlan, ports)
+            investigation = vlan_service.save_investigation(
+                _database_path(), vlan_id, "routed", "complete", route, hosts, summary
+            )
+        except ValueError as exc:
+            return _error(exc)
+        app_module.record_social_audit(
+            "vlan.investigate",
+            detail=f"{vlan['label']}: {summary['reachable_hosts']}/{summary['total_hosts']} reachable",
+        )
+        return jsonify({"status": "success", "investigation": investigation})
+
+    @blueprint.post("/vlans/segmentation-rules")
+    @_write_required(admin=True)
+    def create_segmentation_rule():
+        import app as app_module
+
+        try:
+            rule = vlan_service.save_segmentation_rule(_database_path(), request.form)
+        except ValueError as exc:
+            return _error(exc)
+        app_module.record_social_audit("vlan.segmentation.create", detail=rule["id"])
+        return jsonify({"status": "success", "rule": rule})
+
+    @blueprint.post("/vlans/segmentation-rules/<rule_id>/test")
+    @_write_required(admin=True)
+    def test_segmentation_rule(rule_id):
+        import app as app_module
+
+        if request.form.get("authorised") != "on":
+            return _error("Confirm that this segmentation test is authorised")
+        rule = vlan_service.get_segmentation_rule(_database_path(), rule_id)
+        if not rule:
+            return _error("Segmentation rule was not found", 404)
+        if rule.get("source_probe_id"):
+            return _error("This rule is assigned to a remote probe and cannot be run from the main host", 409)
+        source_vlan = vlan_service.get_vlan(_database_path(), rule["source_vlan_id"])
+        started = time.monotonic()
+        detail = ""
+        try:
+            if rule["protocol"] == "tcp":
+                result = vlan_service.safe_tcp_check(
+                    rule["destination"], [rule["port"]], timeout=1.0,
+                    source_ip=(source_vlan or {}).get("source_ip") or None,
+                )[0]
+                observed = "allow" if result["open"] else "block"
+                latency_ms = result["latency_ms"]
+                detail = result["detail"]
+            elif rule["protocol"] == "icmp":
+                ping = app_module.run_ping_check(rule["destination"], count=1, timeout=2)
+                observed = "allow" if ping.get("reachable") else "block"
+                latency_ms = (ping.get("latency") or {}).get("avg_ms")
+                detail = ping.get("output") or "ICMP check completed"
+            else:
+                observed = "error"
+                latency_ms = round((time.monotonic() - started) * 1000, 2)
+                detail = "UDP policy cannot be proven reliably from the main host; use a remote probe or protocol-specific check"
+        except Exception as exc:
+            observed = "error"
+            latency_ms = round((time.monotonic() - started) * 1000, 2)
+            detail = str(exc)
+        source = (
+            f"main-host via source {source_vlan.get('source_ip')}"
+            if source_vlan and source_vlan.get("source_ip")
+            else "main-host routed perspective"
+        )
+        result = vlan_service.record_segmentation_result(
+            _database_path(), rule_id, observed, source, detail, latency_ms
+        )
+        app_module.record_social_audit(
+            "vlan.segmentation.test", detail=f"{rule_id}:{observed}"
+        )
+        return jsonify({"status": "success", "result": result})
+
+    @blueprint.post("/vlans/pfsense/integrations")
+    @_write_required(admin=True)
+    def create_pfsense_integration():
+        import app as app_module
+
+        try:
+            integration = vlan_service.save_integration(_database_path(), request.form)
+        except ValueError as exc:
+            return _error(exc)
+        app_module.record_social_audit(
+            "vlan.pfsense.configure", detail=integration["name"]
+        )
+        return jsonify({"status": "success", "integration": integration})
+
+    @blueprint.post("/vlans/pfsense/import")
+    @_write_required(admin=True)
+    def import_pfsense_json():
+        import app as app_module
+
+        artifact = request.files.get("pfsense_file")
+        try:
+            if artifact and artifact.filename:
+                data = artifact.stream.read(vlan_service.MAX_IMPORT_BYTES + 1)
+                if len(data) > vlan_service.MAX_IMPORT_BYTES:
+                    raise ValueError("pfSense import exceeded the 2 MiB safety limit")
+                payload = json.loads(data.decode("utf-8"))
+            else:
+                payload = request.get_json(silent=True) or json.loads(
+                    request.form.get("pfsense_json") or "{}"
+                )
+            result = _import_pfsense(app_module, payload)
+        except (ValueError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+            return _error(exc)
+        app_module.record_social_audit(
+            "vlan.pfsense.import",
+            detail=f"{len(result['vlans'])} VLANs, {len(result['devices'])} devices",
+        )
+        return jsonify({"status": "success", **result})
+
+    @blueprint.post("/vlans/pfsense/integrations/<integration_id>/sync")
+    @_write_required(admin=True)
+    def sync_pfsense_integration(integration_id):
+        import app as app_module
+
+        integration = vlan_service.get_integration(_database_path(), integration_id)
+        if not integration:
+            return _error("pfSense integration was not found", 404)
+        try:
+            payload = vlan_service.fetch_integration_payload(integration)
+            result = _import_pfsense(app_module, payload)
+            vlan_service.update_integration_status(
+                _database_path(), integration_id,
+                f"Imported {len(result['vlans'])} VLANs and {len(result['devices'])} devices",
+            )
+        except Exception as exc:
+            vlan_service.update_integration_status(
+                _database_path(), integration_id, f"Sync failed: {exc}"
+            )
+            return _error(exc, 502)
+        app_module.record_social_audit("vlan.pfsense.sync", detail=integration["name"])
+        return jsonify({"status": "success", **result})
+
+    @blueprint.post("/vlans/probes")
+    @_write_required(admin=True)
+    def create_remote_probe():
+        import app as app_module
+
+        try:
+            probe = vlan_service.save_remote_probe(_database_path(), request.form)
+        except ValueError as exc:
+            return _error(exc)
+        app_module.record_social_audit("vlan.probe.create", detail=probe["name"])
+        return jsonify({"status": "success", "probe": probe})
+
+    @blueprint.get("/vlans/probes/<probe_id>/config.json")
+    @_login_required
+    def remote_probe_config(probe_id):
+        probe = vlan_service.get_remote_probe(_database_path(), probe_id)
+        if not probe:
+            return _error("Remote probe was not found", 404)
+        vlan = vlan_service.get_vlan(_database_path(), probe["vlan_id"])
+        return jsonify(
+            {
+                "schema": "mobile-router-vlan-probe-v1",
+                "probe_id": probe["id"],
+                "name": probe["name"],
+                "vlan": {"id": vlan["id"], "label": vlan["label"], "subnet": vlan["subnet"]},
+                "server_ingest_path": f"/api/v1/vlan-probes/{probe['id']}/observations",
+                "secret_environment_variable": probe["secret_env"],
+                "agent_script": "scripts/vlan_probe_agent.py",
+            }
+        )
+
+    @blueprint.post("/api/v1/vlan-probes/<probe_id>/observations")
+    def ingest_remote_probe(probe_id):
+        import app as app_module
+
+        body = request.get_data(cache=False)
+        try:
+            probe, payload = vlan_service.verify_probe_submission(
+                _database_path(), probe_id, body,
+                request.headers.get("X-Probe-Timestamp"),
+                request.headers.get("X-Probe-Nonce"),
+                request.headers.get("X-Probe-Signature"),
+            )
+            vlan = vlan_service.get_vlan(_database_path(), probe["vlan_id"])
+            devices = _record_devices(
+                app_module, vlan, payload.get("devices") or [], "vlan-remote-probe"
+            )
+            segmentation_results = []
+            for observation in payload.get("segmentation_results") or []:
+                segmentation_results.append(
+                    vlan_service.record_segmentation_result(
+                        _database_path(), observation.get("rule_id"),
+                        observation.get("observed"), f"remote-probe:{probe['name']}",
+                        observation.get("detail") or "", observation.get("latency_ms"),
+                    )
+                )
+            investigation = vlan_service.save_investigation(
+                _database_path(), vlan["id"], "remote-agent", "complete",
+                payload.get("route") or {}, payload.get("hosts") or [],
+                {
+                    "recorded_devices": len(devices),
+                    "segmentation_results": len(segmentation_results),
+                    "visibility": "local-layer-2",
+                    "probe": probe["name"],
+                },
+            )
+        except ValueError as exc:
+            return _error(exc, 401)
+        return jsonify(
+            {
+                "status": "success",
+                "recorded_devices": len(devices),
+                "segmentation_results": len(segmentation_results),
+                "investigation_id": investigation["id"],
+            }
+        )
+
+    @blueprint.get("/vlans/export.json")
+    @_login_required
+    def vlan_export():
+        return jsonify(
+            {
+                "schema": "mobile-router-vlan-investigations-v1",
+                "exported_at": time.time(),
+                "vlans": vlan_service.list_vlans(_database_path()),
+                "segmentation_rules": vlan_service.list_segmentation_rules(_database_path()),
+                "integrations": [
+                    {
+                        key: value for key, value in item.items()
+                        if key not in {"token_configured"}
+                    }
+                    for item in vlan_service.list_integrations(_database_path())
+                ],
+                "remote_probes": [
+                    {
+                        key: value for key, value in item.items()
+                        if key not in {"secret_configured"}
+                    }
+                    for item in vlan_service.list_remote_probes(_database_path())
+                ],
+            }
+        )
+
+    return blueprint

--- a/routes/vlan_lookup.py
+++ b/routes/vlan_lookup.py
@@ -1,5 +1,6 @@
 """Read-only VLAN lookup for dynamically rendered device cards."""
 
+import ipaddress
 from pathlib import Path
 
 from flask import Blueprint, current_app, jsonify, request, session
@@ -23,21 +24,31 @@ def create_vlan_lookup_blueprint(_context_provider):
         if len(addresses) > 256:
             return jsonify({"status": "error", "message": "At most 256 addresses may be looked up"}), 400
         database_path = Path(current_app.instance_path) / "vlan_investigations.sqlite3"
+        networks = [
+            (ipaddress.ip_network(vlan["subnet"], strict=False), vlan)
+            for vlan in vlan_service.list_vlans(database_path)
+        ]
         results = {}
         for address in addresses:
-            vlan = vlan_service.vlan_for_ip(database_path, address)
-            if vlan:
-                results[address] = {
-                    "id": vlan["id"],
-                    "tag": vlan.get("tag"),
-                    "name": vlan["name"],
-                    "subnet": vlan["subnet"],
-                    "gateway": vlan.get("gateway"),
-                    "label": vlan["label"],
-                    "url": f"/vlans/{vlan['id']}",
-                    "source": "subnet-match",
-                    "confidence": "high",
-                }
+            try:
+                ip = ipaddress.ip_address(address)
+            except ValueError:
+                continue
+            matches = [item for item in networks if ip in item[0]]
+            if not matches:
+                continue
+            _network, vlan = max(matches, key=lambda item: item[0].prefixlen)
+            results[address] = {
+                "id": vlan["id"],
+                "tag": vlan.get("tag"),
+                "name": vlan["name"],
+                "subnet": vlan["subnet"],
+                "gateway": vlan.get("gateway"),
+                "label": vlan["label"],
+                "url": f"/vlans/{vlan['id']}",
+                "source": "subnet-match",
+                "confidence": "high",
+            }
         return jsonify({"status": "success", "vlans": results})
 
     return blueprint

--- a/routes/vlan_lookup.py
+++ b/routes/vlan_lookup.py
@@ -1,0 +1,43 @@
+"""Read-only VLAN lookup for dynamically rendered device cards."""
+
+from pathlib import Path
+
+from flask import Blueprint, current_app, jsonify, request, session
+
+from services import vlan_investigations as vlan_service
+
+
+def create_vlan_lookup_blueprint(_context_provider):
+    blueprint = Blueprint("vlan_lookup", __name__)
+
+    @blueprint.get("/api/v1/vlans/lookup")
+    def lookup_vlans():
+        if not session.get("social_user"):
+            return jsonify({"status": "error", "message": "Login required"}), 401
+        raw = request.args.get("ips") or ""
+        addresses = []
+        for value in raw.split(","):
+            value = value.strip()
+            if value and value not in addresses:
+                addresses.append(value)
+        if len(addresses) > 256:
+            return jsonify({"status": "error", "message": "At most 256 addresses may be looked up"}), 400
+        database_path = Path(current_app.instance_path) / "vlan_investigations.sqlite3"
+        results = {}
+        for address in addresses:
+            vlan = vlan_service.vlan_for_ip(database_path, address)
+            if vlan:
+                results[address] = {
+                    "id": vlan["id"],
+                    "tag": vlan.get("tag"),
+                    "name": vlan["name"],
+                    "subnet": vlan["subnet"],
+                    "gateway": vlan.get("gateway"),
+                    "label": vlan["label"],
+                    "url": f"/vlans/{vlan['id']}",
+                    "source": "subnet-match",
+                    "confidence": "high",
+                }
+        return jsonify({"status": "success", "vlans": results})
+
+    return blueprint

--- a/scripts/vlan_probe_agent.py
+++ b/scripts/vlan_probe_agent.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Restricted remote probe for Mobile Router VLAN investigations.
+
+The agent performs a bounded ping sweep of one configured IPv4 subnet, reads the
+local neighbour table when available, and submits structured observations using
+HMAC-SHA256. It does not capture payloads, attempt authentication, or scan ports.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+import platform
+import re
+import secrets
+import subprocess
+import time
+from urllib.request import Request, urlopen
+
+
+MAX_HOSTS = 1024
+
+
+def ping_command(host):
+    if os.name == "nt":
+        return ["ping", "-n", "1", "-w", "1000", host]
+    return ["ping", "-c", "1", "-W", "1", host]
+
+
+def ping_host(host):
+    started = time.monotonic()
+    try:
+        result = subprocess.run(
+            ping_command(host), capture_output=True, text=True, timeout=3, check=False
+        )
+        reachable = result.returncode == 0
+        detail = (result.stdout or result.stderr or "").strip()[-1000:]
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        reachable = False
+        detail = str(exc)
+    return {
+        "host": host,
+        "reachable": reachable,
+        "duration_ms": round((time.monotonic() - started) * 1000, 2),
+        "detail": detail,
+    }
+
+
+def neighbour_records():
+    commands = (["arp", "-a"],) if os.name == "nt" else (["ip", "neigh", "show"], ["arp", "-an"])
+    output = ""
+    for command in commands:
+        try:
+            result = subprocess.run(command, capture_output=True, text=True, timeout=5, check=False)
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode == 0 and result.stdout:
+            output = result.stdout
+            break
+    records = []
+    seen = set()
+    for line in output.splitlines():
+        ip_match = re.search(r"\b(?:\d{1,3}\.){3}\d{1,3}\b", line)
+        mac_match = re.search(r"\b(?:[0-9a-fA-F]{2}[:-]){5}[0-9a-fA-F]{2}\b", line)
+        if not ip_match:
+            continue
+        ip = ip_match.group(0)
+        mac = mac_match.group(0).replace("-", ":").lower() if mac_match else None
+        key = (ip, mac)
+        if key in seen:
+            continue
+        seen.add(key)
+        records.append({"ip": ip, "mac": mac, "source": "local-neighbour-table"})
+    return records
+
+
+def signature(secret, timestamp, nonce, body):
+    message = str(timestamp).encode("ascii") + b"\n" + nonce.encode("utf-8") + b"\n" + body
+    return hmac.new(secret.encode("utf-8"), message, hashlib.sha256).hexdigest()
+
+
+def build_payload(subnet):
+    network = ipaddress.ip_network(subnet, strict=False)
+    if network.version != 4:
+        raise ValueError("The probe currently supports IPv4 subnets only")
+    hosts = list(network.hosts())
+    if len(hosts) > MAX_HOSTS:
+        raise ValueError(f"Subnet has {len(hosts)} usable hosts; limit is {MAX_HOSTS}")
+    observations = [ping_host(str(host)) for host in hosts]
+    neighbours = neighbour_records()
+    neighbour_by_ip = {item["ip"]: item for item in neighbours}
+    devices = []
+    for item in observations:
+        if not item["reachable"] and item["host"] not in neighbour_by_ip:
+            continue
+        neighbour = neighbour_by_ip.get(item["host"], {})
+        devices.append(
+            {
+                "ip": item["host"],
+                "mac": neighbour.get("mac"),
+                "name": None,
+                "sources": ["remote-probe-ping", neighbour.get("source")]
+                if neighbour else ["remote-probe-ping"],
+            }
+        )
+    for neighbour in neighbours:
+        if neighbour["ip"] not in {item["ip"] for item in devices}:
+            devices.append(neighbour)
+    return {
+        "schema": "mobile-router-vlan-probe-v1",
+        "probe_host": platform.node(),
+        "observed_at": time.time(),
+        "subnet": str(network),
+        "hosts": observations,
+        "devices": devices,
+        "route": {},
+        "segmentation_results": [],
+    }
+
+
+def submit(server, probe_id, secret, payload, verify_tls=True):
+    body = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    timestamp = int(time.time())
+    nonce = secrets.token_hex(16)
+    request = Request(
+        server.rstrip("/") + f"/api/v1/vlan-probes/{probe_id}/observations",
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "X-Probe-Timestamp": str(timestamp),
+            "X-Probe-Nonce": nonce,
+            "X-Probe-Signature": "sha256=" + signature(secret, timestamp, nonce, body),
+        },
+    )
+    context = None
+    if not verify_tls:
+        import ssl
+        context = ssl._create_unverified_context()
+    with urlopen(request, timeout=30, context=context) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Submit bounded local VLAN observations to Mobile Router")
+    parser.add_argument("--server", required=True, help="Mobile Router HTTPS base URL")
+    parser.add_argument("--probe-id", required=True)
+    parser.add_argument("--subnet", required=True)
+    parser.add_argument("--secret-env", required=True)
+    parser.add_argument("--no-verify-tls", action="store_true", help="Explicitly allow a self-signed local server certificate")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    secret = os.environ.get(args.secret_env)
+    if not secret:
+        raise SystemExit(f"Environment variable {args.secret_env} is not set")
+    payload = build_payload(args.subnet)
+    if args.dry_run:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    result = submit(args.server, args.probe_id, secret, payload, verify_tls=not args.no_verify_tls)
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,1 +1,23 @@
 """Application service helpers split from Flask route wiring."""
+
+# The VLAN service normally initialises its schema through list/read operations.
+# A pfSense integration can also be the first VLAN operation in a fresh instance,
+# so guard that direct writer at the package boundary as well. Keeping the guard
+# here avoids coupling the persistence module to Flask application startup.
+from . import vlan_investigations as vlan_investigations
+
+
+_save_vlan_integration = vlan_investigations.save_integration
+
+
+def _save_initialised_vlan_integration(database_path, payload, integration_id=None, now=None):
+    vlan_investigations.initialise_database(database_path)
+    return _save_vlan_integration(
+        database_path,
+        payload,
+        integration_id=integration_id,
+        now=now,
+    )
+
+
+vlan_investigations.save_integration = _save_initialised_vlan_integration

--- a/services/vlan_investigations.py
+++ b/services/vlan_investigations.py
@@ -1,0 +1,894 @@
+"""VLAN inventory, routed investigations, policy tests, and probe ingestion.
+
+The module intentionally keeps network access outside the persistence helpers so
+routes can apply application-level authorisation and bounded execution policies.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+import hashlib
+import hmac
+import ipaddress
+import json
+import os
+from pathlib import Path
+import re
+import socket
+import sqlite3
+import ssl
+import time
+from urllib.parse import urljoin, urlsplit
+from urllib.request import Request, urlopen
+import uuid
+
+
+SCHEMA_VERSION = 1
+MAX_INVESTIGATION_HOSTS = 1024
+MAX_INVESTIGATION_PORTS = 16
+MAX_IMPORT_BYTES = 2 * 1024 * 1024
+MAX_PROBE_BYTES = 1024 * 1024
+PROBE_CLOCK_SKEW_SECONDS = 300
+ALLOWED_PROBE_MODES = {"local", "routed", "infrastructure", "remote-agent"}
+ALLOWED_EXPECTATIONS = {"allow", "block"}
+ALLOWED_PROTOCOLS = {"tcp", "udp", "icmp"}
+_ENV_REF_RE = re.compile(r"^[A-Z][A-Z0-9_]{2,127}$")
+_NONCE_RE = re.compile(r"^[A-Za-z0-9._:-]{8,128}$")
+
+
+@contextmanager
+def _connection(database_path):
+    path = Path(database_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    connection = sqlite3.connect(str(path), timeout=15)
+    connection.row_factory = sqlite3.Row
+    connection.execute("PRAGMA foreign_keys = ON")
+    try:
+        yield connection
+        connection.commit()
+    except Exception:
+        connection.rollback()
+        raise
+    finally:
+        connection.close()
+
+
+def initialise_database(database_path):
+    with _connection(database_path) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS vlan_meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS vlans (
+                id TEXT PRIMARY KEY,
+                tag INTEGER,
+                name TEXT NOT NULL,
+                subnet TEXT NOT NULL UNIQUE,
+                gateway TEXT,
+                interface_name TEXT,
+                router_name TEXT,
+                description TEXT,
+                probe_mode TEXT NOT NULL DEFAULT 'routed',
+                source_type TEXT NOT NULL DEFAULT 'manual',
+                source_ip TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS investigations (
+                id TEXT PRIMARY KEY,
+                vlan_id TEXT NOT NULL,
+                mode TEXT NOT NULL,
+                status TEXT NOT NULL,
+                route_json TEXT NOT NULL DEFAULT '{}',
+                hosts_json TEXT NOT NULL DEFAULT '[]',
+                summary_json TEXT NOT NULL DEFAULT '{}',
+                started_at REAL NOT NULL,
+                finished_at REAL,
+                FOREIGN KEY(vlan_id) REFERENCES vlans(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS segmentation_rules (
+                id TEXT PRIMARY KEY,
+                source_vlan_id TEXT NOT NULL,
+                destination_vlan_id TEXT,
+                destination TEXT NOT NULL,
+                protocol TEXT NOT NULL,
+                port INTEGER,
+                expectation TEXT NOT NULL,
+                description TEXT,
+                source_probe_id TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY(source_vlan_id) REFERENCES vlans(id) ON DELETE CASCADE,
+                FOREIGN KEY(destination_vlan_id) REFERENCES vlans(id) ON DELETE SET NULL
+            );
+            CREATE TABLE IF NOT EXISTS segmentation_results (
+                id TEXT PRIMARY KEY,
+                rule_id TEXT NOT NULL,
+                observed TEXT NOT NULL,
+                mismatch INTEGER NOT NULL,
+                source TEXT NOT NULL,
+                latency_ms REAL,
+                detail TEXT,
+                checked_at REAL NOT NULL,
+                FOREIGN KEY(rule_id) REFERENCES segmentation_rules(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS integrations (
+                id TEXT PRIMARY KEY,
+                kind TEXT NOT NULL,
+                name TEXT NOT NULL,
+                base_url TEXT,
+                token_env TEXT,
+                header_name TEXT NOT NULL DEFAULT 'Authorization',
+                token_prefix TEXT NOT NULL DEFAULT 'Bearer',
+                verify_tls INTEGER NOT NULL DEFAULT 1,
+                config_json TEXT NOT NULL DEFAULT '{}',
+                last_sync REAL,
+                last_status TEXT,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS remote_probes (
+                id TEXT PRIMARY KEY,
+                vlan_id TEXT NOT NULL,
+                name TEXT NOT NULL,
+                secret_env TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'never-seen',
+                last_seen REAL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL,
+                FOREIGN KEY(vlan_id) REFERENCES vlans(id) ON DELETE CASCADE
+            );
+            CREATE TABLE IF NOT EXISTS probe_nonces (
+                probe_id TEXT NOT NULL,
+                nonce TEXT NOT NULL,
+                seen_at REAL NOT NULL,
+                PRIMARY KEY(probe_id, nonce),
+                FOREIGN KEY(probe_id) REFERENCES remote_probes(id) ON DELETE CASCADE
+            );
+            """
+        )
+        connection.execute(
+            "INSERT OR REPLACE INTO vlan_meta(key, value) VALUES('schema_version', ?)",
+            (str(SCHEMA_VERSION),),
+        )
+
+
+def _row_dict(row):
+    return dict(row) if row is not None else None
+
+
+def _clean_text(value, maximum=255):
+    return str(value or "").strip()[:maximum]
+
+
+def _json_load(value, default):
+    try:
+        return json.loads(value or "")
+    except (TypeError, ValueError):
+        return default
+
+
+def _normalise_network(value):
+    try:
+        network = ipaddress.ip_network(str(value or "").strip(), strict=False)
+    except ValueError as exc:
+        raise ValueError("Subnet must be a valid CIDR, for example 192.168.20.0/24") from exc
+    if network.version != 4:
+        raise ValueError("The first VLAN investigation release supports IPv4 subnets only")
+    return network
+
+
+def _normalise_ip(value, label="Address"):
+    if not value:
+        return ""
+    try:
+        address = ipaddress.ip_address(str(value).strip())
+    except ValueError as exc:
+        raise ValueError(f"{label} must be a valid IP address") from exc
+    if address.version != 4:
+        raise ValueError(f"{label} must be IPv4 in this release")
+    return str(address)
+
+
+def _usable_host_count(network):
+    if network.prefixlen >= 31:
+        return network.num_addresses
+    return max(0, network.num_addresses - 2)
+
+
+def validate_vlan_payload(payload, existing=(), vlan_id=None):
+    payload = payload or {}
+    name = _clean_text(payload.get("name"), 120)
+    if not name:
+        raise ValueError("VLAN name is required")
+    network = _normalise_network(payload.get("subnet"))
+    raw_tag = str(payload.get("tag") or "").strip()
+    tag = None
+    if raw_tag:
+        try:
+            tag = int(raw_tag)
+        except ValueError as exc:
+            raise ValueError("VLAN tag must be an integer from 1 to 4094") from exc
+        if not 1 <= tag <= 4094:
+            raise ValueError("VLAN tag must be from 1 to 4094")
+
+    gateway = _normalise_ip(payload.get("gateway"), "Gateway")
+    source_ip = _normalise_ip(payload.get("source_ip"), "Source address")
+    for value, label in ((gateway, "Gateway"), (source_ip, "Source address")):
+        if value and ipaddress.ip_address(value) not in network:
+            raise ValueError(f"{label} must be inside the VLAN subnet")
+
+    probe_mode = _clean_text(payload.get("probe_mode") or "routed", 40)
+    if probe_mode not in ALLOWED_PROBE_MODES:
+        raise ValueError("Unknown VLAN probe mode")
+
+    for item in existing:
+        if str(item.get("id")) == str(vlan_id or ""):
+            continue
+        other = _normalise_network(item.get("subnet"))
+        if network.overlaps(other):
+            raise ValueError(
+                f"Subnet {network} overlaps existing VLAN {item.get('name') or other} ({other})"
+            )
+        if tag is not None and item.get("tag") is not None and int(item["tag"]) == tag:
+            raise ValueError(f"VLAN tag {tag} is already assigned to {item.get('name')}")
+
+    return {
+        "tag": tag,
+        "name": name,
+        "subnet": str(network),
+        "gateway": gateway,
+        "interface_name": _clean_text(payload.get("interface_name") or payload.get("interface"), 120),
+        "router_name": _clean_text(payload.get("router_name") or payload.get("router"), 120),
+        "description": _clean_text(payload.get("description"), 1000),
+        "probe_mode": probe_mode,
+        "source_type": _clean_text(payload.get("source_type") or "manual", 80),
+        "source_ip": source_ip,
+    }
+
+
+def _vlan_label(vlan):
+    if vlan.get("tag") is not None:
+        return f"VLAN {vlan['tag']} · {vlan['name']}"
+    return f"{vlan['name']} · {vlan['subnet']}"
+
+
+def _decorate_vlan(vlan):
+    if not vlan:
+        return None
+    item = dict(vlan)
+    item["label"] = _vlan_label(item)
+    item["usable_hosts"] = _usable_host_count(_normalise_network(item["subnet"]))
+    return item
+
+
+def list_vlans(database_path):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        rows = connection.execute(
+            "SELECT * FROM vlans ORDER BY CASE WHEN tag IS NULL THEN 1 ELSE 0 END, tag, name"
+        ).fetchall()
+    return [_decorate_vlan(_row_dict(row)) for row in rows]
+
+
+def get_vlan(database_path, vlan_id):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        row = connection.execute("SELECT * FROM vlans WHERE id = ?", (str(vlan_id),)).fetchone()
+    return _decorate_vlan(_row_dict(row))
+
+
+def save_vlan(database_path, payload, vlan_id=None, now=None):
+    now = float(now or time.time())
+    existing = list_vlans(database_path)
+    item = validate_vlan_payload(payload, existing, vlan_id=vlan_id)
+    item_id = str(vlan_id or uuid.uuid4())
+    with _connection(database_path) as connection:
+        if vlan_id and not connection.execute("SELECT 1 FROM vlans WHERE id = ?", (item_id,)).fetchone():
+            raise ValueError("VLAN definition was not found")
+        created = connection.execute(
+            "SELECT created_at FROM vlans WHERE id = ?", (item_id,)
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO vlans(
+                id, tag, name, subnet, gateway, interface_name, router_name,
+                description, probe_mode, source_type, source_ip, created_at, updated_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                item_id, item["tag"], item["name"], item["subnet"], item["gateway"],
+                item["interface_name"], item["router_name"], item["description"],
+                item["probe_mode"], item["source_type"], item["source_ip"],
+                float(created["created_at"]) if created else now, now,
+            ),
+        )
+    return get_vlan(database_path, item_id)
+
+
+def delete_vlan(database_path, vlan_id):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        cursor = connection.execute("DELETE FROM vlans WHERE id = ?", (str(vlan_id),))
+        return cursor.rowcount > 0
+
+
+def vlan_for_ip(database_path, address):
+    try:
+        ip = ipaddress.ip_address(str(address or "").strip())
+    except ValueError:
+        return None
+    candidates = []
+    for vlan in list_vlans(database_path):
+        network = _normalise_network(vlan["subnet"])
+        if ip in network:
+            candidates.append((network.prefixlen, vlan))
+    return max(candidates, key=lambda item: item[0])[1] if candidates else None
+
+
+def decorate_device(database_path, device):
+    item = dict(device or {})
+    vlan = None
+    explicit_id = item.get("vlan_id")
+    if explicit_id:
+        vlan = get_vlan(database_path, explicit_id)
+    if vlan is None and item.get("ip"):
+        vlan = vlan_for_ip(database_path, item.get("ip"))
+    if not vlan:
+        return item
+
+    source = "explicit" if explicit_id and str(explicit_id) == str(vlan["id"]) else "subnet-match"
+    item.update(
+        vlan_id=vlan["id"],
+        vlan_tag=vlan.get("tag"),
+        vlan_name=vlan["name"],
+        vlan_subnet=vlan["subnet"],
+        vlan_gateway=vlan.get("gateway"),
+        vlan_interface=vlan.get("interface_name"),
+        vlan_label=vlan["label"],
+        vlan_assignment_source=source,
+        vlan_confidence="high",
+    )
+    return item
+
+
+def decorate_devices(database_path, devices):
+    return [decorate_device(database_path, item) for item in devices]
+
+
+def bounded_investigation_network(cidr, maximum=MAX_INVESTIGATION_HOSTS):
+    network = _normalise_network(cidr)
+    count = _usable_host_count(network)
+    if count > int(maximum):
+        raise ValueError(
+            f"Investigation covers {count} usable addresses; the safety limit is {maximum}"
+        )
+    return network
+
+
+def parse_ports(value, maximum=MAX_INVESTIGATION_PORTS):
+    if value is None or value == "":
+        return []
+    source = value if isinstance(value, (list, tuple, set)) else str(value).split(",")
+    ports = []
+    for raw in source:
+        try:
+            port = int(str(raw).strip())
+        except ValueError as exc:
+            raise ValueError("Selected ports must be comma-separated integers") from exc
+        if not 1 <= port <= 65535:
+            raise ValueError("Selected ports must be from 1 to 65535")
+        if port not in ports:
+            ports.append(port)
+    if len(ports) > int(maximum):
+        raise ValueError(f"At most {maximum} selected ports may be investigated")
+    return sorted(ports)
+
+
+def safe_tcp_check(host, ports, timeout=0.35, source_ip=None):
+    results = []
+    for port in parse_ports(ports):
+        started = time.monotonic()
+        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        sock.settimeout(float(timeout))
+        try:
+            if source_ip:
+                sock.bind((str(source_ip), 0))
+            result = sock.connect_ex((str(host), int(port)))
+            is_open = result == 0
+            detail = "connection accepted" if is_open else f"connection result {result}"
+        except OSError as exc:
+            is_open = False
+            detail = str(exc)
+        finally:
+            sock.close()
+        results.append(
+            {
+                "port": port,
+                "open": is_open,
+                "latency_ms": round((time.monotonic() - started) * 1000, 2),
+                "detail": detail,
+            }
+        )
+    return results
+
+
+def save_investigation(database_path, vlan_id, mode, status, route, hosts, summary, started_at=None, finished_at=None, investigation_id=None):
+    if not get_vlan(database_path, vlan_id):
+        raise ValueError("VLAN definition was not found")
+    item_id = str(investigation_id or uuid.uuid4())
+    started_at = float(started_at or time.time())
+    finished_at = float(finished_at or time.time())
+    with _connection(database_path) as connection:
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO investigations(
+                id, vlan_id, mode, status, route_json, hosts_json, summary_json,
+                started_at, finished_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                item_id, str(vlan_id), _clean_text(mode, 40), _clean_text(status, 40),
+                json.dumps(route or {}, sort_keys=True),
+                json.dumps(hosts or [], sort_keys=True),
+                json.dumps(summary or {}, sort_keys=True),
+                started_at, finished_at,
+            ),
+        )
+    return get_investigation(database_path, item_id)
+
+
+def get_investigation(database_path, investigation_id):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        row = connection.execute(
+            "SELECT * FROM investigations WHERE id = ?", (str(investigation_id),)
+        ).fetchone()
+    if not row:
+        return None
+    item = _row_dict(row)
+    item["route"] = _json_load(item.pop("route_json"), {})
+    item["hosts"] = _json_load(item.pop("hosts_json"), [])
+    item["summary"] = _json_load(item.pop("summary_json"), {})
+    return item
+
+
+def list_investigations(database_path, vlan_id, limit=20):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        rows = connection.execute(
+            "SELECT id FROM investigations WHERE vlan_id = ? ORDER BY started_at DESC LIMIT ?",
+            (str(vlan_id), int(limit)),
+        ).fetchall()
+    return [get_investigation(database_path, row["id"]) for row in rows]
+
+
+def save_segmentation_rule(database_path, payload, rule_id=None, now=None):
+    now = float(now or time.time())
+    source_vlan_id = _clean_text(payload.get("source_vlan_id"), 80)
+    destination_vlan_id = _clean_text(payload.get("destination_vlan_id"), 80)
+    if not get_vlan(database_path, source_vlan_id):
+        raise ValueError("Source VLAN was not found")
+    if destination_vlan_id and not get_vlan(database_path, destination_vlan_id):
+        raise ValueError("Destination VLAN was not found")
+    destination = _clean_text(payload.get("destination"), 255)
+    if not destination:
+        raise ValueError("Destination host or address is required")
+    try:
+        ipaddress.ip_address(destination)
+    except ValueError:
+        if len(destination) > 253 or any(part == "" for part in destination.split(".")):
+            raise ValueError("Destination must be an IP address or hostname")
+    protocol = _clean_text(payload.get("protocol") or "tcp", 10).casefold()
+    if protocol not in ALLOWED_PROTOCOLS:
+        raise ValueError("Protocol must be TCP, UDP, or ICMP")
+    raw_port = str(payload.get("port") or "").strip()
+    port = None
+    if protocol in {"tcp", "udp"}:
+        if not raw_port:
+            raise ValueError("TCP and UDP policy rules require a destination port")
+        port = parse_ports(raw_port, maximum=1)[0]
+    expectation = _clean_text(payload.get("expectation") or "block", 10).casefold()
+    if expectation not in ALLOWED_EXPECTATIONS:
+        raise ValueError("Expected result must be allow or block")
+    item_id = str(rule_id or uuid.uuid4())
+    with _connection(database_path) as connection:
+        created = connection.execute(
+            "SELECT created_at FROM segmentation_rules WHERE id = ?", (item_id,)
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO segmentation_rules(
+                id, source_vlan_id, destination_vlan_id, destination, protocol,
+                port, expectation, description, source_probe_id, created_at, updated_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                item_id, source_vlan_id, destination_vlan_id or None, destination,
+                protocol, port, expectation, _clean_text(payload.get("description"), 1000),
+                _clean_text(payload.get("source_probe_id"), 80) or None,
+                float(created["created_at"]) if created else now, now,
+            ),
+        )
+    return get_segmentation_rule(database_path, item_id)
+
+
+def get_segmentation_rule(database_path, rule_id):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        row = connection.execute(
+            "SELECT * FROM segmentation_rules WHERE id = ?", (str(rule_id),)
+        ).fetchone()
+    return _row_dict(row)
+
+
+def list_segmentation_rules(database_path):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        rows = connection.execute(
+            "SELECT * FROM segmentation_rules ORDER BY created_at, id"
+        ).fetchall()
+        results = connection.execute(
+            """
+            SELECT r.* FROM segmentation_results r
+            JOIN (
+                SELECT rule_id, MAX(checked_at) AS latest
+                FROM segmentation_results GROUP BY rule_id
+            ) latest ON latest.rule_id = r.rule_id AND latest.latest = r.checked_at
+            """
+        ).fetchall()
+    latest_by_rule = {row["rule_id"]: _row_dict(row) for row in results}
+    items = []
+    for row in rows:
+        item = _row_dict(row)
+        item["latest_result"] = latest_by_rule.get(item["id"])
+        items.append(item)
+    return items
+
+
+def record_segmentation_result(database_path, rule_id, observed, source, detail="", latency_ms=None, now=None):
+    rule = get_segmentation_rule(database_path, rule_id)
+    if not rule:
+        raise ValueError("Segmentation rule was not found")
+    observed_value = _clean_text(observed, 10).casefold()
+    if observed_value not in {"allow", "block", "error"}:
+        raise ValueError("Observed result must be allow, block, or error")
+    mismatch = observed_value != rule["expectation"]
+    item = {
+        "id": str(uuid.uuid4()),
+        "rule_id": str(rule_id),
+        "observed": observed_value,
+        "mismatch": bool(mismatch),
+        "source": _clean_text(source, 120),
+        "latency_ms": latency_ms,
+        "detail": _clean_text(detail, 2000),
+        "checked_at": float(now or time.time()),
+    }
+    with _connection(database_path) as connection:
+        connection.execute(
+            """
+            INSERT INTO segmentation_results(
+                id, rule_id, observed, mismatch, source, latency_ms, detail, checked_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                item["id"], item["rule_id"], item["observed"], int(item["mismatch"]),
+                item["source"], item["latency_ms"], item["detail"], item["checked_at"],
+            ),
+        )
+    return item
+
+
+def segmentation_matrix(database_path):
+    vlans = {item["id"]: item for item in list_vlans(database_path)}
+    rows = []
+    for rule in list_segmentation_rules(database_path):
+        item = dict(rule)
+        item["source_vlan"] = vlans.get(rule["source_vlan_id"])
+        item["destination_vlan"] = vlans.get(rule.get("destination_vlan_id"))
+        rows.append(item)
+    return rows
+
+
+def validate_integration_payload(payload):
+    payload = payload or {}
+    name = _clean_text(payload.get("name") or "pfSense", 120)
+    base_url = _clean_text(payload.get("base_url"), 500).rstrip("/")
+    if base_url:
+        parsed = urlsplit(base_url)
+        if parsed.scheme != "https" or not parsed.hostname:
+            raise ValueError("pfSense base URL must be an explicit HTTPS URL")
+    token_env = _clean_text(payload.get("token_env"), 128)
+    if token_env and not _ENV_REF_RE.match(token_env):
+        raise ValueError("Token environment reference must look like MOBILE_ROUTER_PFSENSE_TOKEN")
+    config = {
+        "vlans_path": _clean_text(payload.get("vlans_path") or "/api/v1/vlans", 255),
+        "leases_path": _clean_text(payload.get("leases_path") or "/api/v1/services/dhcpd/leases", 255),
+        "arp_path": _clean_text(payload.get("arp_path") or "/api/v1/diagnostics/arp_table", 255),
+    }
+    return {
+        "kind": "pfsense",
+        "name": name,
+        "base_url": base_url,
+        "token_env": token_env,
+        "header_name": _clean_text(payload.get("header_name") or "Authorization", 120),
+        "token_prefix": _clean_text(payload.get("token_prefix") or "Bearer", 40),
+        "verify_tls": str(payload.get("verify_tls") or "").casefold() not in {"0", "false", "off", "no"},
+        "config": config,
+    }
+
+
+def save_integration(database_path, payload, integration_id=None, now=None):
+    item = validate_integration_payload(payload)
+    item_id = str(integration_id or uuid.uuid4())
+    now = float(now or time.time())
+    with _connection(database_path) as connection:
+        created = connection.execute(
+            "SELECT created_at FROM integrations WHERE id = ?", (item_id,)
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO integrations(
+                id, kind, name, base_url, token_env, header_name, token_prefix,
+                verify_tls, config_json, last_sync, last_status, created_at, updated_at
+            ) VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, COALESCE((SELECT last_sync FROM integrations WHERE id = ?), NULL), COALESCE((SELECT last_status FROM integrations WHERE id = ?), NULL), ?, ?)
+            """,
+            (
+                item_id, item["kind"], item["name"], item["base_url"], item["token_env"],
+                item["header_name"], item["token_prefix"], int(item["verify_tls"]),
+                json.dumps(item["config"], sort_keys=True), item_id, item_id,
+                float(created["created_at"]) if created else now, now,
+            ),
+        )
+    return get_integration(database_path, item_id)
+
+
+def get_integration(database_path, integration_id):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        row = connection.execute(
+            "SELECT * FROM integrations WHERE id = ?", (str(integration_id),)
+        ).fetchone()
+    if not row:
+        return None
+    item = _row_dict(row)
+    item["verify_tls"] = bool(item["verify_tls"])
+    item["config"] = _json_load(item.pop("config_json"), {})
+    item["token_configured"] = bool(item.get("token_env") and os.environ.get(item["token_env"]))
+    return item
+
+
+def list_integrations(database_path):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        rows = connection.execute("SELECT id FROM integrations ORDER BY name").fetchall()
+    return [get_integration(database_path, row["id"]) for row in rows]
+
+
+def update_integration_status(database_path, integration_id, status, now=None):
+    with _connection(database_path) as connection:
+        connection.execute(
+            "UPDATE integrations SET last_sync = ?, last_status = ?, updated_at = ? WHERE id = ?",
+            (float(now or time.time()), _clean_text(status, 1000), float(now or time.time()), str(integration_id)),
+        )
+    return get_integration(database_path, integration_id)
+
+
+def _iter_mapping_records(value):
+    if isinstance(value, list):
+        for item in value:
+            if isinstance(item, dict):
+                yield item
+    elif isinstance(value, dict):
+        for key, item in value.items():
+            if isinstance(item, dict):
+                record = dict(item)
+                record.setdefault("name", key)
+                yield record
+
+
+def parse_pfsense_payload(payload):
+    if not isinstance(payload, dict):
+        raise ValueError("pfSense import must be a JSON object")
+    vlan_sources = payload.get("vlans") or payload.get("interfaces") or []
+    vlans = []
+    for record in _iter_mapping_records(vlan_sources):
+        tag = record.get("tag") or record.get("vlan") or record.get("vlan_id")
+        name = record.get("descr") or record.get("description") or record.get("name") or (f"VLAN {tag}" if tag else "Imported network")
+        subnet = record.get("subnet") or record.get("network") or record.get("cidr")
+        gateway = record.get("gateway") or record.get("ipaddr") or record.get("address")
+        prefix = record.get("prefix") or record.get("subnet_bits")
+        if subnet and "/" not in str(subnet) and prefix:
+            subnet = f"{subnet}/{prefix}"
+        if not subnet and gateway and record.get("subnet") and str(record.get("subnet")).isdigit():
+            subnet = f"{gateway}/{record['subnet']}"
+        if not subnet and gateway and prefix:
+            subnet = str(ipaddress.ip_network(f"{gateway}/{prefix}", strict=False))
+        if not subnet:
+            continue
+        network = _normalise_network(subnet)
+        if gateway:
+            try:
+                gateway_value = _normalise_ip(gateway, "Gateway")
+            except ValueError:
+                gateway_value = ""
+        else:
+            gateway_value = ""
+        vlans.append(
+            {
+                "tag": tag,
+                "name": str(name),
+                "subnet": str(network),
+                "gateway": gateway_value,
+                "interface_name": record.get("if") or record.get("interface") or record.get("port"),
+                "router_name": payload.get("hostname") or "pfSense",
+                "description": "Imported from read-only pfSense data",
+                "probe_mode": "infrastructure",
+                "source_type": "pfsense",
+            }
+        )
+
+    devices_by_key = {}
+    for collection_name in ("leases", "dhcp_leases", "arp", "arp_table", "devices"):
+        for record in _iter_mapping_records(payload.get(collection_name) or []):
+            ip = record.get("ip") or record.get("ip_address") or record.get("address")
+            mac = record.get("mac") or record.get("mac_address")
+            if not ip and not mac:
+                continue
+            key = str(mac or ip).casefold()
+            current = devices_by_key.setdefault(key, {})
+            current.update({key: value for key, value in {
+                "ip": ip,
+                "mac": mac,
+                "hostname": record.get("hostname") or record.get("name"),
+                "manufacturer": record.get("manufacturer") or record.get("vendor"),
+                "interface": record.get("interface") or record.get("if"),
+                "vlan_tag": record.get("vlan") or record.get("tag") or record.get("vlan_id"),
+            }.items() if value not in (None, "")})
+    return {"vlans": vlans, "devices": list(devices_by_key.values())}
+
+
+def fetch_integration_payload(integration, opener=urlopen):
+    if not integration or not integration.get("base_url"):
+        raise ValueError("Integration does not have a base URL")
+    token = os.environ.get(integration.get("token_env") or "") if integration.get("token_env") else ""
+    headers = {"Accept": "application/json", "User-Agent": "Mobile-Router-VLAN/1"}
+    if token:
+        prefix = str(integration.get("token_prefix") or "").strip()
+        headers[integration.get("header_name") or "Authorization"] = f"{prefix} {token}".strip()
+    context = None
+    if not integration.get("verify_tls", True):
+        context = ssl._create_unverified_context()  # Explicit administrator opt-in for local appliances.
+
+    combined = {"hostname": integration.get("name") or "pfSense"}
+    for key, path in (integration.get("config") or {}).items():
+        if not path:
+            continue
+        url = urljoin(integration["base_url"] + "/", str(path).lstrip("/"))
+        request = Request(url, headers=headers, method="GET")
+        response = opener(request, timeout=10, context=context)
+        data = response.read(MAX_IMPORT_BYTES + 1)
+        if len(data) > MAX_IMPORT_BYTES:
+            raise ValueError("pfSense response exceeded the 2 MiB safety limit")
+        decoded = json.loads(data.decode("utf-8"))
+        logical_key = key.removesuffix("_path")
+        combined[logical_key] = decoded.get("data", decoded) if isinstance(decoded, dict) else decoded
+    return combined
+
+
+def save_remote_probe(database_path, payload, probe_id=None, now=None):
+    vlan_id = _clean_text(payload.get("vlan_id"), 80)
+    if not get_vlan(database_path, vlan_id):
+        raise ValueError("Probe VLAN was not found")
+    name = _clean_text(payload.get("name"), 120)
+    if not name:
+        raise ValueError("Probe name is required")
+    secret_env = _clean_text(payload.get("secret_env"), 128)
+    if not _ENV_REF_RE.match(secret_env):
+        raise ValueError("Probe secret environment reference must look like MOBILE_ROUTER_VLAN20_PROBE_KEY")
+    item_id = str(probe_id or uuid.uuid4())
+    now = float(now or time.time())
+    with _connection(database_path) as connection:
+        created = connection.execute(
+            "SELECT created_at FROM remote_probes WHERE id = ?", (item_id,)
+        ).fetchone()
+        connection.execute(
+            """
+            INSERT OR REPLACE INTO remote_probes(
+                id, vlan_id, name, secret_env, status, last_seen, created_at, updated_at
+            ) VALUES(
+                ?, ?, ?, ?,
+                COALESCE((SELECT status FROM remote_probes WHERE id = ?), 'never-seen'),
+                (SELECT last_seen FROM remote_probes WHERE id = ?), ?, ?
+            )
+            """,
+            (
+                item_id, vlan_id, name, secret_env, item_id, item_id,
+                float(created["created_at"]) if created else now, now,
+            ),
+        )
+    return get_remote_probe(database_path, item_id)
+
+
+def get_remote_probe(database_path, probe_id):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        row = connection.execute(
+            "SELECT * FROM remote_probes WHERE id = ?", (str(probe_id),)
+        ).fetchone()
+    if not row:
+        return None
+    item = _row_dict(row)
+    item["secret_configured"] = bool(os.environ.get(item.get("secret_env") or ""))
+    return item
+
+
+def list_remote_probes(database_path, vlan_id=None):
+    initialise_database(database_path)
+    with _connection(database_path) as connection:
+        if vlan_id:
+            rows = connection.execute(
+                "SELECT id FROM remote_probes WHERE vlan_id = ? ORDER BY name", (str(vlan_id),)
+            ).fetchall()
+        else:
+            rows = connection.execute("SELECT id FROM remote_probes ORDER BY name").fetchall()
+    return [get_remote_probe(database_path, row["id"]) for row in rows]
+
+
+def probe_signature(secret, timestamp, nonce, body):
+    message = str(timestamp).encode("ascii") + b"\n" + str(nonce).encode("utf-8") + b"\n" + bytes(body)
+    return hmac.new(str(secret).encode("utf-8"), message, hashlib.sha256).hexdigest()
+
+
+def verify_probe_submission(database_path, probe_id, body, timestamp, nonce, signature, now=None):
+    body = bytes(body or b"")
+    if len(body) > MAX_PROBE_BYTES:
+        raise ValueError("Probe payload exceeded the 1 MiB safety limit")
+    probe = get_remote_probe(database_path, probe_id)
+    if not probe:
+        raise ValueError("Unknown remote probe")
+    secret = os.environ.get(probe.get("secret_env") or "")
+    if not secret:
+        raise ValueError("Remote probe secret is not configured on the server")
+    try:
+        sent_at = int(timestamp)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Probe timestamp is invalid") from exc
+    current = int(now or time.time())
+    if abs(current - sent_at) > PROBE_CLOCK_SKEW_SECONDS:
+        raise ValueError("Probe timestamp is outside the five-minute acceptance window")
+    if not _NONCE_RE.match(str(nonce or "")):
+        raise ValueError("Probe nonce is invalid")
+    expected = probe_signature(secret, sent_at, nonce, body)
+    supplied = str(signature or "").removeprefix("sha256=")
+    if not hmac.compare_digest(expected, supplied):
+        raise ValueError("Probe signature is invalid")
+
+    with _connection(database_path) as connection:
+        connection.execute(
+            "DELETE FROM probe_nonces WHERE seen_at < ?", (current - (PROBE_CLOCK_SKEW_SECONDS * 2),)
+        )
+        try:
+            connection.execute(
+                "INSERT INTO probe_nonces(probe_id, nonce, seen_at) VALUES(?, ?, ?)",
+                (str(probe_id), str(nonce), current),
+            )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError("Probe submission nonce has already been used") from exc
+        connection.execute(
+            "UPDATE remote_probes SET status = 'online', last_seen = ?, updated_at = ? WHERE id = ?",
+            (current, current, str(probe_id)),
+        )
+
+    try:
+        payload = json.loads(body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("Probe payload is not valid UTF-8 JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Probe payload must be a JSON object")
+    devices = payload.get("devices") or []
+    if not isinstance(devices, list) or len(devices) > 4096:
+        raise ValueError("Probe devices must be a list containing at most 4096 records")
+    return probe, payload

--- a/static/css/vlans.css
+++ b/static/css/vlans.css
@@ -1,0 +1,241 @@
+.vlan-tag-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    max-width: 100%;
+    padding: 0.38rem 0.68rem;
+    border: 1px solid color-mix(in srgb, var(--theme-primary) 52%, var(--theme-border));
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--theme-primary-soft) 82%, var(--theme-surface));
+    color: var(--theme-primary);
+    font-size: 0.82rem;
+    font-weight: 800;
+    line-height: 1.1;
+    text-decoration: none;
+    white-space: nowrap;
+    box-shadow: 0 0.18rem 0.65rem rgba(0, 0, 0, 0.08);
+}
+
+.vlan-tag-badge:hover,
+.vlan-tag-badge:focus {
+    color: var(--theme-text);
+    border-color: var(--theme-primary);
+    text-decoration: none;
+    outline: none;
+}
+
+.vlan-tag-badge-unlinked {
+    border-style: dashed;
+    color: var(--theme-muted);
+}
+
+.vlan-hero-tag {
+    font-size: 1rem;
+    padding: 0.58rem 0.9rem;
+}
+
+.vlan-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(17rem, 1fr));
+    gap: 1rem;
+}
+
+.vlan-card {
+    position: relative;
+    min-height: 13rem;
+    overflow: hidden;
+}
+
+.vlan-card::before {
+    content: "";
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 0.34rem;
+    background: var(--theme-primary);
+}
+
+.vlan-card .card-body {
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.vlan-card-title {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.vlan-card-title h3 {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.vlan-definition-list {
+    display: grid;
+    gap: 0.4rem;
+    margin: 0;
+}
+
+.vlan-definition-list > div {
+    display: grid;
+    grid-template-columns: minmax(7rem, 0.45fr) minmax(0, 1fr);
+    gap: 0.75rem;
+    padding: 0.38rem 0;
+    border-bottom: 1px solid var(--theme-border);
+}
+
+.vlan-definition-list > div:last-child {
+    border-bottom: 0;
+}
+
+.vlan-definition-list dt,
+.vlan-definition-list dd {
+    margin: 0;
+}
+
+.vlan-definition-list dt {
+    color: var(--theme-muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.vlan-visibility-banner {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    gap: 0.8rem;
+    align-items: start;
+    padding: 0.85rem 1rem;
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-radius);
+    background: var(--theme-surface-soft);
+}
+
+.vlan-visibility-banner i {
+    margin-top: 0.2rem;
+    color: var(--theme-primary);
+    font-size: 1.25rem;
+}
+
+.vlan-visibility-banner strong,
+.vlan-visibility-banner span {
+    display: block;
+}
+
+.vlan-visibility-banner span {
+    color: var(--theme-muted);
+    font-size: 0.88rem;
+}
+
+.vlan-status-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    gap: 0.8rem;
+}
+
+.vlan-status-tile {
+    padding: 0.85rem;
+    border: 1px solid var(--theme-border);
+    border-radius: var(--theme-radius);
+    background: var(--theme-surface-soft);
+}
+
+.vlan-status-tile strong,
+.vlan-status-tile span {
+    display: block;
+}
+
+.vlan-status-tile strong {
+    font-size: 1.35rem;
+}
+
+.vlan-status-tile span {
+    color: var(--theme-muted);
+    font-size: 0.8rem;
+}
+
+.vlan-device-name {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.45rem;
+}
+
+.vlan-matrix-status {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    padding: 0.24rem 0.48rem;
+    border-radius: 999px;
+    font-size: 0.76rem;
+    font-weight: 800;
+}
+
+.vlan-matrix-status-pass {
+    background: rgba(40, 167, 69, 0.14);
+    color: #19853a;
+}
+
+.vlan-matrix-status-fail {
+    background: rgba(220, 53, 69, 0.14);
+    color: #b32332;
+}
+
+.vlan-matrix-status-unknown {
+    background: var(--theme-surface-soft);
+    color: var(--theme-muted);
+}
+
+.vlan-investigation-hosts {
+    max-height: 28rem;
+    overflow: auto;
+}
+
+.vlan-investigation-host-row {
+    display: grid;
+    grid-template-columns: minmax(8rem, 0.45fr) minmax(0, 1fr) auto;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.55rem 0;
+    border-bottom: 1px solid var(--theme-border);
+}
+
+.vlan-form-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 0.85rem;
+}
+
+.vlan-form-grid .vlan-form-span {
+    grid-column: 1 / -1;
+}
+
+.vlan-output:not(:empty) {
+    margin: 1rem 0;
+}
+
+.vlan-secret-reference {
+    font-family: var(--font-monospace, monospace);
+    overflow-wrap: anywhere;
+}
+
+@media (max-width: 767.98px) {
+    .vlan-form-grid {
+        grid-template-columns: minmax(0, 1fr);
+    }
+
+    .vlan-form-grid .vlan-form-span {
+        grid-column: auto;
+    }
+
+    .vlan-definition-list > div,
+    .vlan-investigation-host-row {
+        grid-template-columns: minmax(0, 1fr);
+        gap: 0.2rem;
+    }
+
+    .vlan-tag-badge {
+        white-space: normal;
+    }
+}

--- a/static/js/vlan-tags.js
+++ b/static/js/vlan-tags.js
@@ -1,0 +1,96 @@
+(function () {
+  'use strict';
+
+  const pending = new Map();
+  const cache = new Map();
+  let timer = null;
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function badgeMarkup(vlan) {
+    return `<a class="vlan-tag-badge" href="${escapeHtml(vlan.url)}" title="${escapeHtml(vlan.subnet)}" data-vlan-tag="${vlan.tag === null || vlan.tag === undefined ? '' : escapeHtml(vlan.tag)}"><i class="fa-solid fa-layer-group" aria-hidden="true"></i><span>${escapeHtml(vlan.label)}</span></a>`;
+  }
+
+  function targetFor(element) {
+    if (element.matches('[data-device-workspace]')) {
+      return element.querySelector('.device-compact-summary');
+    }
+    if (element.matches('[data-network-device-card]')) {
+      return element.querySelector('.wireless-network-badges');
+    }
+    return element.querySelector('[data-vlan-badge-target]') || element;
+  }
+
+  function apply(element, vlan) {
+    if (!element || !vlan || element.querySelector('.vlan-tag-badge')) return;
+    const target = targetFor(element);
+    if (!target) return;
+    target.insertAdjacentHTML('afterbegin', badgeMarkup(vlan));
+    element.dataset.vlanId = vlan.id;
+    element.dataset.vlanTag = vlan.tag === null || vlan.tag === undefined ? '' : String(vlan.tag);
+    element.dataset.vlanLabel = vlan.label;
+  }
+
+  function queueElement(element) {
+    const host = String(element.getAttribute('data-host') || '').trim();
+    if (!host || element.dataset.vlanLookupQueued === 'true' || element.querySelector('.vlan-tag-badge')) return;
+    element.dataset.vlanLookupQueued = 'true';
+    if (cache.has(host)) {
+      apply(element, cache.get(host));
+      return;
+    }
+    if (!pending.has(host)) pending.set(host, []);
+    pending.get(host).push(element);
+    window.clearTimeout(timer);
+    timer = window.setTimeout(flush, 80);
+  }
+
+  async function flush() {
+    const batch = Array.from(pending.keys()).slice(0, 256);
+    if (!batch.length) return;
+    const elements = new Map();
+    batch.forEach(function (host) {
+      elements.set(host, pending.get(host) || []);
+      pending.delete(host);
+    });
+    try {
+      const response = await fetch(`/api/v1/vlans/lookup?ips=${encodeURIComponent(batch.join(','))}`, {
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      if (!response.ok) return;
+      const payload = await response.json();
+      batch.forEach(function (host) {
+        const vlan = (payload.vlans || {})[host] || null;
+        cache.set(host, vlan);
+        (elements.get(host) || []).forEach(function (element) { apply(element, vlan); });
+      });
+    } catch (error) {
+      // VLAN badges are supplemental; network pages remain functional offline.
+    }
+    if (pending.size) timer = window.setTimeout(flush, 80);
+  }
+
+  function scan(root) {
+    const source = root || document;
+    if (source.matches && source.matches('[data-device-workspace][data-host], [data-network-device-card][data-host], [data-vlan-host][data-host]')) queueElement(source);
+    source.querySelectorAll('[data-device-workspace][data-host], [data-network-device-card][data-host], [data-vlan-host][data-host]').forEach(queueElement);
+  }
+
+  scan(document);
+  const observer = new MutationObserver(function (mutations) {
+    mutations.forEach(function (mutation) {
+      mutation.addedNodes.forEach(function (node) {
+        if (node.nodeType === Node.ELEMENT_NODE) scan(node);
+      });
+    });
+  });
+  observer.observe(document.documentElement, { childList: true, subtree: true });
+}());

--- a/static/js/vlans.js
+++ b/static/js/vlans.js
@@ -1,0 +1,80 @@
+(function () {
+  'use strict';
+
+  const output = document.querySelector('[data-vlan-output]');
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+
+  function show(kind, message, detail) {
+    if (!output) return;
+    output.innerHTML = `<div class="alert alert-${kind}" role="status"><strong>${escapeHtml(message)}</strong>${detail ? `<p class="mb-0 mt-1">${escapeHtml(detail)}</p>` : ''}</div>`;
+    output.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  function responseMessage(payload, form) {
+    if (payload.message) return payload.message;
+    if (payload.vlan) return `${payload.vlan.label} saved.`;
+    if (payload.investigation) {
+      const summary = payload.investigation.summary || {};
+      return `Investigation complete: ${summary.reachable_hosts || 0} of ${summary.total_hosts || 0} hosts reachable.`;
+    }
+    if (payload.rule) return 'Segmentation expectation saved.';
+    if (payload.result) return payload.result.mismatch ? 'Segmentation result does not match the saved expectation.' : 'Segmentation result matches the saved expectation.';
+    if (payload.integration) return 'Infrastructure integration saved.';
+    if (payload.probe) return 'Remote probe configuration saved.';
+    if (payload.vlans) return `Imported ${payload.vlans.length} VLAN definition(s) and ${(payload.devices || []).length} device record(s).`;
+    return `${form.dataset.actionLabel || 'Operation'} completed.`;
+  }
+
+  async function submitForm(form) {
+    const confirmText = form.getAttribute('data-confirm');
+    if (confirmText && !window.confirm(confirmText)) return;
+    const button = form.querySelector('button[type="submit"]');
+    const original = button ? button.textContent : '';
+    if (button) {
+      button.disabled = true;
+      button.textContent = form.action.includes('/investigate') ? 'Investigating…' : 'Working…';
+    }
+    show('info', form.action.includes('/investigate') ? 'Running bounded VLAN investigation…' : 'Saving VLAN records…', 'Long routed investigations may take several minutes. Do not close the page.');
+
+    try {
+      const response = await fetch(form.action, {
+        method: (form.method || 'POST').toUpperCase(),
+        body: new FormData(form),
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      const payload = await response.json().catch(function () { return {}; });
+      if (!response.ok) throw new Error(payload.message || `Request failed (${response.status})`);
+      const kind = payload.result && payload.result.mismatch ? 'warning' : 'success';
+      show(kind, responseMessage(payload, form));
+      const destination = form.getAttribute('data-vlan-redirect');
+      if (destination) {
+        window.location.assign(destination);
+      } else if (form.hasAttribute('data-vlan-refresh')) {
+        window.setTimeout(function () { window.location.reload(); }, 650);
+      }
+    } catch (error) {
+      show('danger', 'VLAN operation failed', error.message || String(error));
+    } finally {
+      if (button) {
+        button.disabled = false;
+        button.textContent = original;
+      }
+    }
+  }
+
+  document.addEventListener('submit', function (event) {
+    const form = event.target.closest('form[data-vlan-ajax]');
+    if (!form) return;
+    event.preventDefault();
+    submitForm(form);
+  });
+}());

--- a/templates/_footer.html
+++ b/templates/_footer.html
@@ -11,5 +11,5 @@
 <script src="/static/js/port-knowledge.js"></script>
 <script src="/static/js/model-profiles.js"></script>
 <script src="/static/js/host-facts.js"></script>
+<script src="/static/js/vlan-tags.js"></script>
 <script src="/static/js/long-page.js"></script>
-

--- a/templates/_header.html
+++ b/templates/_header.html
@@ -9,6 +9,7 @@
 <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/navigation-shell.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/long-page.css') }}">
+<link rel="stylesheet" href="{{ url_for('static', filename='css/vlans.css') }}">
 <link rel="stylesheet" href="{{ url_for('static', filename='css/train-controller.css') }}">
 <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon.ico') }}">
 

--- a/templates/_primary-nav-links.html
+++ b/templates/_primary-nav-links.html
@@ -67,7 +67,7 @@
 <div class="nav-item dropdown nav-compact-group">
   <button type="button"
           id="records-menu"
-          class="nav-link dropdown-toggle {% if title in ['Device Inventory', 'Device Model Library', 'Alerts', 'Reports', 'Evidence Vault', 'Social Engineering'] or title[:7] == 'Client ' or title[:6] == 'Model ' %}active{% endif %}"
+          class="nav-link dropdown-toggle {% if title in ['Device Inventory', 'Device Model Library', 'VLAN Investigations', 'Alerts', 'Reports', 'Evidence Vault', 'Social Engineering'] or title[:7] == 'Client ' or title[:6] == 'Model ' or request.path.startswith('/vlans') %}active{% endif %}"
           data-navigation-toggle="dropdown"
           aria-haspopup="true"
           aria-expanded="false">
@@ -76,6 +76,7 @@
   <div class="dropdown-menu navigation-menu" aria-labelledby="records-menu">
     <a href="/inventory" class="dropdown-item {% if title == 'Device Inventory' or title[:7] == 'Client ' %}active{% endif %}" {% if title == 'Device Inventory' or title[:7] == 'Client ' %}aria-current="page"{% endif %}>Inventory</a>
     <a href="/models" class="dropdown-item {% if title == 'Device Model Library' or title[:6] == 'Model ' %}active{% endif %}" {% if title == 'Device Model Library' or title[:6] == 'Model ' %}aria-current="page"{% endif %}>Device Model Library</a>
+    <a href="/vlans" class="dropdown-item {% if title == 'VLAN Investigations' or request.path.startswith('/vlans') %}active{% endif %}" {% if title == 'VLAN Investigations' or request.path.startswith('/vlans') %}aria-current="page"{% endif %}>VLAN Investigations</a>
     <a href="/alerts" class="dropdown-item {% if title == 'Alerts' %}active{% endif %}" {% if title == 'Alerts' %}aria-current="page"{% endif %}>Alerts</a>
     <a href="/reports" class="dropdown-item {% if title == 'Reports' %}active{% endif %}" {% if title == 'Reports' %}aria-current="page"{% endif %}>Reports</a>
     <a href="/evidence" class="dropdown-item {% if title == 'Evidence Vault' %}active{% endif %}" {% if title == 'Evidence Vault' %}aria-current="page"{% endif %}>Evidence Vault</a>

--- a/templates/_vlan_badge.html
+++ b/templates/_vlan_badge.html
@@ -1,0 +1,17 @@
+{% set vlan_record = vlan if vlan is defined and vlan else device if device is defined and device else {} %}
+{% set vlan_identifier = vlan_record.id if vlan_record.id is defined else vlan_record.vlan_id %}
+{% set vlan_label = vlan_record.label if vlan_record.label is defined else vlan_record.vlan_label %}
+{% set vlan_tag = vlan_record.tag if vlan_record.tag is defined else vlan_record.vlan_tag %}
+{% set vlan_name = vlan_record.name if vlan_record.name is defined else vlan_record.vlan_name %}
+{% set vlan_subnet = vlan_record.subnet if vlan_record.subnet is defined else vlan_record.vlan_subnet %}
+{% if vlan_identifier and vlan_label %}
+  <a class="vlan-tag-badge" href="/vlans/{{ vlan_identifier|urlencode }}" title="{{ vlan_subnet or vlan_label }}" data-vlan-tag="{{ vlan_tag if vlan_tag is not none else '' }}">
+    <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
+    <span>{{ vlan_label }}</span>
+  </a>
+{% elif vlan_tag is not none or vlan_name or vlan_subnet %}
+  <span class="vlan-tag-badge vlan-tag-badge-unlinked" title="VLAN mapping is present but no saved VLAN definition is linked">
+    <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
+    <span>{% if vlan_tag is not none %}VLAN {{ vlan_tag }}{% if vlan_name %} · {{ vlan_name }}{% endif %}{% else %}{{ vlan_name or vlan_subnet }}{% endif %}</span>
+  </span>
+{% endif %}

--- a/templates/client_workspace/_network.html
+++ b/templates/client_workspace/_network.html
@@ -1,11 +1,26 @@
+{% set inventory_device = vlan_device(inventory_device) %}
 <section aria-labelledby="workspace-network-title">
   <div class="device-workspace-section-heading">
     <div>
       <p class="page-kicker mb-1">Network</p>
       <h2 id="workspace-network-title" class="theme-section-title mb-1">Connectivity and relationships</h2>
-      <p class="text-muted mb-0">Reachability, path diagnostics, linked interfaces, dependencies, and scheduled checks.</p>
+      <p class="text-muted mb-0">VLAN membership, reachability, path diagnostics, linked interfaces, dependencies, and scheduled checks.</p>
     </div>
+    {% include '_vlan_badge.html' %}
   </div>
+
+  {% if inventory_device.vlan_id %}
+    <div class="vlan-visibility-banner mt-3">
+      <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
+      <div>
+        <strong>{{ inventory_device.vlan_label }}</strong>
+        <span>{{ inventory_device.vlan_subnet }}{% if inventory_device.vlan_gateway %} · gateway {{ inventory_device.vlan_gateway }}{% endif %}{% if inventory_device.vlan_interface %} · interface {{ inventory_device.vlan_interface }}{% endif %} · {{ inventory_device.vlan_assignment_source|replace('-', ' ') }} with {{ inventory_device.vlan_confidence }} confidence.</span>
+        <a href="/vlans/{{ inventory_device.vlan_id|urlencode }}">Open this VLAN investigation and segmentation matrix</a>
+      </div>
+    </div>
+  {% else %}
+    <div class="alert alert-warning mt-3">No saved VLAN or routed-network definition contains {{ ip }}. <a href="/vlans">Define the subnet</a> to make its network boundary explicit across the inventory.</div>
+  {% endif %}
 
   <div class="device-overview-columns mt-3">
     <article class="theme-card card" data-ip-client-tools data-host="{{ ip }}">
@@ -15,18 +30,13 @@
           <button type="button" class="btn btn-outline-success" data-ip-client-ping>Ping client</button>
           <button type="button" class="btn btn-outline-info" data-ip-client-route>Route diagnostics</button>
           <button type="button" class="btn btn-outline-secondary" data-ip-client-traceroute>Traceroute</button>
+          {% if inventory_device.vlan_id %}<a class="btn btn-outline-info" href="/vlans/{{ inventory_device.vlan_id|urlencode }}">Investigate VLAN</a>{% endif %}
           <a class="btn btn-outline-primary" href="/diagnostics">Open diagnostics</a>
         </div>
         {% if reachability_history %}
-          <div class="alert alert-info mt-3 mb-0">
-            Recent reachability: {{ reachability_history|length }} check(s); latest {{ 'reachable' if reachability_history[-1].reachable else 'unreachable' }} with {{ reachability_history[-1].packet_loss_percent }}% packet loss.
-          </div>
+          <div class="alert alert-info mt-3 mb-0">Recent reachability: {{ reachability_history|length }} check(s); latest {{ 'reachable' if reachability_history[-1].reachable else 'unreachable' }} with {{ reachability_history[-1].packet_loss_percent }}% packet loss.</div>
         {% else %}
-          <div class="device-empty-state mt-3">
-            <i class="fa-solid fa-satellite-dish" aria-hidden="true"></i>
-            <h4>No reachability history yet</h4>
-            <p>Ping the device to start a lightweight reachability history.</p>
-          </div>
+          <div class="device-empty-state mt-3"><i class="fa-solid fa-satellite-dish" aria-hidden="true"></i><h4>No reachability history yet</h4><p>Ping the device to start a lightweight reachability history.</p></div>
         {% endif %}
       </div>
     </article>
@@ -35,6 +45,9 @@
       <div class="card-body">
         <h3 class="theme-subsection-title">Network presence</h3>
         <dl class="interface-definition-list">
+          <div><dt>VLAN / network</dt><dd>{{ inventory_device.vlan_label or 'Not assigned' }}</dd></div>
+          <div><dt>802.1Q tag</dt><dd>{{ inventory_device.vlan_tag if inventory_device.vlan_tag is not none else 'Unknown or untagged' }}</dd></div>
+          <div><dt>Subnet</dt><dd>{{ inventory_device.vlan_subnet or 'No matching definition' }}</dd></div>
           <div><dt>IPv4</dt><dd>{{ ip }}</dd></div>
           <div><dt>MAC</dt><dd>{{ mac or 'Unknown' }}</dd></div>
           <div><dt>Interfaces</dt><dd>{{ (inventory_device.interfaces or [])|join(', ') or 'Unknown' }}</dd></div>
@@ -48,28 +61,12 @@
   <article class="theme-card card mt-4">
     <div class="card-body">
       <h3 class="theme-subsection-title">Client relationship map</h3>
-      <p class="text-muted">Context links between this client, interfaces, discovery sources, saved services, and evidence records.</p>
+      <p class="text-muted">Context links between this client, VLAN, interfaces, discovery sources, saved services, and evidence records.</p>
       <div class="theme-grid">
-        {% for node in relationship_map.nodes %}
-          <div class="port-service-card">
-            <strong>{{ node.label }}</strong>
-            <small>{{ node.type }}</small>
-          </div>
-        {% else %}
-          <div class="device-empty-state">
-            <i class="fa-solid fa-diagram-project" aria-hidden="true"></i>
-            <h4>No relationships recorded</h4>
-            <p>Run discovery and service scans to build links between this device and its network context.</p>
-          </div>
-        {% endfor %}
+        {% if inventory_device.vlan_id %}<div class="port-service-card"><strong>{{ inventory_device.vlan_label }}</strong><small>{{ inventory_device.vlan_subnet }} · VLAN boundary</small></div>{% endif %}
+        {% for node in relationship_map.nodes %}<div class="port-service-card"><strong>{{ node.label }}</strong><small>{{ node.type }}</small></div>{% else %}{% if not inventory_device.vlan_id %}<div class="device-empty-state"><i class="fa-solid fa-diagram-project" aria-hidden="true"></i><h4>No relationships recorded</h4><p>Run discovery and service scans to build links between this device and its network context.</p></div>{% endif %}{% endfor %}
       </div>
-      {% if relationship_map.links %}
-        <ul class="mt-3 mb-0">
-          {% for link in relationship_map.links %}
-            <li>{{ link.source }} → {{ link.target }} <span class="text-muted">({{ link.label }})</span></li>
-          {% endfor %}
-        </ul>
-      {% endif %}
+      {% if relationship_map.links %}<ul class="mt-3 mb-0">{% for link in relationship_map.links %}<li>{{ link.source }} → {{ link.target }} <span class="text-muted">({{ link.label }})</span></li>{% endfor %}</ul>{% endif %}
     </div>
   </article>
 
@@ -77,19 +74,11 @@
     <div class="card-body">
       <h3 class="theme-subsection-title">Scheduled client checks</h3>
       <p class="text-muted">Save a recurring check plan for this client and run it on demand.</p>
-      {% if scheduled_check %}
-        <div class="alert alert-info">Scheduled every {{ scheduled_check.interval_minutes }} minute(s): {{ scheduled_check.checks|join(', ') }}</div>
-      {% endif %}
+      {% if scheduled_check %}<div class="alert alert-info">Scheduled every {{ scheduled_check.interval_minutes }} minute(s): {{ scheduled_check.checks|join(', ') }}</div>{% endif %}
       <form class="theme-form" data-ip-client-scheduled-form data-workspace-form>
-        <label for="client-check-interval">Interval minutes</label>
-        <input id="client-check-interval" class="form-control" name="intervalMinutes" type="number" min="5" max="10080" value="{{ scheduled_check.interval_minutes if scheduled_check else 60 }}" data-ip-client-check-interval>
-        <label class="mt-2" for="client-checks">Checks</label>
-        <input id="client-checks" class="form-control" name="checks" value="{{ scheduled_check.checks|join(', ') if scheduled_check else 'ping, common-ports, baseline-drift' }}" data-ip-client-checks placeholder="ping, common-ports, http-inspect, service-fingerprint, baseline-drift">
-        <div class="theme-actions">
-          <button type="submit" class="btn btn-primary">Save scheduled checks</button>
-          <button type="button" class="btn btn-outline-success" data-ip-client-run-scheduled>Run saved checks now</button>
-          <span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span>
-        </div>
+        <label for="client-check-interval">Interval minutes</label><input id="client-check-interval" class="form-control" name="intervalMinutes" type="number" min="5" max="10080" value="{{ scheduled_check.interval_minutes if scheduled_check else 60 }}" data-ip-client-check-interval>
+        <label class="mt-2" for="client-checks">Checks</label><input id="client-checks" class="form-control" name="checks" value="{{ scheduled_check.checks|join(', ') if scheduled_check else 'ping, common-ports, baseline-drift' }}" data-ip-client-checks placeholder="ping, common-ports, http-inspect, service-fingerprint, baseline-drift">
+        <div class="theme-actions"><button type="submit" class="btn btn-primary">Save scheduled checks</button><button type="button" class="btn btn-outline-success" data-ip-client-run-scheduled>Run saved checks now</button><span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span></div>
       </form>
     </div>
   </article>
@@ -98,13 +87,8 @@
     <div class="card-body">
       <h3 class="theme-subsection-title">Investigation note</h3>
       <form class="theme-form" data-ip-client-evidence-form data-workspace-form>
-        <label for="ip-client-evidence">Evidence / investigation note</label>
-        <textarea id="ip-client-evidence" class="form-control" name="notes" data-ip-client-evidence-notes rows="3" placeholder="Example: Gateway responded to ping; SSH and HTTPS open during authorized baseline." required></textarea>
-        <div class="theme-actions">
-          <button type="submit" class="btn btn-primary">Save evidence note</button>
-          <a class="btn btn-link" href="/evidence">Open Evidence Vault</a>
-          <span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span>
-        </div>
+        <label for="ip-client-evidence">Evidence / investigation note</label><textarea id="ip-client-evidence" class="form-control" name="notes" data-ip-client-evidence-notes rows="3" placeholder="Example: Gateway responded to ping; SSH and HTTPS open during authorized baseline." required></textarea>
+        <div class="theme-actions"><button type="submit" class="btn btn-primary">Save evidence note</button><a class="btn btn-link" href="/evidence">Open Evidence Vault</a><span class="workspace-form-status text-muted" data-workspace-form-status>Saved</span></div>
       </form>
     </div>
   </article>

--- a/templates/client_workspace/_overview.html
+++ b/templates/client_workspace/_overview.html
@@ -1,3 +1,4 @@
+{% set inventory_device = vlan_device(inventory_device) %}
 {% set identity = inventory_device.identity_assessment or {} %}
 {% set unexpected = baseline_diff.unexpected_ports or [] %}
 {% set missing = baseline_diff.missing_ports or [] %}
@@ -8,9 +9,12 @@
     <div>
       <p class="page-kicker mb-1">At a glance</p>
       <h2 id="workspace-overview-title" class="theme-section-title mb-1">Device overview</h2>
-      <p class="text-muted mb-0">Identity, service, security, and recent-change summaries for {{ display_name }}.</p>
+      <p class="text-muted mb-0">Identity, network, service, security, and recent-change summaries for {{ display_name }}.</p>
     </div>
-    <span class="badge badge-{{ health_summary.badge }} p-2">{{ health_summary.level }} · {{ health_summary.score }}/100</span>
+    <div class="d-flex align-items-center flex-wrap" style="gap: .5rem;">
+      {% include '_vlan_badge.html' %}
+      <span class="badge badge-{{ health_summary.badge }} p-2">{{ health_summary.level }} · {{ health_summary.score }}/100</span>
+    </div>
   </div>
 
   <div class="device-dashboard-grid mt-3">
@@ -23,8 +27,8 @@
     <button type="button" class="device-dashboard-card" data-workspace-open="network">
       <span class="device-dashboard-icon"><i class="fa-solid fa-diagram-project" aria-hidden="true"></i></span>
       <strong>Network</strong>
-      <span>{{ (inventory_device.interfaces or [])|length }} interface link(s)</span>
-      <small>{{ (inventory_device.sources or [])|length }} discovery source(s)</small>
+      <span>{{ inventory_device.vlan_label or ((inventory_device.interfaces or [])|length ~ ' interface link(s)') }}</span>
+      <small>{% if inventory_device.vlan_subnet %}{{ inventory_device.vlan_subnet }}{% if inventory_device.vlan_gateway %} · gateway {{ inventory_device.vlan_gateway }}{% endif %}{% else %}{{ (inventory_device.sources or [])|length }} discovery source(s){% endif %}</small>
     </button>
     <button type="button" class="device-dashboard-card" data-workspace-open="services">
       <span class="device-dashboard-icon"><i class="fa-solid fa-server" aria-hidden="true"></i></span>
@@ -45,6 +49,9 @@
       <div class="card-body">
         <h3 class="theme-subsection-title">Recommended next actions</h3>
         <ol class="device-recommendation-list mb-0">
+          {% if not inventory_device.vlan_id %}
+            <li><a href="/vlans">Define the containing subnet or VLAN tag so this device's network boundary is explicit.</a></li>
+          {% endif %}
           {% if not identity %}
             <li><button type="button" class="btn btn-link p-0" data-ip-client-intelligence>Identify this device from saved evidence and safe service probes.</button></li>
           {% endif %}
@@ -75,19 +82,15 @@
         </div>
         <ol class="client-timeline device-activity-preview mt-3 mb-0">
           {% for event in client_timeline[:5] %}
-            <li>
-              <strong>{{ event.time_label }}</strong> — {{ event.type }}
-              <p class="mb-0">{{ event.message }}</p>
-            </li>
-          {% else %}
-            <li class="text-muted">No device activity has been recorded yet.</li>
-          {% endfor %}
+            <li><strong>{{ event.time_label }}</strong> — {{ event.type }}<p class="mb-0">{{ event.message }}</p></li>
+          {% else %}<li class="text-muted">No device activity has been recorded yet.</li>{% endfor %}
         </ol>
       </div>
     </article>
   </div>
 
   <div class="theme-actions mt-4">
+    {% if inventory_device.vlan_id %}<a class="btn btn-outline-info" href="/vlans/{{ inventory_device.vlan_id|urlencode }}">Open {{ inventory_device.vlan_label }}</a>{% endif %}
     <button type="button" class="btn btn-primary" data-workspace-open="services">Scan and review services</button>
     <button type="button" class="btn btn-outline-dark" data-ip-client-intelligence>Identify device</button>
     <a class="btn btn-outline-info" href="/clients/{{ ip|urlencode }}/host-facts">Host facts &amp; capabilities</a>
@@ -98,63 +101,25 @@
     <section class="theme-card card mt-4" aria-labelledby="noscript-client-actions">
       <div class="card-body">
         <h3 id="noscript-client-actions" class="theme-section-title">IP Client Actions</h3>
+        {% include '_vlan_badge.html' %}
         <p><strong>Client Health:</strong> {{ health_summary.level }} · {{ health_summary.score }}/100</p>
-        {% if unexpected or missing %}
-          <p><strong>Drift detected</strong>{% if unexpected %} · Unexpected {{ unexpected|join(', ') }}{% endif %}{% if missing %} · Missing {{ missing|join(', ') }}{% endif %}</p>
-        {% endif %}
-        <p>
-          <button type="button" class="btn btn-outline-warning">Watch this device</button>
-          <button type="button" class="btn btn-outline-primary">Save baseline</button>
-          <button type="button" data-port-scan-cancel hidden>Cancel scan</button>
-        </p>
+        {% if unexpected or missing %}<p><strong>Drift detected</strong>{% if unexpected %} · Unexpected {{ unexpected|join(', ') }}{% endif %}{% if missing %} · Missing {{ missing|join(', ') }}{% endif %}</p>{% endif %}
+        <p><button type="button" class="btn btn-outline-warning">Watch this device</button><button type="button" class="btn btn-outline-primary">Save baseline</button><button type="button" data-port-scan-cancel hidden>Cancel scan</button></p>
         <h4>Saved Service Profile</h4>
         <div class="port-service-grid">
           {% for port in open_port_details %}
             <div class="port-service-card" data-web-service-preview>
               <strong class="port-service-number">{% if port.web_url %}<a href="{{ port.web_url }}" target="_blank" rel="noopener noreferrer">{{ port.port }}/tcp</a>{% else %}{{ port.port }}/tcp{% endif %}</strong>
-              <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}">
-                <span>{{ port.service }}</span>
-                <small>{{ port.description }}</small>
-              </a>
-              {% if port.web_url %}
-                <div class="web-service-hover-preview">
-                  <strong>{{ port.http_title or port.web_url }}</strong>
-                  <span>Status: {{ port.http_status or 'not captured' }}{% if port.http_server %} · {{ port.http_server }}{% endif %}</span>
-                </div>
-              {% endif %}
+              <a class="port-service-card-link" href="/clients/{{ ip|urlencode }}/services/{{ port.port }}"><span>{{ port.service }}</span><small>{{ port.description }}</small></a>
+              {% if port.web_url %}<div class="web-service-hover-preview"><strong>{{ port.http_title or port.web_url }}</strong><span>Status: {{ port.http_status or 'not captured' }}{% if port.http_server %} · {{ port.http_server }}{% endif %}</span></div>{% endif %}
             </div>
-          {% else %}
-            <p class="text-muted">No saved services.</p>
-          {% endfor %}
+          {% else %}<p class="text-muted">No saved services.</p>{% endfor %}
         </div>
-        <h4 class="mt-3">Device Port Scan</h4>
-        <p><a href="/port-scan?host={{ ip|urlencode }}">Common ports · All ports · Open full port scan</a></p>
-        <p>Inspect web services · Fingerprint services</p>
-
-        <h4 class="mt-3">Client Profile Metadata</h4>
-        <p>Expected open ports: {{ (inventory_device.expected_open_ports or [])|join(', ') or 'Not configured' }}</p>
-        <p><a href="/clients/{{ ip|urlencode }}/export.json">Export JSON</a> · <a href="/clients/{{ ip|urlencode }}/export.md">Export Markdown</a></p>
-
-        <h4>Client Relationship Map</h4>
-        <p>Open the Network workspace to review interfaces, discovery sources, paths, and linked services.</p>
-        <p>
-          <button type="button" data-ip-client-ping>Ping client</button>
-          <button type="button" data-ip-client-route>Route diagnostics</button>
-          <button type="button" data-ip-client-traceroute>Traceroute</button>
-        </p>
-
-        <h4>Scheduled Client Checks</h4>
-        <p>Open the Network workspace to create or run scheduled reachability and baseline checks.</p>
-        <button type="button">Save evidence note</button>
-
-        <h4>Client Timeline</h4>
-        <ol>
-          {% for event in client_timeline %}
-            <li>{{ event.time_label }} — {{ event.type }}: {{ event.message }}</li>
-          {% else %}
-            <li>No timeline events recorded.</li>
-          {% endfor %}
-        </ol>
+        <h4 class="mt-3">Device Port Scan</h4><p><a href="/port-scan?host={{ ip|urlencode }}">Common ports · All ports · Open full port scan</a></p><p>Inspect web services · Fingerprint services</p>
+        <h4 class="mt-3">Client Profile Metadata</h4><p>Expected open ports: {{ (inventory_device.expected_open_ports or [])|join(', ') or 'Not configured' }}</p><p><a href="/clients/{{ ip|urlencode }}/export.json">Export JSON</a> · <a href="/clients/{{ ip|urlencode }}/export.md">Export Markdown</a></p>
+        <h4>Client Relationship Map</h4><p>Open the Network workspace to review interfaces, discovery sources, paths, and linked services.</p><p><button type="button" data-ip-client-ping>Ping client</button><button type="button" data-ip-client-route>Route diagnostics</button><button type="button" data-ip-client-traceroute>Traceroute</button></p>
+        <h4>Scheduled Client Checks</h4><p>Open the Network workspace to create or run scheduled reachability and baseline checks.</p><button type="button">Save evidence note</button>
+        <h4>Client Timeline</h4><ol>{% for event in client_timeline %}<li>{{ event.time_label }} — {{ event.type }}: {{ event.message }}</li>{% else %}<li>No timeline events recorded.</li>{% endfor %}</ol>
       </div>
     </section>
   </noscript>

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -7,9 +7,10 @@
   <div class="page-hero-copy">
     <p class="page-kicker">Network visibility</p>
     <h1 class="page-title">Device Inventory</h1>
-    <p class="page-subtitle">Review discovered IPs, MAC addresses, manufacturers, interfaces, sources, saved ports, and first/last seen timestamps in one place.</p>
+    <p class="page-subtitle">Review discovered IPs, VLAN assignments, MAC addresses, manufacturers, interfaces, sources, saved ports, and first/last seen timestamps in one place.</p>
   </div>
   <div class="theme-actions">
+    <a class="btn btn-outline-info" href="/vlans">VLAN investigations</a>
     <a class="btn btn-outline-primary" href="/inventory/export.json">Export devices + ports</a>
   </div>
 </section>
@@ -36,24 +37,9 @@
 </section>
 
 <section class="theme-grid inventory-summary-grid" aria-label="Inventory summary">
-  <article class="theme-card inventory-stat-card">
-    <div class="card-body">
-      <p class="page-kicker">Total devices</p>
-      <strong>{{ insights.total_devices }}</strong>
-    </div>
-  </article>
-  <article class="theme-card inventory-stat-card">
-    <div class="card-body">
-      <p class="page-kicker">Known vendors</p>
-      <strong>{{ insights.known_manufacturers }}</strong>
-    </div>
-  </article>
-  <article class="theme-card inventory-stat-card {% if insights.unknown_manufacturers %}inventory-stat-warning{% endif %}">
-    <div class="card-body">
-      <p class="page-kicker">Unknown OUI</p>
-      <strong>{{ insights.unknown_manufacturers }}</strong>
-    </div>
-  </article>
+  <article class="theme-card inventory-stat-card"><div class="card-body"><p class="page-kicker">Total devices</p><strong>{{ insights.total_devices }}</strong></div></article>
+  <article class="theme-card inventory-stat-card"><div class="card-body"><p class="page-kicker">Known vendors</p><strong>{{ insights.known_manufacturers }}</strong></div></article>
+  <article class="theme-card inventory-stat-card {% if insights.unknown_manufacturers %}inventory-stat-warning{% endif %}"><div class="card-body"><p class="page-kicker">Unknown OUI</p><strong>{{ insights.unknown_manufacturers }}</strong></div></article>
 </section>
 
 <section class="theme-card card">
@@ -61,103 +47,43 @@
     <h2 class="theme-section-title">Manufacturer/OUI insights</h2>
     {% if insights.top_vendors %}
       <div class="inventory-vendor-list">
-        {% for vendor in insights.top_vendors %}
-          <div class="inventory-vendor-row {% if vendor.manufacturer == 'Unknown' %}inventory-unknown-vendor{% endif %}">
-            <div>
-              <strong>{{ vendor.manufacturer }}</strong>
-              {% if vendor.manufacturer == 'Unknown' %}
-                <span class="badge badge-warning">Needs review</span>
-              {% endif %}
-            </div>
-            <span>{{ vendor.count }} device{% if vendor.count != 1 %}s{% endif %}</span>
-          </div>
-        {% endfor %}
+        {% for vendor in insights.top_vendors %}<div class="inventory-vendor-row {% if vendor.manufacturer == 'Unknown' %}inventory-unknown-vendor{% endif %}"><div><strong>{{ vendor.manufacturer }}</strong>{% if vendor.manufacturer == 'Unknown' %}<span class="badge badge-warning">Needs review</span>{% endif %}</div><span>{{ vendor.count }} device{% if vendor.count != 1 %}s{% endif %}</span></div>{% endfor %}
       </div>
-    {% else %}
-      <p class="text-muted">Run an active, passive, Bluetooth, or wireless scan to populate manufacturer insights.</p>
-    {% endif %}
+    {% else %}<p class="text-muted">Run an active, passive, Bluetooth, or wireless scan to populate manufacturer insights.</p>{% endif %}
   </div>
 </section>
 
 <section class="theme-card card">
   <div class="card-body">
-    <div class="inventory-table-header">
-      <h2 class="theme-section-title">Discovered devices</h2>
-      <a class="btn btn-outline-primary btn-sm" href="/network-scan">Run scan</a>
-    </div>
+    <div class="inventory-table-header"><h2 class="theme-section-title">Discovered devices</h2><a class="btn btn-outline-primary btn-sm" href="/network-scan">Run scan</a></div>
     {% if devices %}
       <div class="table-responsive">
         <table class="table theme-table inventory-table">
-          <thead>
-            <tr>
-              <th>Device</th>
-              <th>IP</th>
-              <th>MAC / BSSID</th>
-              <th>Manufacturer</th>
-              <th>Sources</th>
-              <th>Interfaces</th>
-              <th>First seen</th>
-              <th>Last seen</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
+          <thead><tr><th>Device</th><th>Network / VLAN</th><th>IP</th><th>MAC / BSSID</th><th>Manufacturer</th><th>Sources</th><th>Interfaces</th><th>First seen</th><th>Last seen</th><th>Actions</th></tr></thead>
           <tbody>
-            {% for device in devices %}
+            {% for original_device in devices %}
+              {% set device = vlan_device(original_device) %}
               <tr class="{% if device.is_unknown_manufacturer %}inventory-unknown-row{% endif %}">
-                <td>{{ device.display_name }}</td>
+                <td><div class="vlan-device-name"><strong>{{ device.display_name }}</strong>{% if device.vlan_id %}<small class="text-muted">{{ device.vlan_assignment_source|replace('-', ' ') }}</small>{% endif %}</div></td>
+                <td>{% include '_vlan_badge.html' %}{% if not device.vlan_id %}<a class="small text-muted" href="/vlans">Assign by subnet</a>{% endif %}</td>
                 <td>{{ device.ip or '—' }}</td>
-                <td>
-                  {% if device.mac %}
-                    <a href="/clients/{{ device.mac|urlencode }}">{{ device.mac }}</a>
-                  {% else %}
-                    {{ device.bssid or '—' }}
-                  {% endif %}
-                </td>
+                <td>{% if device.mac %}<a href="/clients/{{ device.mac|urlencode }}">{{ device.mac }}</a>{% else %}{{ device.bssid or '—' }}{% endif %}</td>
                 <td>{{ device.manufacturer }}</td>
                 <td>{{ device.sources|join(', ') }}</td>
                 <td>{{ device.interfaces|join(', ') if device.interfaces else '—' }}</td>
                 <td>{{ device.first_seen_label }}</td>
                 <td>{{ device.last_seen_label }}</td>
                 <td>
-                  {% if device.open_port_details %}
-                    <div class="small text-muted mb-2">
-                      Open:
-                      {% for port in device.open_port_details %}
-                        {% if loop.index <= 4 %}
-                          <span class="badge badge-info">{{ port.port }} {{ port.service }}</span>
-                        {% endif %}
-                      {% endfor %}
-                    </div>
-                  {% endif %}
-                  {% if device.client_health %}
-                    <div class="small text-muted mb-2">
-                      <span class="badge badge-{{ device.client_health.badge }}">{{ device.client_health.level }} {{ device.client_health.score }}/100</span>
-                      {% if device.client_baseline and device.client_baseline.status == 'Drift detected' %}
-                        <span class="badge badge-danger">Drift</span>
-                      {% endif %}
-                      {% if device.is_watched_client %}
-                        <span class="badge badge-warning">Watched</span>
-                      {% endif %}
-                      {% for tag in device.client_tags or [] %}
-                        {% if loop.index <= 3 %}<span class="badge badge-light border">{{ tag }}</span>{% endif %}
-                      {% endfor %}
-                    </div>
-                  {% endif %}
-                  {% if device.ip and not device.is_control_traffic %}
-                    <a class="btn btn-outline-primary btn-sm" href="/clients/{{ device.ip|urlencode }}">Device scan</a>
-                    <a class="btn btn-outline-secondary btn-sm" href="/port-scan?host={{ device.ip|urlencode }}">Tools scan</a>
-                  {% else %}
-                    —
-                  {% endif %}
+                  {% if device.open_port_details %}<div class="small text-muted mb-2">Open: {% for port in device.open_port_details %}{% if loop.index <= 4 %}<span class="badge badge-info">{{ port.port }} {{ port.service }}</span>{% endif %}{% endfor %}</div>{% endif %}
+                  {% if device.client_health %}<div class="small text-muted mb-2"><span class="badge badge-{{ device.client_health.badge }}">{{ device.client_health.level }} {{ device.client_health.score }}/100</span>{% if device.client_baseline and device.client_baseline.status == 'Drift detected' %}<span class="badge badge-danger">Drift</span>{% endif %}{% if device.is_watched_client %}<span class="badge badge-warning">Watched</span>{% endif %}{% for tag in device.client_tags or [] %}{% if loop.index <= 3 %}<span class="badge badge-light border">{{ tag }}</span>{% endif %}{% endfor %}</div>{% endif %}
+                  {% if device.ip and not device.is_control_traffic %}<a class="btn btn-outline-primary btn-sm" href="/clients/{{ device.ip|urlencode }}">Device scan</a><a class="btn btn-outline-secondary btn-sm" href="/port-scan?host={{ device.ip|urlencode }}">Tools scan</a>{% else %}—{% endif %}
                 </td>
               </tr>
             {% endfor %}
           </tbody>
         </table>
       </div>
-    {% else %}
-      <p class="text-muted">No devices discovered yet. Run a scan to build the inventory.</p>
-    {% endif %}
+    {% else %}<p class="text-muted">No devices discovered yet. Run a scan to build the inventory.</p>{% endif %}
   </div>
 </section>
 {% endblock %}

--- a/templates/vlan_detail.html
+++ b/templates/vlan_detail.html
@@ -1,0 +1,121 @@
+{% extends 'base.html' %}
+
+{% block title %}{{ vlan.label if vlan else 'VLAN not found' }}{% endblock %}
+
+{% block content %}
+{% if not vlan %}
+<section class="page-hero"><div class="page-hero-copy"><p class="page-kicker">VLAN Investigations</p><h1 class="page-title">VLAN not found</h1><p class="page-subtitle">The requested VLAN definition no longer exists.</p></div><div class="theme-actions"><a class="btn btn-primary" href="/vlans">Return to VLANs</a></div></section>
+{% else %}
+<section class="page-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">VLAN investigation</p>
+    <h1 class="page-title">{{ vlan.name }}</h1>
+    <p class="page-subtitle">{{ vlan.description or 'Routed network definition, device assignments, visibility evidence, and segmentation expectations.' }}</p>
+    <div class="mt-3">{% include '_vlan_badge.html' %}</div>
+  </div>
+  <div class="theme-actions"><a class="btn btn-outline-secondary" href="/vlans">All VLANs</a><a class="btn btn-outline-primary" href="/inventory">Inventory</a></div>
+</section>
+
+<div class="vlan-output" data-vlan-output aria-live="polite"></div>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Network overview</h2>
+    <div class="vlan-status-grid">
+      <div class="vlan-status-tile"><strong>{{ devices|length }}</strong><span>Assigned devices</span></div>
+      <div class="vlan-status-tile"><strong>{{ vlan.usable_hosts }}</strong><span>Usable IPv4 addresses</span></div>
+      <div class="vlan-status-tile"><strong>{{ investigations|length }}</strong><span>Saved investigations</span></div>
+      <div class="vlan-status-tile"><strong>{{ probes|length }}</strong><span>Local probes</span></div>
+    </div>
+    <dl class="vlan-definition-list mt-3">
+      <div><dt>802.1Q tag</dt><dd>{{ vlan.tag if vlan.tag is not none else 'Not recorded / untagged route' }}</dd></div>
+      <div><dt>Subnet</dt><dd><code>{{ vlan.subnet }}</code></dd></div>
+      <div><dt>Gateway</dt><dd>{{ vlan.gateway or 'Not recorded' }}</dd></div>
+      <div><dt>Router / interface</dt><dd>{{ vlan.router_name or 'Unknown router' }}{% if vlan.interface_name %} · {{ vlan.interface_name }}{% endif %}</dd></div>
+      <div><dt>Visibility method</dt><dd>{{ vlan.probe_mode|replace('-', ' ')|title }} · source {{ vlan.source_type }}</dd></div>
+      <div><dt>Optional source address</dt><dd>{{ vlan.source_ip or 'Main host routing table' }}</dd></div>
+    </dl>
+    <div class="vlan-visibility-banner mt-3">
+      <i class="fa-solid fa-eye" aria-hidden="true"></i>
+      <div><strong>{% if vlan.probe_mode == 'remote-agent' %}Local layer-2 visibility expected{% else %}Routed visibility{% endif %}</strong><span>{% if vlan.probe_mode == 'remote-agent' %}A probe inside this VLAN can report ARP/neighbour and local discovery evidence. Signed submissions are treated as local observations for this VLAN.{% else %}The main application can test routed IP reachability and selected services. ARP, DHCP broadcasts, mDNS, SSDP, and other layer-2 or link-local discovery normally require a probe or infrastructure integration inside the VLAN.{% endif %}</span></div>
+    </div>
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <div class="inventory-table-header"><div><h2 class="theme-section-title">Assigned devices</h2><p class="text-muted mb-0">Every row keeps the VLAN label visible so subnet membership is not lost among device details.</p></div><a class="btn btn-outline-primary btn-sm" href="/inventory">Full inventory</a></div>
+    {% if devices %}
+      <div class="table-responsive"><table class="table theme-table"><thead><tr><th>Device</th><th>VLAN</th><th>IP</th><th>MAC</th><th>Source</th><th>Services</th></tr></thead><tbody>
+      {% for device in devices %}<tr><td><div class="vlan-device-name"><a href="/clients/{{ (device.ip or device.mac)|urlencode }}">{{ device.display_name or device.name or device.ip or device.mac }}</a></div></td><td>{% include '_vlan_badge.html' %}</td><td>{{ device.ip or '—' }}</td><td>{{ device.mac or '—' }}</td><td>{{ device.vlan_assignment_source or 'subnet-match' }} · {{ device.vlan_confidence or 'high' }}</td><td>{% for port in device.open_port_details or [] %}{% if loop.index <= 5 %}<span class="badge badge-info">{{ port.port }} {{ port.service }}</span>{% endif %}{% else %}<span class="text-muted">None saved</span>{% endfor %}</td></tr>{% endfor %}
+      </tbody></table></div>
+    {% else %}
+      <div class="device-empty-state"><i class="fa-solid fa-computer" aria-hidden="true"></i><h3>No assigned devices</h3><p>Run the authorised routed investigation, import infrastructure records, or deploy a remote probe to populate this VLAN.</p></div>
+    {% endif %}
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Routed CIDR investigation</h2>
+    <p class="text-muted">The scan pings every usable address within the saved subnet using a bounded worker pool, optionally checks up to 16 selected TCP ports on reachable hosts, records route context, and merges the results into the device inventory.</p>
+    {% if vlan.usable_hosts > 1024 %}<div class="alert alert-warning">This subnet contains {{ vlan.usable_hosts }} usable addresses and exceeds the 1,024-address investigation limit. Define a smaller non-overlapping network before scanning.</div>{% endif %}
+    <form class="theme-form" action="/vlans/{{ vlan.id }}/investigate" method="post" data-vlan-ajax data-vlan-refresh>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+      <label for="vlan-ports">Optional TCP ports</label><input id="vlan-ports" class="form-control" name="ports" value="22,53,80,443" placeholder="22, 80, 443">
+      <div class="form-check mt-3"><input id="vlan-authorised" class="form-check-input" type="checkbox" name="authorised" value="on" required><label class="form-check-label" for="vlan-authorised">I am authorised to investigate every address in {{ vlan.subnet }}</label></div>
+      <div class="theme-actions"><button class="btn btn-primary" type="submit" {% if vlan.usable_hosts > 1024 %}disabled{% endif %}>Run routed investigation</button></div>
+    </form>
+    {% if investigations %}
+      <h3 class="theme-subsection-title mt-4">Recent investigations</h3>
+      {% for investigation in investigations %}
+        <details class="theme-card card mb-2" {% if loop.first %}open{% endif %}><summary class="card-header"><strong>{{ investigation.mode|replace('-', ' ')|title }}</strong> · {{ investigation.summary.reachable_hosts or 0 }}/{{ investigation.summary.total_hosts or 0 }} reachable · {{ investigation.status }}</summary><div class="card-body"><dl class="vlan-definition-list"><div><dt>Visibility</dt><dd>{{ investigation.summary.visibility or investigation.mode }}</dd></div><div><dt>Duration</dt><dd>{{ investigation.summary.duration_seconds or 'Not reported' }} seconds</dd></div><div><dt>Recorded devices</dt><dd>{{ investigation.summary.recorded_devices or 0 }}</dd></div><div><dt>Selected ports</dt><dd>{{ (investigation.summary.selected_ports or [])|join(', ') or 'None' }}</dd></div></dl><div class="vlan-investigation-hosts mt-3">{% for host in investigation.hosts if host.reachable %}<div class="vlan-investigation-host-row"><strong>{{ host.host }}</strong><span>{{ host.hostname or 'No reverse DNS name' }}</span><span class="badge badge-success">Reachable</span></div>{% else %}<p class="text-muted">No reachable hosts were reported.</p>{% endfor %}</div></div></details>
+      {% endfor %}
+    {% endif %}
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Segmentation reachability matrix</h2>
+    <p class="text-muted">Rules compare intended allow/block behaviour with observed results. Main-host checks are labelled as a routed perspective; a true source-VLAN result requires a configured source address or remote probe inside that VLAN.</p>
+    <div class="table-responsive"><table class="table theme-table"><thead><tr><th>Source</th><th>Destination</th><th>Check</th><th>Expected</th><th>Observed</th><th>Perspective</th><th>Action</th></tr></thead><tbody>
+    {% for rule in matrix %}<tr><td>{{ rule.source_vlan.label if rule.source_vlan else rule.source_vlan_id }}</td><td>{{ rule.destination_vlan.label if rule.destination_vlan else rule.destination }}</td><td>{{ rule.protocol|upper }}{% if rule.port %}/{{ rule.port }}{% endif %} · {{ rule.destination }}</td><td>{{ rule.expectation|title }}</td><td>{% if rule.latest_result %}<span class="vlan-matrix-status {{ 'vlan-matrix-status-fail' if rule.latest_result.mismatch else 'vlan-matrix-status-pass' }}">{{ rule.latest_result.observed|title }}{% if rule.latest_result.mismatch %} · mismatch{% else %} · matches{% endif %}</span>{% else %}<span class="vlan-matrix-status vlan-matrix-status-unknown">Not tested</span>{% endif %}</td><td>{{ rule.latest_result.source if rule.latest_result else (('Remote probe ' ~ rule.source_probe_id) if rule.source_probe_id else 'Main host') }}</td><td>{% if not rule.source_probe_id %}<form action="/vlans/segmentation-rules/{{ rule.id }}/test" method="post" data-vlan-ajax data-vlan-refresh><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><input type="hidden" name="authorised" value="on"><button class="btn btn-sm btn-outline-primary" type="submit">Test</button></form>{% else %}<span class="text-muted">Await probe</span>{% endif %}</td></tr>{% else %}<tr><td colspan="7" class="text-muted">No segmentation expectations have been recorded.</td></tr>{% endfor %}
+    </tbody></table></div>
+    <h3 class="theme-subsection-title mt-4">Add an expectation</h3>
+    <form class="theme-form" action="/vlans/segmentation-rules" method="post" data-vlan-ajax data-vlan-refresh>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}"><input type="hidden" name="source_vlan_id" value="{{ vlan.id }}">
+      <div class="vlan-form-grid"><div><label for="rule-destination-vlan">Destination VLAN</label><select id="rule-destination-vlan" class="form-control" name="destination_vlan_id"><option value="">Specific host only</option>{% for item in all_vlans if item.id != vlan.id %}<option value="{{ item.id }}">{{ item.label }}</option>{% endfor %}</select></div><div><label for="rule-destination">Destination host</label><input id="rule-destination" class="form-control" name="destination" placeholder="192.168.40.10" required></div><div><label for="rule-protocol">Protocol</label><select id="rule-protocol" class="form-control" name="protocol"><option value="tcp">TCP</option><option value="icmp">ICMP</option><option value="udp">UDP (remote/protocol-specific preferred)</option></select></div><div><label for="rule-port">Port</label><input id="rule-port" class="form-control" name="port" type="number" min="1" max="65535" value="443"></div><div><label for="rule-expectation">Expected policy</label><select id="rule-expectation" class="form-control" name="expectation"><option value="allow">Allow</option><option value="block">Block</option></select></div><div><label for="rule-probe">Remote source probe</label><select id="rule-probe" class="form-control" name="source_probe_id"><option value="">Main host routed perspective</option>{% for probe in probes %}<option value="{{ probe.id }}">{{ probe.name }}</option>{% endfor %}</select></div><div class="vlan-form-span"><label for="rule-description">Policy note</label><input id="rule-description" class="form-control" name="description" placeholder="IoT may reach Home Assistant HTTPS only"></div></div>
+      <div class="theme-actions"><button class="btn btn-primary" type="submit">Save segmentation expectation</button></div>
+    </form>
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Infrastructure and pfSense</h2>
+    <p class="text-muted">Infrastructure records can provide VLAN definitions, DHCP leases, ARP entries, interface names, and gateway context without probing every endpoint.</p>
+    {% if integrations %}<div class="table-responsive"><table class="table theme-table"><thead><tr><th>Integration</th><th>Endpoint</th><th>Secret reference</th><th>Status</th><th>Action</th></tr></thead><tbody>{% for integration in integrations %}<tr><td>{{ integration.name }}</td><td>{{ integration.base_url or 'JSON import only' }}</td><td><code>{{ integration.token_env or 'None' }}</code></td><td>{{ integration.last_status or 'Never synchronised' }}</td><td><form action="/vlans/pfsense/integrations/{{ integration.id }}/sync" method="post" data-vlan-ajax data-vlan-refresh><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><button class="btn btn-sm btn-outline-success">Synchronise</button></form></td></tr>{% endfor %}</tbody></table></div>{% else %}<p>No saved pfSense integration. Configure one from the <a href="/vlans">VLAN library</a>, or import a read-only JSON export there.</p>{% endif %}
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Remote VLAN probes</h2>
+    <p class="text-muted">A probe inside this VLAN can observe local neighbours and submit structured results over a signed HMAC channel. Only an environment-variable reference is stored; the shared key remains outside the application database.</p>
+    {% if probes %}<div class="table-responsive"><table class="table theme-table"><thead><tr><th>Probe</th><th>Status</th><th>Last seen</th><th>Secret environment reference</th><th>Configuration</th></tr></thead><tbody>{% for probe in probes %}<tr><td>{{ probe.name }}</td><td>{{ probe.status }}</td><td>{{ probe.last_seen or 'Never' }}</td><td><code>{{ probe.secret_env }}</code> · {{ 'configured' if probe.secret_configured else 'not set' }}</td><td><a class="btn btn-sm btn-outline-secondary" href="/vlans/probes/{{ probe.id }}/config.json">Download config</a></td></tr>{% endfor %}</tbody></table></div>{% endif %}
+    <form class="theme-form mt-3" action="/vlans/probes" method="post" data-vlan-ajax data-vlan-refresh><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><input type="hidden" name="vlan_id" value="{{ vlan.id }}"><div class="vlan-form-grid"><div><label for="probe-name">Probe name</label><input id="probe-name" class="form-control" name="name" placeholder="IoT Raspberry Pi" required></div><div><label for="probe-secret-env">Secret environment variable</label><input id="probe-secret-env" class="form-control vlan-secret-reference" name="secret_env" placeholder="MOBILE_ROUTER_VLAN50_PROBE_KEY" required></div></div><div class="theme-actions"><button class="btn btn-primary" type="submit">Create remote probe</button></div></form>
+  </div>
+</section>
+
+<section class="theme-card card">
+  <div class="card-body">
+    <h2 class="theme-section-title">Edit network definition</h2>
+    <form class="theme-form" action="/vlans/{{ vlan.id }}/update" method="post" data-vlan-ajax data-vlan-refresh><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><div class="vlan-form-grid"><div><label>Name<input class="form-control" name="name" value="{{ vlan.name }}" required></label></div><div><label>802.1Q tag<input class="form-control" name="tag" type="number" min="1" max="4094" value="{{ vlan.tag if vlan.tag is not none else '' }}"></label></div><div><label>Subnet<input class="form-control" name="subnet" value="{{ vlan.subnet }}" required></label></div><div><label>Gateway<input class="form-control" name="gateway" value="{{ vlan.gateway or '' }}"></label></div><div><label>Router interface<input class="form-control" name="interface_name" value="{{ vlan.interface_name or '' }}"></label></div><div><label>Router<input class="form-control" name="router_name" value="{{ vlan.router_name or '' }}"></label></div><div><label>Visibility method<select class="form-control" name="probe_mode">{% for mode in ['routed', 'local', 'infrastructure', 'remote-agent'] %}<option value="{{ mode }}" {% if vlan.probe_mode == mode %}selected{% endif %}>{{ mode|replace('-', ' ')|title }}</option>{% endfor %}</select></label></div><div><label>Optional source IP<input class="form-control" name="source_ip" value="{{ vlan.source_ip or '' }}"></label></div><div class="vlan-form-span"><label>Notes<textarea class="form-control" name="description" rows="3">{{ vlan.description or '' }}</textarea></label></div></div><div class="theme-actions"><button class="btn btn-primary" type="submit">Save changes</button></div></form>
+    <form class="mt-3" action="/vlans/{{ vlan.id }}/delete" method="post" data-vlan-ajax data-vlan-redirect="/vlans" data-confirm="Delete this VLAN definition? Device records will remain, but the saved VLAN link and investigations will be removed."><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><button class="btn btn-outline-danger" type="submit">Delete VLAN definition</button></form>
+  </div>
+</section>
+
+<script src="/static/js/vlans.js"></script>
+{% endif %}
+{% endblock %}

--- a/templates/vlans.html
+++ b/templates/vlans.html
@@ -1,0 +1,113 @@
+{% extends 'base.html' %}
+
+{% block title %}VLAN Investigations{% endblock %}
+
+{% block content %}
+<section class="page-hero">
+  <div class="page-hero-copy">
+    <p class="page-kicker">Segmentation visibility</p>
+    <h1 class="page-title">VLAN Investigations</h1>
+    <p class="page-subtitle">Define routed networks, make known 802.1Q tags visible throughout the inventory, investigate permitted subnets, and compare observed access with the intended segmentation policy.</p>
+  </div>
+  <div class="theme-actions">
+    <a class="btn btn-outline-secondary" href="/vlans/export.json">Export VLAN records</a>
+    <a class="btn btn-outline-primary" href="/inventory">Device inventory</a>
+  </div>
+</section>
+
+<div class="vlan-output" data-vlan-output aria-live="polite"></div>
+
+<section class="vlan-status-grid" aria-label="VLAN summary">
+  <article class="vlan-status-tile"><strong>{{ vlans|length }}</strong><span>Defined VLANs</span></article>
+  <article class="vlan-status-tile"><strong>{{ device_counts.values()|sum }}</strong><span>Assigned devices</span></article>
+  <article class="vlan-status-tile"><strong>{{ integrations|length }}</strong><span>Infrastructure integrations</span></article>
+  <article class="vlan-status-tile"><strong>{{ probes|length }}</strong><span>Remote probes</span></article>
+</section>
+
+<section class="theme-card card mt-4">
+  <div class="card-body">
+    <h2 class="theme-section-title">Defined networks</h2>
+    <p class="text-muted">A saved subnet automatically labels matching inventory devices. An explicit device assignment takes precedence over subnet inference.</p>
+    {% if vlans %}
+      <div class="vlan-card-grid">
+        {% for vlan in vlans %}
+          <article class="theme-card card vlan-card">
+            <div class="card-body">
+              <div class="vlan-card-title">
+                <h3>{{ vlan.name }}</h3>
+                {% include '_vlan_badge.html' %}
+              </div>
+              <dl class="vlan-definition-list">
+                <div><dt>Subnet</dt><dd><code>{{ vlan.subnet }}</code></dd></div>
+                <div><dt>Gateway</dt><dd>{{ vlan.gateway or 'Not recorded' }}</dd></div>
+                <div><dt>Interface</dt><dd>{{ vlan.interface_name or 'Not recorded' }}</dd></div>
+                <div><dt>Visibility</dt><dd>{{ vlan.probe_mode|replace('-', ' ')|title }}</dd></div>
+                <div><dt>Devices</dt><dd>{{ device_counts.get(vlan.id, 0) }}</dd></div>
+              </dl>
+              <div class="theme-actions mt-auto">
+                <a class="btn btn-primary btn-sm" href="/vlans/{{ vlan.id|urlencode }}">Open investigation</a>
+              </div>
+            </div>
+          </article>
+        {% endfor %}
+      </div>
+    {% else %}
+      <div class="device-empty-state">
+        <i class="fa-solid fa-layer-group" aria-hidden="true"></i>
+        <h3>No VLAN definitions yet</h3>
+        <p>Add a tagged or untagged routed network below. Devices already in the inventory will be assigned when their IP falls within the saved subnet.</p>
+      </div>
+    {% endif %}
+  </div>
+</section>
+
+<section class="theme-card card mt-4">
+  <div class="card-body">
+    <h2 class="theme-section-title">Add a VLAN or routed network</h2>
+    <form class="theme-form" action="/vlans" method="post" data-vlan-ajax data-vlan-refresh>
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+      <div class="vlan-form-grid">
+        <div><label for="vlan-name">Network name</label><input id="vlan-name" class="form-control" name="name" placeholder="Users" required></div>
+        <div><label for="vlan-tag">802.1Q tag</label><input id="vlan-tag" class="form-control" name="tag" type="number" min="1" max="4094" placeholder="20"></div>
+        <div><label for="vlan-subnet">IPv4 subnet</label><input id="vlan-subnet" class="form-control" name="subnet" placeholder="192.168.20.0/24" required></div>
+        <div><label for="vlan-gateway">Gateway</label><input id="vlan-gateway" class="form-control" name="gateway" placeholder="192.168.20.1"></div>
+        <div><label for="vlan-interface">Router interface</label><input id="vlan-interface" class="form-control" name="interface_name" placeholder="igb1.20"></div>
+        <div><label for="vlan-router">Router</label><input id="vlan-router" class="form-control" name="router_name" placeholder="pfSense"></div>
+        <div><label for="vlan-mode">Visibility method</label><select id="vlan-mode" class="form-control" name="probe_mode"><option value="routed">Routed from this host</option><option value="local">Locally attached</option><option value="infrastructure">Infrastructure records</option><option value="remote-agent">Remote probe</option></select></div>
+        <div><label for="vlan-source-ip">Optional local source IP</label><input id="vlan-source-ip" class="form-control" name="source_ip" placeholder="192.168.20.5"></div>
+        <div class="vlan-form-span"><label for="vlan-description">Notes</label><textarea id="vlan-description" class="form-control" name="description" rows="2" placeholder="Expected purpose, firewall boundary, DHCP source, or ownership notes."></textarea></div>
+      </div>
+      <div class="theme-actions"><button class="btn btn-primary" type="submit">Save network definition</button></div>
+    </form>
+  </div>
+</section>
+
+<section class="theme-card card mt-4">
+  <div class="card-body">
+    <h2 class="theme-section-title">pfSense read-only import</h2>
+    <p class="text-muted">Import a JSON export immediately, or configure explicit HTTPS JSON endpoints. Authentication secrets are read from an environment variable and are never saved in the application database.</p>
+    <div class="device-overview-columns">
+      <form class="theme-form" action="/vlans/pfsense/import" method="post" enctype="multipart/form-data" data-vlan-ajax data-vlan-refresh>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <label for="pfsense-file">pfSense VLAN, interface, lease, or ARP JSON</label>
+        <input id="pfsense-file" class="form-control-file" type="file" name="pfsense_file" accept="application/json,.json" required>
+        <div class="theme-actions"><button class="btn btn-outline-primary" type="submit">Import read-only JSON</button></div>
+      </form>
+      <form class="theme-form" action="/vlans/pfsense/integrations" method="post" data-vlan-ajax data-vlan-refresh>
+        <input type="hidden" name="csrf_token" value="{{ csrf_token }}">
+        <label for="pfsense-name">Integration name</label><input id="pfsense-name" class="form-control" name="name" value="pfSense">
+        <label class="mt-2" for="pfsense-url">HTTPS base URL</label><input id="pfsense-url" class="form-control" name="base_url" placeholder="https://pfsense.example.internal" required>
+        <label class="mt-2" for="pfsense-token-env">Token environment variable</label><input id="pfsense-token-env" class="form-control vlan-secret-reference" name="token_env" placeholder="MOBILE_ROUTER_PFSENSE_TOKEN">
+        <div class="form-check mt-2"><input id="pfsense-verify" class="form-check-input" type="checkbox" name="verify_tls" value="on" checked><label class="form-check-label" for="pfsense-verify">Verify the appliance TLS certificate</label></div>
+        <details class="mt-2"><summary>Endpoint paths</summary><label class="mt-2">VLANs path<input class="form-control" name="vlans_path" value="/api/v1/vlans"></label><label>DHCP leases path<input class="form-control" name="leases_path" value="/api/v1/services/dhcpd/leases"></label><label>ARP table path<input class="form-control" name="arp_path" value="/api/v1/diagnostics/arp_table"></label></details>
+        <div class="theme-actions"><button class="btn btn-outline-primary" type="submit">Save integration</button></div>
+      </form>
+    </div>
+    {% if integrations %}
+      <div class="table-responsive mt-3"><table class="table theme-table"><thead><tr><th>Name</th><th>URL</th><th>Secret</th><th>Last status</th><th>Action</th></tr></thead><tbody>{% for integration in integrations %}<tr><td>{{ integration.name }}</td><td>{{ integration.base_url or 'Import only' }}</td><td><code>{{ integration.token_env or 'None' }}</code> · {{ 'configured' if integration.token_configured else 'not set' }}</td><td>{{ integration.last_status or 'Never synchronised' }}</td><td><form action="/vlans/pfsense/integrations/{{ integration.id }}/sync" method="post" data-vlan-ajax data-vlan-refresh><input type="hidden" name="csrf_token" value="{{ csrf_token }}"><button class="btn btn-sm btn-outline-success" type="submit">Synchronise</button></form></td></tr>{% endfor %}</tbody></table></div>
+    {% endif %}
+  </div>
+</section>
+
+<script src="/static/js/vlans.js"></script>
+{% endblock %}

--- a/tests/test_vlan_investigations.py
+++ b/tests/test_vlan_investigations.py
@@ -1,0 +1,399 @@
+import io
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import time
+import unittest
+from unittest.mock import patch
+
+import app as app_module
+from app import app
+from services import vlan_investigations as vlan_service
+
+
+class VlanInvestigationServiceTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="mobile-router-vlan-")
+        self.database = Path(self.temp_dir) / "vlans.sqlite3"
+
+    def tearDown(self):
+        shutil.rmtree(self.temp_dir, ignore_errors=False)
+
+    def save_vlan(self, **overrides):
+        payload = {
+            "name": "Users",
+            "tag": "20",
+            "subnet": "192.168.20.0/24",
+            "gateway": "192.168.20.1",
+            "interface_name": "igb1.20",
+            "router_name": "pfSense",
+            "probe_mode": "routed",
+            **overrides,
+        }
+        return vlan_service.save_vlan(self.database, payload)
+
+    def test_vlan_validation_and_device_decoration(self):
+        vlan = self.save_vlan()
+
+        self.assertEqual(vlan["label"], "VLAN 20 · Users")
+        self.assertEqual(vlan["usable_hosts"], 254)
+        decorated = vlan_service.decorate_device(
+            self.database,
+            {"ip": "192.168.20.42", "name": "Laptop"},
+        )
+        self.assertEqual(decorated["vlan_id"], vlan["id"])
+        self.assertEqual(decorated["vlan_tag"], 20)
+        self.assertEqual(decorated["vlan_assignment_source"], "subnet-match")
+        self.assertEqual(decorated["vlan_confidence"], "high")
+
+    def test_vlan_rejects_invalid_tags_gateways_and_overlaps(self):
+        self.save_vlan()
+        with self.assertRaisesRegex(ValueError, "1 to 4094"):
+            self.save_vlan(name="Invalid tag", tag="4095", subnet="192.168.30.0/24", gateway="192.168.30.1")
+        with self.assertRaisesRegex(ValueError, "inside the VLAN subnet"):
+            self.save_vlan(name="Wrong gateway", tag="30", subnet="192.168.30.0/24", gateway="192.168.40.1")
+        with self.assertRaisesRegex(ValueError, "overlaps existing VLAN"):
+            self.save_vlan(name="Overlap", tag="21", subnet="192.168.20.128/25", gateway="192.168.20.129")
+
+    def test_bounded_investigation_limits_hosts_and_ports(self):
+        network = vlan_service.bounded_investigation_network("10.10.0.0/22")
+        self.assertEqual(network.prefixlen, 22)
+        with self.assertRaisesRegex(ValueError, "safety limit"):
+            vlan_service.bounded_investigation_network("10.10.0.0/21")
+        self.assertEqual(vlan_service.parse_ports("22, 443, 22"), [22, 443])
+        with self.assertRaisesRegex(ValueError, "At most 16"):
+            vlan_service.parse_ports(",".join(str(port) for port in range(1, 18)))
+
+    def test_investigations_and_segmentation_results_are_persisted(self):
+        source = self.save_vlan()
+        destination = vlan_service.save_vlan(
+            self.database,
+            {
+                "name": "Servers",
+                "tag": "40",
+                "subnet": "192.168.40.0/24",
+                "gateway": "192.168.40.1",
+            },
+        )
+        investigation = vlan_service.save_investigation(
+            self.database,
+            source["id"],
+            "routed",
+            "complete",
+            {"scan_path_context": "via 192.168.20.1"},
+            [{"host": "192.168.20.10", "reachable": True}],
+            {"total_hosts": 254, "reachable_hosts": 1},
+        )
+        self.assertEqual(investigation["summary"]["reachable_hosts"], 1)
+        rule = vlan_service.save_segmentation_rule(
+            self.database,
+            {
+                "source_vlan_id": source["id"],
+                "destination_vlan_id": destination["id"],
+                "destination": "192.168.40.10",
+                "protocol": "tcp",
+                "port": "22",
+                "expectation": "block",
+            },
+        )
+        result = vlan_service.record_segmentation_result(
+            self.database,
+            rule["id"],
+            "allow",
+            "main-host routed perspective",
+            "Connection accepted",
+            4.2,
+        )
+        self.assertTrue(result["mismatch"])
+        matrix = vlan_service.segmentation_matrix(self.database)
+        self.assertEqual(matrix[0]["source_vlan"]["label"], "VLAN 20 · Users")
+        self.assertEqual(matrix[0]["destination_vlan"]["label"], "VLAN 40 · Servers")
+        self.assertTrue(matrix[0]["latest_result"]["mismatch"])
+
+    def test_pfsense_payload_normalises_vlan_and_device_records(self):
+        parsed = vlan_service.parse_pfsense_payload(
+            {
+                "hostname": "cornelius-pfsense",
+                "vlans": [
+                    {
+                        "tag": 50,
+                        "name": "IoT",
+                        "subnet": "10.50.0.0/24",
+                        "gateway": "10.50.0.1",
+                        "interface": "igb2.50",
+                    }
+                ],
+                "leases": [
+                    {
+                        "ip": "10.50.0.20",
+                        "mac": "aa:bb:cc:dd:ee:20",
+                        "hostname": "lamp",
+                        "vlan": 50,
+                    }
+                ],
+                "arp_table": [
+                    {
+                        "ip": "10.50.0.21",
+                        "mac": "aa:bb:cc:dd:ee:21",
+                    }
+                ],
+            }
+        )
+        self.assertEqual(parsed["vlans"][0]["tag"], 50)
+        self.assertEqual(parsed["vlans"][0]["subnet"], "10.50.0.0/24")
+        self.assertEqual(parsed["devices"][0]["hostname"], "lamp")
+        self.assertEqual(len(parsed["devices"]), 2)
+
+    def test_integration_stores_environment_reference_not_secret(self):
+        os.environ["MOBILE_ROUTER_TEST_PFSENSE_TOKEN"] = "secret-token"
+        self.addCleanup(os.environ.pop, "MOBILE_ROUTER_TEST_PFSENSE_TOKEN", None)
+        integration = vlan_service.save_integration(
+            self.database,
+            {
+                "name": "Lab pfSense",
+                "base_url": "https://192.168.10.1",
+                "token_env": "MOBILE_ROUTER_TEST_PFSENSE_TOKEN",
+                "verify_tls": "on",
+            },
+        )
+        self.assertEqual(integration["token_env"], "MOBILE_ROUTER_TEST_PFSENSE_TOKEN")
+        self.assertTrue(integration["token_configured"])
+        self.assertNotIn("secret-token", json.dumps(integration))
+        with self.assertRaisesRegex(ValueError, "HTTPS"):
+            vlan_service.save_integration(
+                self.database,
+                {"name": "Unsafe", "base_url": "http://192.168.10.1"},
+            )
+
+    def test_remote_probe_signature_timestamp_and_replay_protection(self):
+        vlan = self.save_vlan()
+        secret_env = "MOBILE_ROUTER_TEST_VLAN_PROBE_KEY"
+        os.environ[secret_env] = "test-probe-secret"
+        self.addCleanup(os.environ.pop, secret_env, None)
+        probe = vlan_service.save_remote_probe(
+            self.database,
+            {"name": "Users probe", "vlan_id": vlan["id"], "secret_env": secret_env},
+        )
+        body = json.dumps({"devices": [{"ip": "192.168.20.44"}]}).encode("utf-8")
+        timestamp = int(time.time())
+        nonce = "nonce-12345678"
+        signature = vlan_service.probe_signature(
+            os.environ[secret_env], timestamp, nonce, body
+        )
+        verified_probe, payload = vlan_service.verify_probe_submission(
+            self.database,
+            probe["id"],
+            body,
+            timestamp,
+            nonce,
+            signature,
+            now=timestamp,
+        )
+        self.assertEqual(verified_probe["id"], probe["id"])
+        self.assertEqual(payload["devices"][0]["ip"], "192.168.20.44")
+        with self.assertRaisesRegex(ValueError, "already been used"):
+            vlan_service.verify_probe_submission(
+                self.database,
+                probe["id"],
+                body,
+                timestamp,
+                nonce,
+                signature,
+                now=timestamp,
+            )
+        with self.assertRaisesRegex(ValueError, "five-minute"):
+            vlan_service.verify_probe_submission(
+                self.database,
+                probe["id"],
+                body,
+                timestamp - 1000,
+                "another-nonce-1234",
+                vlan_service.probe_signature(
+                    os.environ[secret_env], timestamp - 1000, "another-nonce-1234", body
+                ),
+                now=timestamp,
+            )
+
+
+class VlanInvestigationRouteTest(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.mkdtemp(prefix="mobile-router-vlan-route-")
+        self.original_instance_path = app.instance_path
+        app.instance_path = self.temp_dir
+        self.client = app.test_client()
+        self.inventory_backup = dict(app_module.device_inventory)
+        self.users_backup = dict(app_module.social_users)
+        app_module.device_inventory.clear()
+        app_module.social_users.clear()
+        app_module.social_users["vlan-admin"] = {
+            "id": "vlan-admin",
+            "username": "vlan-admin",
+            "role": "admin",
+            "password_hash": "unused",
+        }
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {"username": "vlan-admin", "role": "admin"}
+            flask_session["social_csrf_token"] = "vlan-csrf"
+
+    def tearDown(self):
+        app.instance_path = self.original_instance_path
+        app_module.device_inventory.clear()
+        app_module.device_inventory.update(self.inventory_backup)
+        app_module.social_users.clear()
+        app_module.social_users.update(self.users_backup)
+        shutil.rmtree(self.temp_dir, ignore_errors=False)
+
+    def create_vlan(self, name="Users", tag="20", subnet="192.168.20.0/24"):
+        response = self.client.post(
+            "/vlans",
+            data={
+                "name": name,
+                "tag": tag,
+                "subnet": subnet,
+                "gateway": str(next(__import__("ipaddress").ip_network(subnet).hosts())),
+                "probe_mode": "routed",
+                "csrf_token": "vlan-csrf",
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        return response.get_json()["vlan"]
+
+    def test_vlan_page_requires_login_and_writes_require_csrf(self):
+        with self.client.session_transaction() as flask_session:
+            flask_session.pop("social_user", None)
+        self.assertEqual(self.client.get("/vlans").status_code, 401)
+        with self.client.session_transaction() as flask_session:
+            flask_session["social_user"] = {"username": "vlan-admin", "role": "admin"}
+        response = self.client.post(
+            "/vlans",
+            data={"name": "Users", "tag": "20", "subnet": "192.168.20.0/24"},
+        )
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("CSRF", response.get_json()["message"])
+
+    def test_vlan_tag_is_prominent_in_library_inventory_client_and_network_workspace(self):
+        vlan = self.create_vlan()
+        app_module.record_inventory_devices(
+            [{"ip": "192.168.20.44", "mac": "00:11:22:33:44:55", "name": "Workstation"}],
+            "test-scan",
+            "eth0",
+        )
+
+        library = self.client.get("/vlans")
+        inventory = self.client.get("/inventory")
+        client_page = self.client.get("/clients/192.168.20.44")
+        network_panel = self.client.get("/clients/192.168.20.44/workspace/network")
+        lookup = self.client.get("/api/v1/vlans/lookup?ips=192.168.20.44")
+
+        self.assertIn(b"VLAN 20 \xc2\xb7 Users", library.data)
+        self.assertIn(b"VLAN 20 \xc2\xb7 Users", inventory.data)
+        self.assertIn(b"VLAN 20 \xc2\xb7 Users", client_page.data)
+        self.assertIn(b"VLAN 20 \xc2\xb7 Users", network_panel.data)
+        self.assertEqual(lookup.status_code, 200)
+        self.assertEqual(lookup.get_json()["vlans"]["192.168.20.44"]["id"], vlan["id"])
+        device = app_module.find_inventory_device("192.168.20.44")
+        self.assertEqual(device["vlan_tag"], 20)
+        self.assertEqual(device["vlan_name"], "Users")
+
+    @patch("routes.vlan_investigations._routed_investigation")
+    def test_authorised_routed_investigation_is_saved(self, investigate):
+        vlan = self.create_vlan()
+        investigate.return_value = (
+            {"scan_path_context": "via 192.168.20.1"},
+            [{"host": "192.168.20.44", "reachable": True}],
+            {
+                "total_hosts": 254,
+                "reachable_hosts": 1,
+                "unreachable_hosts": 253,
+                "selected_ports": [22, 443],
+                "recorded_devices": 1,
+                "visibility": "routed",
+                "duration_seconds": 0.1,
+            },
+        )
+        response = self.client.post(
+            f"/vlans/{vlan['id']}/investigate",
+            data={
+                "ports": "22,443",
+                "authorised": "on",
+                "csrf_token": "vlan-csrf",
+            },
+        )
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        payload = response.get_json()["investigation"]
+        self.assertEqual(payload["summary"]["reachable_hosts"], 1)
+        investigate.assert_called_once()
+
+    def test_pfsense_json_import_creates_vlan_and_assigns_device(self):
+        payload = {
+            "hostname": "pfSense",
+            "vlans": [
+                {
+                    "tag": 50,
+                    "name": "IoT",
+                    "subnet": "10.50.0.0/24",
+                    "gateway": "10.50.0.1",
+                    "interface": "igb2.50",
+                }
+            ],
+            "leases": [
+                {
+                    "ip": "10.50.0.20",
+                    "mac": "aa:bb:cc:dd:ee:20",
+                    "hostname": "lamp",
+                    "vlan": 50,
+                }
+            ],
+        }
+        response = self.client.post(
+            "/vlans/pfsense/import",
+            data={
+                "csrf_token": "vlan-csrf",
+                "pfsense_file": (io.BytesIO(json.dumps(payload).encode("utf-8")), "pfsense.json"),
+            },
+            content_type="multipart/form-data",
+        )
+        self.assertEqual(response.status_code, 200, response.get_data(as_text=True))
+        self.assertEqual(response.get_json()["vlans"][0]["label"], "VLAN 50 · IoT")
+        device = app_module.find_inventory_device("10.50.0.20")
+        self.assertEqual(device["vlan_tag"], 50)
+        self.assertEqual(device["vlan_label"], "VLAN 50 · IoT")
+
+
+class VlanInvestigationAssetTest(unittest.TestCase):
+    def test_navigation_templates_and_dynamic_assets_include_vlan_support(self):
+        navigation = Path("app_support/navigation.py").read_text(encoding="utf-8")
+        primary = Path("templates/_primary-nav-links.html").read_text(encoding="utf-8")
+        footer = Path("templates/_footer.html").read_text(encoding="utf-8")
+        inventory = Path("templates/inventory.html").read_text(encoding="utf-8")
+        network = Path("templates/client_workspace/_network.html").read_text(encoding="utf-8")
+        script = Path("static/js/vlan-tags.js").read_text(encoding="utf-8")
+
+        self.assertIn("VLAN Investigations", navigation)
+        self.assertIn('href="/vlans"', primary)
+        self.assertIn("vlan-tags.js", footer)
+        self.assertIn("Network / VLAN", inventory)
+        self.assertIn("Open this VLAN investigation", network)
+        self.assertIn("MutationObserver", script)
+        self.assertIn("data-network-device-card", script)
+        self.assertIn("data-device-workspace", script)
+
+    def test_vlan_javascript_parses_when_node_is_available(self):
+        node = shutil.which("node")
+        if not node:
+            return
+        for path in ("static/js/vlans.js", "static/js/vlan-tags.js"):
+            result = subprocess.run(
+                [node, "--check", path],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            self.assertEqual(result.returncode, 0, f"{path}: {result.stderr}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_vlan_investigations.py
+++ b/tests/test_vlan_investigations.py
@@ -264,7 +264,9 @@ class VlanInvestigationRouteTest(unittest.TestCase):
     def test_vlan_page_requires_login_and_writes_require_csrf(self):
         with self.client.session_transaction() as flask_session:
             flask_session.pop("social_user", None)
-        self.assertEqual(self.client.get("/vlans").status_code, 401)
+        response = self.client.get("/vlans")
+        self.assertEqual(response.status_code, 302)
+        self.assertIn("/login", response.location)
         with self.client.session_transaction() as flask_session:
             flask_session["social_user"] = {"username": "vlan-admin", "role": "admin"}
         response = self.client.post(


### PR DESCRIPTION
## What changed

- adds a SQLite-backed VLAN and routed-network inventory with explicit 802.1Q tags, subnets, gateways, router interfaces, visibility methods, and provenance
- automatically decorates matching devices with the most-specific VLAN definition and makes labels such as `VLAN 20 · Users` prominent in inventory rows, device overview/network workspaces, sticky device headers, and dynamically refreshed wireless client cards
- adds bounded authorised routed CIDR investigations with route context, reverse DNS, optional selected TCP checks, saved history, and inventory merging
- adds an expected-vs-observed segmentation reachability matrix with explicit main-host versus remote-probe perspective
- adds read-only pfSense JSON import plus configurable HTTPS endpoint synchronisation; credentials remain environment-variable references
- adds HMAC-SHA256 signed, timestamp-bounded, nonce/replay-protected remote VLAN probe ingestion and a dependency-free probe agent
- distinguishes routed visibility from local layer-2 visibility instead of implying that routed scans can see ARP, mDNS, SSDP, or DHCP broadcasts
- adds navigation, exports, mobile styling, AJAX controls, deployment documentation, and comprehensive cross-platform tests

## Safety limits

- IPv4 VLAN subnets in the first release
- no overlapping saved VLAN definitions
- maximum 1,024 usable addresses per routed investigation
- maximum 16 selected TCP ports
- maximum 2 MiB infrastructure import/response and 1 MiB probe submission
- explicit administrator authorisation and CSRF protection for writes/scans
- remote probe submissions require a configured external secret, a valid HMAC, a fresh timestamp, and a one-time nonce

## Validation

Final GitHub Actions run `30824012519` passed on both platforms:

- Ubuntu: 418 passed, 1 skipped
- Windows: 418 passed, 1 skipped
- Python compilation passed
- application import passed
- JavaScript syntax validation passed
- duplicate analysis scanned 108 Python files and 1,017 non-trivial functions

The duplicate report records existing shared route-authentication helpers as future consolidation candidates; it found no runtime or test failure.